### PR TITLE
Fixed empty session cookie

### DIFF
--- a/node_modules/col-whiteboards/lib/api.js
+++ b/node_modules/col-whiteboards/lib/api.js
@@ -744,7 +744,21 @@ Collabosphere.appServer.io.on('connection', function(socket) {
   // Extract the user id from the session cookie that was sent along in the socket handshake
   var cookieName = apiDomain + '_' + courseId;
   var sessionCookie = cookie.parse(socket.handshake.headers.cookie)[cookieName];
+  if (!sessionCookie) {
+    log.error({
+      'socket': socket.id,
+      'whiteboardId': whiteboardId
+    }, 'A user tried to connect on a socket without a session cookie');
+    return socket.disconnect();
+  }
   var userId = cookieParser.signedCookie(sessionCookie, config.get('cookie.secret'));
+  if (!userId) {
+    log.error({
+      'socket': socket.id,
+      'whiteboardId': whiteboardId
+    }, 'A user tried to connect on a socket with an empty session cookie');
+    return socket.disconnect();
+  }
 
   // Verify that the user exists
   UsersAPI.getUser(userId, function(err, user) {


### PR DESCRIPTION
Fix for when a user connects on a websocket without having a valid session cookie
