### PR TITLE
COL-243 - intermittent test failures

### DIFF
--- a/node_modules/col-assets/tests/util.js
+++ b/node_modules/col-assets/tests/util.js
@@ -96,6 +96,8 @@ var assertAsset = module.exports.assertAsset = function(asset, opts) {
     assert.strictEqual(asset.id, opts.expectedAsset.id);
     assert.strictEqual(asset.type, opts.expectedAsset.type);
     assert.strictEqual(asset.course_id, opts.expectedAsset.course_id);
+    asset.users = _.sortBy(asset.users, 'id');
+    opts.expectedAsset.users = _.sortBy(opts.expectedAsset.users, 'id');
     assert.deepEqual(asset.users, opts.expectedAsset.users);
     assert.strictEqual(asset.title, opts.expectedAsset.title);
     assert.strictEqual(asset.created_at, opts.expectedAsset.created_at);

--- a/node_modules/col-whiteboards/tests/util.js
+++ b/node_modules/col-whiteboards/tests/util.js
@@ -17,7 +17,6 @@ var _ = require('lodash');
 var assert = require('assert');
 
 var AssetsTestsUtil = require('col-assets/tests/util');
-var CanvasTestsUtil = require('col-canvas/tests/util');
 var CollabosphereUtil = require('col-core/lib/util');
 var DB = require('col-core/lib/db');
 var UsersTestUtil = require('col-users/tests/util');
@@ -410,9 +409,6 @@ var assertExportWhiteboardToPngFails = module.exports.assertExportWhiteboardToPn
  * @throws {AssertionError}                                     Error thrown when an assertion failed
  */
 var assertExportWhiteboardToAsset = module.exports.assertExportWhiteboardToAsset = function(client, course, id, title, opts, callback) {
-  // The PNG version of the whiteboard will be uploaded back into Canvas
-  CanvasTestsUtil.mockFileUpload(course);
-
   // Get the assets in the asset library
   AssetsTestsUtil.assertGetAssets(client, course, null, null, null, null, function(assets) {
 


### PR DESCRIPTION
- Removed an unneeded mock when exporting a whiteboard to the asset library
- Sorting an asset users list when comparing it to another

There are still 2 intermittent test failures in the comments tests. Those are fixed by https://github.com/ets-berkeley-edu/collabosphere/pull/40 however
