### PR TITLE
COL-17 - Encode cookie names and return a P3P CP header

### DIFF
--- a/node_modules/col-core/lib/api.js
+++ b/node_modules/col-core/lib/api.js
@@ -154,7 +154,7 @@ var initializeAuthorizationMiddleware = function(apiRouter) {
 
     // Get the user id from the client's cookies. As a user can have multiple tools open
     // in multiple courses, we have a cookie per domain/course tuple
-    var cookieName = decodeURIComponent(apiDomain + '_' + courseId);
+    var cookieName = encodeURIComponent(apiDomain + '_' + courseId);
     var userId = req.signedCookies[cookieName];
 
     // If no user id could be found, we bail out immediately
@@ -165,7 +165,7 @@ var initializeAuthorizationMiddleware = function(apiRouter) {
     // Get the user
     UsersAPI.getUser(userId, function(err, user) {
       if (err) {
-        return callback(err);
+        return next(err);
       }
 
       // Add the current user and course to the request object

--- a/node_modules/col-core/lib/server.js
+++ b/node_modules/col-core/lib/server.js
@@ -59,6 +59,14 @@ var setUpServer = module.exports.setUpServer = function() {
   // Collabosphere stores a user's id in a signed cookie
   app.use(cookieParser(config.get('cookie.secret')));
 
+  // Always set a P3P (Privacy Preferences Platform) Header with a Compact Policy. Safari and IE
+  // require this header to be set or they will discard our cookies which would break our authentication
+  // mechanism. See http://www.w3.org/TR/P3P11/#compact_policy_vocabulary for more information
+  app.use(function(req, res, next) {
+    res.set('P3P', 'CP="NOI ADM DEV PSAi COM NAV OUR OTR STP IND DEM"');
+    next();
+  });
+
   /*!
    * Collabosphere supports the following type of request encodings:
    *

--- a/node_modules/col-lti/lib/rest.js
+++ b/node_modules/col-lti/lib/rest.js
@@ -35,12 +35,13 @@ var launch = function(req, res, toolId) {
       return res.status(err.code).send(err.msg);
     }
 
+    // Get the Canvas domain and course the user is launching the tool from
     var api_domain = body.custom_canvas_api_domain;
     var course_id = body.custom_canvas_course_id;
 
     // We store the user id in cookie specific to the canvas api domain and course. This
     // allows the user to open multiple tools (on multiple Canvas instances) concurrently
-    var name = api_domain + '_' + course_id;
+    var name = encodeURIComponent(api_domain + '_' + course_id);
     res.cookie(name, user.id, {'signed': true});
 
     // Redirect the user to the tool's HTML. We need to include the api_domain

--- a/node_modules/col-whiteboards/lib/api.js
+++ b/node_modules/col-whiteboards/lib/api.js
@@ -742,7 +742,7 @@ Collabosphere.appServer.io.on('connection', function(socket) {
   var whiteboardId = socket.handshake.query.whiteboard_id;
 
   // Extract the user id from the session cookie that was sent along in the socket handshake
-  var cookieName = apiDomain + '_' + courseId;
+  var cookieName = encodeURIComponent(apiDomain + '_' + courseId);
   var sessionCookie = cookie.parse(socket.handshake.headers.cookie)[cookieName];
   if (!sessionCookie) {
     log.error({


### PR DESCRIPTION
This fixes launching the tools in IE and latest versions of Safari
