### PR TITLE
COL-516, Teacher role matches with LTI instructor full URN and short-name; ContentDeveloper, too

### DIFF
--- a/node_modules/col-core/lib/constants.js
+++ b/node_modules/col-core/lib/constants.js
@@ -38,6 +38,8 @@ var Constants = module.exports = {
     'urn:lti:instrole:ims/lis/Administrator'
   ],
   'TEACHER_ROLES': [
+    'ContentDeveloper',
+    'Instructor',
     'urn:lti:role:ims/lis/ContentDeveloper',
     'urn:lti:role:ims/lis/Instructor',
     'urn:lti:role:ims/lis/TeachingAssistant'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-516

We are rolling forward on PR #220 by supporting both deprecated and full URN role names.