### PR TITLE
NOJIRA, remove start.sh from deploy.sh; post-deploy tasks might require downtime

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -30,7 +30,7 @@ log() {
 }
 
 # If we have missing requirements then echo usage info and exit.
-[[ $# -gt 0 ]] || { echo_usage; exit 0; }
+[[ $# -gt 0 ]] || { echo_usage; exit 1; }
 [[ "${DOCUMENT_ROOT}" ]] || { echo; echo "[ERROR] 'DOCUMENT_ROOT' is undefined"; echo_usage; exit 1; }
 
 log "DOCUMENT_ROOT, the Apache directory to which we copy SuiteC static files, is set to: ${DOCUMENT_ROOT}"
@@ -108,8 +108,6 @@ log "Kill the existing SuiteC process"
 log "Copy SuiteC static files to Apache directory: ${DOCUMENT_ROOT}"
 cp -R target/* "${DOCUMENT_ROOT}"
 
-log "Start a new and improved SuiteC process."
-./deploy/start.sh
+log "We are done but SuiteC has NOT been started. Perform post-deploy tasks, if any, then run deploy/start.sh."
 
-log "We are done. Time to smoke-test the application."
 exit 0


### PR DESCRIPTION
If there are no post-deploy tasks then Ops can run:
```
./deploy/deploy.sh -t 1.63 && ./deploy/start.sh
```
we must `exit 1` when `echo_usage` such that *start.sh* won't run in example above. 