### PR TITLE
COL-528 Make asset migration accessible to admins from the browser

### DIFF
--- a/node_modules/col-activities/tests/util.js
+++ b/node_modules/col-activities/tests/util.js
@@ -30,7 +30,7 @@ var csv = require('fast-csv');
 var randomstring = require('randomstring');
 
 var AssetsTestUtil = require('col-assets/tests/util');
-var DB = require('col-core/lib/db');
+var CourseTestUtil = require('col-course/tests/util');
 var EmailUtil = require('col-core/lib/email');
 var LtiTestUtil = require('col-lti/tests/util');
 var TestsUtil = require('col-tests');
@@ -977,33 +977,6 @@ var assertSendWeeklyNotificationsFails = module.exports.assertSendWeeklyNotifica
 
 /* Utilities specific to notification email tests */
 
-
-/**
- * Get a course object given a Canvas course id
- *
- * @param  {Number}           canvasCourseId      The id of the course in Canvas
- * @param  {Function}         callback            Invoked when the course has been retrieved
- * @param  {Course}           callback.course     The retrieved course object
- * @throws {AssertionError}                       Error thrown when an assertion failed
- * @api private
- */
-var getCourse = function(canvasCourseId, callback) {
-  var options = {
-    'where': {
-      'canvas_course_id': canvasCourseId
-    },
-    'include': [{
-      'model': DB.Canvas,
-      'as': 'canvas'
-    }]
-  };
-  DB.Course.findOne(options).complete(function(err, course) {
-    assert.ok(!err);
-    assert.ok(course);
-    return callback(course);
-  });
-};
-
 /**
  * Set up a course with 6 users that each have their own asset and whiteboard.
  *
@@ -1036,7 +1009,7 @@ var setupCourse = module.exports.setupCourse = function(callback) {
               LtiTestUtil.assertWhiteboardsLaunchSucceeds(client1, course, user1, function() {
 
                 // Get the actual course object so we can pass it into the poller
-                getCourse(course.id, function(dbCourse) {
+                CourseTestUtil.getDbCourse(course.id, function(dbCourse) {
 
                   return callback(dbCourse, course, {
                     'nico': {

--- a/node_modules/col-assets/lib/migrate.js
+++ b/node_modules/col-assets/lib/migrate.js
@@ -1,0 +1,408 @@
+/**
+ * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+var _ = require('lodash');
+var async = require('async');
+var contentDisposition = require('content-disposition');
+var fs = require('fs');
+var Joi = require('joi');
+var os = require('os');
+var path = require('path');
+var request = require('request');
+
+var AssetsAPI = require('col-assets');
+var CategoriesAPI = require('col-categories');
+var DB = require('col-core/lib/db');
+var log = require('col-core/lib/logger')('col-assets/migrate');
+var UserAPI = require('col-users');
+var UserConstants = require('col-users/lib/constants');
+
+/**
+ * Migrate assets and categories
+ *
+ * @param  {Context}          fromCtx                     Context for user associated with source assets
+ * @param  {Context}          opts                        Migration options
+ * @param  {Boolean}          opts.categories             Whether categories should be migrated
+ * @param  {Number}           opts.destinationUserId      SuiteC id for destination user
+ * @param  {Boolean}          opts.validateUserAccounts   Whether to run additional user validations 
+ * @param  {Function}         callback                    Standard callback function
+ * @param  {Object}           callback.results            Migration results
+ */
+var migrate = module.exports.migrate = function(fromCtx, opts, callback) {
+  // Validate migration options
+  opts = opts || {};
+  var validationSchema = Joi.object().keys({
+    'opts': Joi.object().keys({
+      'categories': Joi.boolean().required(),
+      'destinationUserId': Joi.number().required(),
+      'validateUserAccounts': Joi.boolean().required()
+    })
+  });
+  var validationResult = Joi.validate({
+    'opts': opts
+  }, validationSchema);
+  if (validationResult.error) {
+    return callback({'code': 400, 'msg': validationResult.error.details[0].message});
+  }
+
+  createDestinationContexts(opts.destinationUserId, function(err, toCtx, adminCtx) {
+    if (fromCtx.course.id === toCtx.course.id) {
+      log.error({'course': fromCtx.course}, 'Cannot migrate a course to itself');
+      return callback({'code': 400, 'msg': 'Bad request'});
+    }
+
+    if (opts.validateUserAccounts) {
+      if (!fromCtx.user.is_admin || !toCtx.user.is_admin) {
+        log.error({'course': fromCtx.course}, 'Unauthorized to migrate assets');
+        return callback({'code': 401, 'msg': 'Unauthorized to migrate assets'});
+      }
+
+      var userAccountsMatch = (fromCtx.user.canvas_user_id === toCtx.user.canvas_user_id);
+      var canvasInstancesMatch = (fromCtx.course.canvas_api_domain === toCtx.course.canvas_api_domain);
+      if (!userAccountsMatch || !canvasInstancesMatch) {
+        return callback({'code': 400, 'msg': 'Bad request'});
+      }
+    }
+
+    // Migrate categories
+    migrateCategories(opts.categories, fromCtx, toCtx, adminCtx, function(categoryMapping) {
+      // Migrate all assets
+      migrateAssets(fromCtx, toCtx, categoryMapping, function(total, results) {
+        log.info({'total': total, 'results': results}, 'Finished migrating assets');
+
+        return callback(null, results);
+      });
+    });
+  });
+};
+
+/**
+ * Migrate assets
+ *
+ * @param  {Context}          fromCtx             Context for user associated with source assets
+ * @param  {Context}          toCtx               Context for user associated with destination assets
+ * @param  {Object}           categoryMapping     Mapping from source to destination categories
+ * @param  {Function}         callback            Standard callback function
+ * @param  {Object}           callback.results    Migration results
+ */
+var migrateAssets = function(fromCtx, toCtx, categoryMapping, callback) {
+  var options = {
+    'where': {
+      'course_id': fromCtx.course.id,
+    },
+    'order': 'created_at ASC',
+    'include': [
+      {
+        'model': DB.User,
+        'as': 'users',
+        'required': true,
+        'attributes': UserConstants.BASIC_USER_FIELDS,
+        'where': {
+          'id': fromCtx.user.id
+        }
+      },
+      {
+        'model': DB.Category,
+        'attributes': ['id']
+      }
+    ]
+  };
+
+  DB.Asset.findAll(options).complete(function(err, assets) {
+    if (err) {
+      return log.error({'err': err}, 'Failed to get the assets to migrate');
+    }
+
+    var downloadDir = path.join(os.tmpdir(), Date.now().toString());
+    var results = {};
+
+    async.eachSeries(assets, function(asset, done) {
+      migrateAsset(toCtx, asset.toJSON(), categoryMapping, downloadDir, results, done);
+    }, function() {
+      return callback(assets.length, results);
+    });
+  });
+};
+
+/**
+ * Migrate an asset
+ *
+ * @param  {Context}          toCtx               Context for user associated with destination assets
+ * @param  {Asset}            asset               The asset to migrate
+ * @param  {Object}           categoryMapping     Mapping from source to destination categories
+ * @param  {String}           downloadDir         Path for temporary download directory
+ * @param  {Object}           results             Object to keep track of migration results
+ * @param  {Function}         callback            Standard callback function
+ */
+var migrateAsset = function(toCtx, asset, categoryMapping, downloadDir, results, callback) {
+  var type = asset.type;
+
+  // Callback executed when the asset has finished migrating
+  var migrateCallback = function(err, newAsset) {
+    results[type] = results[type] || {
+      'success': 0,
+      'error': 0
+    };
+
+    if (err) {
+      log.error({'asset': asset, 'err': err}, 'Failed to migrate an asset');
+      results[type].error++;
+    } else {
+      log.info({'asset': asset, 'newAsset': newAsset}, 'Successfully migrated an asset');
+      results[type].success++;
+    }
+    return callback();
+  };
+
+  var destinationCategories = getMappedCategories(asset.categories, categoryMapping);
+
+  if (asset.type === 'link') {
+    migrateLink(toCtx, asset, destinationCategories, migrateCallback);
+  } else if (asset.type === 'file') {
+    migrateFile(toCtx, asset, destinationCategories, downloadDir, migrateCallback);
+  } else if (asset.type === 'whiteboard') {
+    log.info({'asset': asset}, 'Skipping whiteboard migration');
+    return callback();
+  } else {
+    log.error({'asset': asset}, 'Unrecognized asset type');
+    return callback();
+  }
+};
+
+ /**
+ * Migrate all categories
+ *
+ * @param  {Boolean}      shouldMigrate              Whether to migrate categories
+ * @param  {Context}      fromCtx                    Context for user associated with source assets
+ * @param  {Context}      toCtx                      Context for user associated with destination assets
+ * @param  {Context}      adminCtx                   An admin context for API interaction
+ * @param  {Function}     callback                   Standard callback function
+ * @param  {Object}       callback.categoryMapping   Mapping from source to destination categories
+ */
+var migrateCategories = function(shouldMigrate, fromCtx, toCtx, adminCtx, callback) {
+  if (!shouldMigrate) {
+    return callback();
+  }
+
+  // Get the categories in the source course
+  CategoriesAPI.getCategories(fromCtx, true, false, function(err, fromCategories) {
+    if (err) {
+      log.error({'err': err}, 'Unable to retrieve the source categories');
+      return callback(err);
+    }
+
+    // Filter out Canvas assignment categories
+    fromCategories = _.filter(fromCategories, function(category) { 
+      return !category.canvas_assignment_id;
+    });
+
+    // Get the categories in the destination course
+    CategoriesAPI.getCategories(toCtx, true, false, function(err, toCategories) {
+      if (err) {
+        log.error({'err': err}, 'Unable to retrieve the destination categories');
+        return callback(err);
+      }
+
+      // Derive the mapping between the existing categories based on
+      // exact title matches
+      var categoryMapping = {};
+      _.each(fromCategories, function(fromCategory) {
+        _.each(toCategories, function(toCategory) {
+          if (fromCategory.title === toCategory.title) {
+            categoryMapping[fromCategory.id] = toCategory.id;
+          }
+        });
+      });
+
+      // Migrate the categories that could not be mapped
+      var migratedCategories = 0;
+      async.eachSeries(fromCategories, function(fromCategory, done) {
+        if (!categoryMapping[fromCategory.id]) {
+          migrateCategory(adminCtx, fromCategory.toJSON(), categoryMapping, function(err) {
+            if (!err) {
+              migratedCategories++;
+            }
+            return done();
+          });
+        } else {
+          return done();
+        }
+      }, function() {
+        log.info({'categories': migratedCategories}, 'Finished migrating categories');
+        return callback(categoryMapping);
+      });
+    });
+  });
+};
+
+/**
+ * Migrate a category
+ *
+ * @param  {Context}          adminCtx            An admin context for API interaction
+ * @param  {Category}         category            The category to migrate
+ * @param  {Object}           categoryMapping     Mapping from source to destination categories
+ * @param  {Function}         callback            Standard callback function
+ * @param  {Object}           callback.err        An error that occurred, if any
+ */
+var migrateCategory = function(adminCtx, category, categoryMapping, callback) {
+  CategoriesAPI.createCategory(adminCtx, category.title, category.visible, undefined, undefined, function(err, newCategory) {
+    if (err) {
+      log.error({'category': category, 'err': err}, 'Failed to migrate category');
+      return callback(err);
+    }
+
+    categoryMapping[category.id] = newCategory.id;
+    return callback();
+  });
+};
+
+/**
+ * Migrate a link asset
+ *
+ * @param  {Context}          toCtx               Context for user associated with destination assets
+ * @param  {Asset}            link                The link to migrate
+ * @param  {Number[]}         categories          Destination categories for the link asset
+ * @param  {Function}         callback            Standard callback function
+ */
+var migrateLink = function(toCtx, link, categories, callback) {
+  AssetsAPI.createLink(toCtx, link.title, link.url, {
+    'categories': categories,
+    'description': link.description || undefined,
+    'source': link.source || undefined,
+    'thumbnail_url': link.thumbnail_url || undefined,
+    'image_url': link.image_url || undefined,
+    'embed_id': link.embed_id || undefined,
+    'embed_key': link.embed_key || undefined,
+    'embed_code': link.embed_code || undefined
+  }, callback);
+};
+
+/**
+ * Migrate a file asset
+ *
+ * @param  {Context}          toCtx               Context for user associated with destination assets
+ * @param  {Asset}            file                The file to migrate
+ * @param  {Number[]}         categories          Destination categories for the file asset
+ * @param  {String}           downloadDir         Path for temporary download directory
+ * @param  {Function}         callback            Standard callback function
+ */
+var migrateFile = function(toCtx, file, categories, downloadDir, callback) {
+  fs.stat(downloadDir, function(err, stat) {
+    // Download the file to a temporary folder
+    if (err) {
+      if (err.code === 'ENOENT') {
+        fs.mkdirSync(downloadDir);
+      } else {
+        log.error({downloadDir: downloadDir, errorCode: err.code}, 'Failed to create temp directory during file migration');
+        return callback(err);
+      }
+    }
+    request(file.download_url).on('response', function(res) {
+      // Extract the name of the file
+      var disposition = contentDisposition.parse(res.headers['content-disposition']);
+      var filename = disposition.parameters.filename;
+      var filePath = path.join(downloadDir, filename);
+
+      // Function that will clean up the temporary file
+      var cleanTempFile = function(err) {
+        fs.unlink(filePath, function() {
+          return callback(err);
+        });
+      };
+
+      res.pipe(fs.createWriteStream(filePath))
+      .on('error', cleanTempFile)
+      .on('finish', function() {
+
+        // Create the file asset
+        AssetsAPI.createFile(toCtx, file.title, {
+          'mimetype': file.mime,
+          'file': filePath,
+          'filename': file.title
+        }, {
+          'categories': categories,
+          'description': file.description || undefined,
+          'thumbnail_url': file.thumbnail_url || undefined,
+          'image_url': file.image_url || undefined,
+          'embed_id': file.embed_id || undefined,
+          'embed_key': file.embed_key || undefined,
+          'embed_code': file.embed_code || undefined
+        }, cleanTempFile);
+      });
+    });
+  });
+};
+
+
+/**
+ * Create mock contexts for destination course and user
+ *
+ * @param  {Number}       destinationUserId    The Collabosphere ID for the destination user
+ * @param  {Function}     callback             Standard callback function
+ * @param  {Function}     callback.err         Error, if any
+ * @param  {Function}     callback.userCtx     Mock context for destination user 
+ * @param  {Function}     callback.adminCtx    Mock admin context for destination course
+ */
+
+var createDestinationContexts = function(destinationUserId, callback) {
+  UserAPI.getUser(destinationUserId, function(err, destinationUser) {
+    // Create mock context for destination user
+    if (err) {
+      log.error({'toUser': toUser, 'err': err}, 'Unable to retrieve user to migrate to');
+      return callback(err);
+    }
+
+    userCtx = {
+      'user': destinationUser,
+      'course': destinationUser.course
+    };
+
+    // Create mock admin context for destination course
+    adminCtx = {
+      'user': {
+        'is_admin': true
+      },
+      'course': destinationUser.course
+    };
+
+    return callback(null, userCtx, adminCtx);
+  });
+};
+
+/**
+ * Map a list of categories from the source course to the corresponding categories in the destination course
+ *
+ * @param  {Number[]}         categories          The ids of the source course categories to map
+ * @param  {Object}           categoryMapping     Mapping from source to destination categories
+ * @return {Number[]}                             The mapped destination course category ids
+ */
+var getMappedCategories = function(categories, categoryMapping) {
+  return _.chain(categories)
+          .map(function(category) {
+            return categoryMapping[category.id];
+          })
+          .compact()
+          .value();
+};

--- a/node_modules/col-assets/lib/rest.js
+++ b/node_modules/col-assets/lib/rest.js
@@ -30,6 +30,7 @@ var Collabosphere = require('col-core');
 var CollabosphereUtil = require('col-core/lib/util');
 
 var AssetsAPI = require('./api');
+var MigrateAssetsAPI = require('./migrate');
 
 /*!
  * Get an asset
@@ -138,6 +139,25 @@ Collabosphere.apiRouter.post('/assets', function(req, res) {
   } else {
     return res.status(400).send('Unrecognized asset type');
   }
+});
+
+/*!
+ * Migrate assets
+ */
+Collabosphere.apiRouter.post('/assets/migrate', function(req, res) {
+  var opts = {
+    'categories': true,
+    'destinationUserId': req.body.destinationUserId,
+    'validateUserAccounts': true
+  };
+
+  MigrateAssetsAPI.migrate(req.ctx, opts, function(err, results) {
+    if (err) {
+      return res.status(err.code).send(err.msg);
+    }
+
+    return res.status(200).send(results);
+  });
 });
 
 /*!

--- a/node_modules/col-assets/tests/test-assets.js
+++ b/node_modules/col-assets/tests/test-assets.js
@@ -1145,4 +1145,182 @@ describe('Assets', function() {
       });
     });
   });
+
+  describe('Migrate assets', function() {
+
+    /**
+     * Test that verifies asset and category migration
+     */
+    it('migrates file and link assets with categories', function(callback) {
+      var course1 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var course2 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+
+      var instructor = TestsUtil.generateInstructor(global.tests.canvas.ucberkeley);
+
+      // Instructor is teaching course 1
+      TestsUtil.getAssetLibraryClient(null, course1, instructor, function(client1, course1, instructor1) {
+        // Instructor is teaching course 2
+        TestsUtil.getAssetLibraryClient(null, course2, instructor, function(client2, course2, instructor2) {
+
+            // Instructor creates categories in course 1
+            CategoriesTestUtil.assertCreateCategory(client1, course1, 'Category 1', function(category1) {
+              CategoriesTestUtil.assertCreateCategory(client1, course1, 'Category 2', function(category2) {
+
+              // Instructor creates assets in course 1
+              var opts = {'categories': category1.id};
+              AssetsTestUtil.assertCreateLink(client1, course1, 'UC Berkeley', 'http://www.ucberkeley.edu/', opts, function(asset1) {
+                opts = {'categories': [category1.id, category2.id]};
+                AssetsTestUtil.assertCreateLink(client1, course1, 'UC Davis', 'http://www.ucdavis.edu/', opts, function(asset2) {
+
+                  // Migrate assets from instructor's course 1 id to instructor's course 2 id
+                  UsersTestUtil.assertGetMe(client2, course2, null, function(me2) {
+                    AssetsTestUtil.assertMigration(client1, course1, me2.id, 0, 2, function() {
+
+                      // Get instructor's assets in course 2
+                      AssetsTestUtil.assertGetAssets(client2, course2, null, null, null, 2, function(assets) {
+
+                        // Verify that assets were migrated and categories preserved
+                        var migratedAsset1 = _.find(assets.results, {'title': 'UC Berkeley'});
+                        AssetsTestUtil.assertGetMigratedAsset(client2, course2, migratedAsset1.id, ['Category 1'], function() {
+                          var migratedAsset2 = _.find(assets.results, {'title': 'UC Davis'});
+                          AssetsTestUtil.assertGetMigratedAsset(client2, course2, migratedAsset2.id, ['Category 1', 'Category 2'], function() {
+
+                            return callback();
+                          });
+                        });
+                      });
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    /**
+     * Test that verifies admin authorization in source course
+     */
+    it('verifies admin authorization in source course', function(callback) {
+      var course1 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var course2 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+
+      var user = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+      var userAsInstructor = TestsUtil.generateInstructor(global.tests.canvas.ucberkeley);
+      user.id = userAsInstructor.id;
+
+      // User is a regular user in course 1
+      TestsUtil.getAssetLibraryClient(null, course1, user, function(client1, course1, user) {
+        // User is an instructor in course 2
+        TestsUtil.getAssetLibraryClient(null, course2, userAsInstructor, function(client2, course2, userAsInstructor) {
+
+          // Verify that migration from course 1 to course 2 fails
+          UsersTestUtil.assertGetMe(client2, course2, null, function(me2) {
+            AssetsTestUtil.assertMigrationFails(client1, course1, me2.id, 401, function() {
+              return callback();
+            });
+          });
+        });
+      });
+    });
+
+    /**
+     * Test that verifies admin authorization in destination course
+     */
+    it('verifies admin authorization in destination course', function(callback) {
+      var course1 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var course2 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+
+      var user = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+      var userAsInstructor = TestsUtil.generateInstructor(global.tests.canvas.ucberkeley);
+      user.id = userAsInstructor.id;
+
+      // User is an instructor in course 1
+      TestsUtil.getAssetLibraryClient(null, course1, userAsInstructor, function(client1, course1, userAsInstructor) {
+        // User is a regular user in course 2
+        TestsUtil.getAssetLibraryClient(null, course2, user, function(client2, course2, user) {
+
+          // Verify that migration from course 1 to course 2 fails
+          UsersTestUtil.assertGetMe(client2, course2, null, function(me2) {
+            AssetsTestUtil.assertMigrationFails(client1, course1, me2.id, 401, function() {
+              return callback();
+            });
+          });
+        });
+      });
+    });
+
+    /**
+     * Test that verifies Canvas user account must match between source and destination course
+     */
+    it('insists on matching Canvas user accounts', function(callback) {
+      var course1 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var course2 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+
+      var instructor1 = TestsUtil.generateInstructor(global.tests.canvas.ucberkeley);
+      var instructor2 = TestsUtil.generateInstructor(global.tests.canvas.ucberkeley);
+
+      // Instructor 1 teaches course 1
+      TestsUtil.getAssetLibraryClient(null, course1, instructor1, function(client1, course1, instructor1) {
+        // Instructor 2 teaches course 2
+        TestsUtil.getAssetLibraryClient(null, course2, instructor2, function(client2, course2, instructor2) {
+
+          // Verify that migration from course 1 to course 2 fails
+          UsersTestUtil.assertGetMe(client2, course2, null, function(me2) {
+            AssetsTestUtil.assertMigrationFails(client1, course1, me2.id, 400, function() {
+              return callback();
+            });
+          });
+        });
+      });
+    });
+
+    /**
+     * Test that verifies Canvas instance must match between source and destination course
+     */
+    it('insists on matching Canvas instances', function(callback) {
+      var berkeleyCourse = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var davisCourse = TestsUtil.generateCourse(global.tests.canvas.ucdavis);
+
+      var berkeleyInstructor = TestsUtil.generateInstructor(global.tests.canvas.ucberkeley);
+      var davisInstructor = TestsUtil.generateInstructor(global.tests.canvas.ucdavis);
+
+      // Berkeley and Davis instructors happen to have the same Canvas account id
+      berkeleyInstructor.id = davisInstructor.id;
+
+      // Berkeley instructor teaches Berkeley course
+      TestsUtil.getAssetLibraryClient(null, berkeleyCourse, berkeleyInstructor, function(berkeleyClient, berkeleyCourse, berkeleyInstructor) {
+        // Davis instructor teaches Davis course
+        TestsUtil.getAssetLibraryClient(null, davisCourse, davisInstructor, function(davisClient, davisCourse, davisInstructor) {
+
+          // Verify that migration from Berkeley course to Davis course fails
+          UsersTestUtil.assertGetMe(davisClient, davisCourse, null, function(davisMe) {
+            AssetsTestUtil.assertMigrationFails(berkeleyClient, berkeleyCourse, davisMe.id, 400, function() {
+              return callback();
+            });
+          });
+        });
+      });
+    });
+
+    /**
+     * Test that verifies source and destination course must differ
+     */
+    it('refuses to migrate a course to itself', function(callback) {
+      var course = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var instructor = TestsUtil.generateInstructor(global.tests.canvas.ucberkeley);
+
+      // Instructor teaches course
+      TestsUtil.getAssetLibraryClient(null, course, instructor, function(client, course, instructor) {
+
+        // Verify that migration from course to itself fails
+        UsersTestUtil.assertGetMe(client, course, null, function(me) {
+          AssetsTestUtil.assertMigrationFails(client, course, me.id, 400, function() {
+            return callback();
+          });
+        });
+      });
+    });
+  });
 });

--- a/node_modules/col-assets/tests/util.js
+++ b/node_modules/col-assets/tests/util.js
@@ -979,3 +979,70 @@ var assertLikeFails = module.exports.assertLikeFails = function(client, course, 
     return callback();
   });
 };
+
+/**
+ * Assert that assets can be migrated
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
+ * @param  {Number}             destinationUserId               The course-associated SuiteC id of the user with which migrated assets should be associated
+ * @param  {Number}             expectedFileCount               Number of file assets expected to migrate
+ * @param  {Number}             expectedLinkCount               Number of link assets expected to migrate
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertMigration = module.exports.assertMigration = function(client, course, destinationUserId, expectedFileCount, expectedLinkCount, callback) {
+  client.assets.migrateAssets(course, destinationUserId, function(err, result) {
+    assert.ok(!err);
+    assert.ok(result);
+
+    if (expectedFileCount) {
+      assert.strictEqual(result.file.success, expectedFileCount);
+      assert.strictEqual(result.file.error, 0);
+    }
+
+    if (expectedLinkCount) {
+      assert.strictEqual(result.link.success, expectedLinkCount);
+      assert.strictEqual(result.link.error, 0);
+    }
+
+    return callback();
+  });
+};
+
+/**
+ * Assert that an asset migration fails
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
+ * @param  {Number}             destinationUserId               The course-associated SuiteC id of the user with which migrated assets should be associated
+ * @param  {Number}             code                            The expected HTTP error code
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertMigrationFails = module.exports.assertMigrationFails = function(client, course, destinationUserId, code, callback) {
+  client.assets.migrateAssets(course, destinationUserId, function(err, result) {
+    assert.ok(err);
+    assert.strictEqual(err.code, code);
+
+    return callback();
+  });
+};
+
+/**
+ * Assert that a migrated asset can be retrieved
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
+ * @param  {Number}             assetId                         The id for the migrated asset
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertGetMigratedAsset = module.exports.assertGetMigratedAsset = function(client, course, assetId, categoryTitles, callback) {
+  assertGetAsset(client, course, assetId, null, 0, function(migratedAsset) {
+    assertAsset(migratedAsset, {'expectComments': true, 'expectedCommentCount': 0});
+    assert.deepEqual(_.map(migratedAsset.categories, 'title'), categoryTitles);
+
+    return callback();
+  });
+};

--- a/node_modules/col-course/lib/api.js
+++ b/node_modules/col-course/lib/api.js
@@ -23,6 +23,7 @@
  * ENHANCEMENTS, OR MODIFICATIONS.
  */
 
+var _ = require('lodash');
 var Joi = require('joi');
 
 var DB = require('col-core/lib/db');
@@ -283,4 +284,85 @@ var getCourses = module.exports.getCourses = function(callback) {
     'order': 'id ASC'
   };
   DB.Course.findAll(options).complete(callback);
+};
+
+/**
+ * Get active courses associated with the current user's Canvas account
+ *
+ * @param  {Context}    ctx                        Standard context containing the current user and the current course
+ * @param  {Object}     [filters]                  A set of options to filter the results by
+ * @param  {Boolean}    [filters.admin]            Whether to only return courses in which the user is an admin
+ * @param  {Boolean}    [filters.assetLibrary]     Whether to only return courses in which the asset library is enabled
+ * @param  {Boolean}    [filters.excludeCurrent]   Whether to exclude the current course
+ * @param  {Function}   callback                   Standard callback function
+ * @param  {Object}     callback.err               An error that occurred, if any
+ * @param  {Course[]}   callback.courses           The courses in the database. The associated `Canvas` object will be retrieved as well
+ */
+var getUserCourses = module.exports.getUserCourses = function(ctx, filters, callback) {
+  // Parameter validation
+  filters = filters || {};
+  var validationSchema = Joi.object().keys({
+    'filters': Joi.object().keys({
+      'admin': Joi.boolean().optional(),
+      'asset_library': Joi.boolean().optional(),
+      'exclude_current': Joi.boolean().optional()
+    })
+  });
+  var validationResult = Joi.validate({
+    'filters': filters
+  }, validationSchema);
+  if (validationResult.error) {
+    return callback({'code': 400, 'msg': validationResult.error.details[0].message});
+  }
+
+  var courseOptions = {
+    'active': true,
+    'canvas_api_domain': ctx.course.canvas_api_domain
+  };
+
+  // If requested, only return courses with an asset library URL
+  if (filters.asset_library) {
+    courseOptions.assetlibrary_url = {
+      $ne: null
+    };
+  }
+
+  // If requested, exclude the current course
+  if (filters.exclude_current) {
+    courseOptions.id = {
+      $ne: ctx.course.id
+    };
+  }
+
+  var userOptions = {
+    'canvas_enrollment_state': 'active',
+    'canvas_user_id': ctx.user.canvas_user_id
+  };
+
+  var queryOptions = {
+    'where': userOptions,
+    'attributes': ['canvas_course_role', 'id'],
+    'include': [
+      {
+        'model': DB.Course,
+        'required': true,
+        'as': 'course',
+        'where': courseOptions
+      }
+    ]
+  };
+
+  DB.User.findAll(queryOptions).complete(function(err, userCourses) {
+    if (err) {
+      return callback(err);
+    }
+
+    // If requested, only return courses where user is an admin. This needs to be done post-query because is_admin is a
+    // derived attribute not present in the database.
+    if (filters.admin) {
+      userCourses = _.filter(userCourses, 'is_admin');
+    }
+
+    return callback(null, userCourses);
+  });
 };

--- a/node_modules/col-course/lib/rest.js
+++ b/node_modules/col-course/lib/rest.js
@@ -68,3 +68,22 @@ Collabosphere.apiRouter.post('/course/weekly_notifications', function(req, res) 
     return res.sendStatus(200);
   });
 });
+
+/*!
+ * Get active courses associated with the current user's Canvas account
+ */
+Collabosphere.apiRouter.get('/courses', function(req, res) {
+  var filters = {
+    'admin': req.query.admin,
+    'asset_library': req.query.assetLibrary,
+    'exclude_current': req.query.excludeCurrent
+  };
+
+  CourseAPI.getUserCourses(req.ctx, filters, function(err, courses) {
+    if (err) {
+      return res.status(err.code).send(err.msg);
+    }
+
+    return res.status(200).send(courses);
+  });
+});

--- a/node_modules/col-course/tests/test-course.js
+++ b/node_modules/col-course/tests/test-course.js
@@ -54,6 +54,151 @@ describe('Course', function() {
     });
   });
 
+  describe('User course listing', function() {
+    /**
+     * Test that verifies that courses associated with a user's Canvas account are returned
+     */
+    it('returns courses associated with a user\'s Canvas account', function(callback) {
+      var course1 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var course2 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var course3 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+
+      var user1 = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+      var user2 = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+      var user3 = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+
+      // User 1 is in course 1
+      TestsUtil.getAssetLibraryClient(null, course1, user1, function(client1_1, course1, user1) {
+        // User 1 is in course 2
+        TestsUtil.getAssetLibraryClient(null, course2, user1, function(client1_2, course2, user1) {
+          //User 2 is in course 2
+          TestsUtil.getAssetLibraryClient(null, course2, user2, function(client2_2, course2, user2) {
+            //User 3 is in course 3
+            TestsUtil.getAssetLibraryClient(null, course3, user3, function(client3_3, course3, user3) {
+
+              // User 1's first client gets both of User 1's courses
+              CourseTestUtil.assertGetUserCourses(client1_1, course1, null, [course1, course2], function() {
+                // User 1's second client gets both of User 1's courses
+                CourseTestUtil.assertGetUserCourses(client1_2, course2, null, [course1, course2], function() {
+                  // User 2's client gets User 2's only course
+                  CourseTestUtil.assertGetUserCourses(client2_2, course2, null, [course2], function() {
+                    // User 3's client gets User 3's only course
+                    CourseTestUtil.assertGetUserCourses(client3_3, course3, null, [course3], function() {
+
+                      return callback();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('excludes the current course if requested', function(callback) {
+      var course1 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var course2 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+
+      var user = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+
+      // User is in course 1
+      TestsUtil.getAssetLibraryClient(null, course1, user, function(client1, course1, user) {
+        // User is in course 2
+        TestsUtil.getAssetLibraryClient(null, course2, user, function(client2, course2, user) {
+
+          // Set excludeCurrent option
+          var opts = {'excludeCurrent': true};
+          // Request excludes the current course
+          CourseTestUtil.assertGetUserCourses(client1, course1, opts, [course2], function() {
+
+            return callback();
+          });
+        });
+      });
+    });
+
+    it('returns only courses with the Asset Library enabled if requested', function(callback) {
+      var course1 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var course2 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+
+      var user = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+
+      // User is in course 1
+      TestsUtil.getAssetLibraryClient(null, course1, user, function(client1, course1, user) {
+        // User is in course 2
+        TestsUtil.getAssetLibraryClient(null, course2, user, function(client2, course2, user) {
+
+          // Disable asset library in course 2
+          CourseTestUtil.getDbCourse(course2.id, function(dbCourse) {
+            dbCourse.assetlibrary_url = null;
+            dbCourse.save().complete(function(err, dbCourse) {      
+                  
+              // Set assetLibrary option
+              var opts = {'assetLibrary': true};
+              // Request returns only course 1
+              CourseTestUtil.assertGetUserCourses(client1, course1, opts, [course1], function() {
+
+                return callback();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('returns only courses where user has an admin role if requested', function(callback) {
+      var course1 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var course2 = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+
+      var user = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+      var userAsInstructor = TestsUtil.generateInstructor(global.tests.canvas.ucberkeley);
+      user.id = userAsInstructor.id;
+
+      // User is a regular user in course 1
+      TestsUtil.getAssetLibraryClient(null, course1, user, function(client1, course1, user) {
+        // User is an instructor in course 2
+        TestsUtil.getAssetLibraryClient(null, course2, userAsInstructor, function(client2, course2, userAsInstructor) {
+          
+          // Set admin option
+          var opts = {'admin': true};
+          // User 1's client returns only course 2
+          CourseTestUtil.assertGetUserCourses(client1, course1, opts, [course2], function() {
+
+            return callback();
+          });
+        });
+      });
+    });
+
+    it('does not erroneously match user account IDs between Canvas instances', function(callback) {
+      var berkeleyCourse = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var davisCourse = TestsUtil.generateCourse(global.tests.canvas.ucdavis);
+
+      var berkeleyUser = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+      var davisUser = TestsUtil.generateUser(global.tests.canvas.ucdavis);
+
+      // Berkeley and Davis users happen to have the same ID in their respective instances
+      berkeleyUser.id = davisUser.id;
+
+      // Berkeley user is in Berkeley course
+      TestsUtil.getAssetLibraryClient(null, berkeleyCourse, berkeleyUser, function(berkeleyClient, berkeleyCourse, berkeleyUser) {
+        // Davis user is in Davis course
+        TestsUtil.getAssetLibraryClient(null, davisCourse, davisUser, function(davisClient, davisCourse, davisUser) {
+
+          // Berkeley client gets only Berkeley course
+          CourseTestUtil.assertGetUserCourses(berkeleyClient, berkeleyCourse, null, [berkeleyCourse], function() {
+            // Davis client gets only Davis course
+            CourseTestUtil.assertGetUserCourses(davisClient, davisCourse, null, [davisCourse], function() {
+        
+              return callback();
+            });
+          });
+        });
+      });
+    });
+  });
+
   describe('Daily notification settings', function() {
     /**
      * Test that verifies that daily notifications are enabled by default

--- a/node_modules/col-course/tests/util.js
+++ b/node_modules/col-course/tests/util.js
@@ -23,6 +23,7 @@
  * ENHANCEMENTS, OR MODIFICATIONS.
  */
 
+var _ = require('lodash');
 var assert = require('assert');
 
 var CourseAPI = require('col-course');
@@ -109,6 +110,33 @@ var assertUpdateWeeklyNotificationsFails = module.exports.assertUpdateWeeklyNoti
   client.course.updateWeeklyNotifications(course, enabled, function(err) {
     assert.ok(err);
     assert.strictEqual(err.code, code);
+
+    return callback();
+  });
+};
+
+/**
+ * Assert that user courses are retrieved
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
+ * @param  {Object}             opts                            Request options
+ * @param  {Course[]}           expectedCourses                 Canvas course expected to be returned
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertGetUserCourses = module.exports.assertGetUserCourses = function(client, course, opts, expectedCourses, callback) {
+  client.course.getUserCourses(course, opts, function(err, userCourses) {
+    assert.ok(!err);
+    assert.strictEqual(userCourses.length, expectedCourses.length);
+
+    _.each(userCourses, function(userCourse) {
+      assert.ok(userCourse.id);
+      assert.ok(userCourse.canvas_course_role);
+      assert.ok(userCourse.course);
+      console.log(expectedCourses);
+      assert.ok(_.find(expectedCourses, {'id': userCourse.course.canvas_course_id}));
+    });
 
     return callback();
   });

--- a/node_modules/col-course/tests/util.js
+++ b/node_modules/col-course/tests/util.js
@@ -26,6 +26,7 @@
 var assert = require('assert');
 
 var CourseAPI = require('col-course');
+var DB = require('col-core/lib/db');
 
 /**
  * Assert that daily notification settings can be updated
@@ -110,5 +111,31 @@ var assertUpdateWeeklyNotificationsFails = module.exports.assertUpdateWeeklyNoti
     assert.strictEqual(err.code, code);
 
     return callback();
+  });
+};
+
+/**
+ * Get a database-backed course object given a Canvas course id
+ *
+ * @param  {Number}           canvasCourseId      The id of the course in Canvas
+ * @param  {Function}         callback            Invoked when the course has been retrieved
+ * @param  {Course}           callback.course     The retrieved course object
+ * @throws {AssertionError}                       Error thrown when an assertion failed
+ * @api private
+ */
+var getDbCourse = module.exports.getDbCourse = function(canvasCourseId, callback) {
+  var options = {
+    'where': {
+      'canvas_course_id': canvasCourseId
+    },
+    'include': [{
+      'model': DB.Canvas,
+      'as': 'canvas'
+    }]
+  };
+  DB.Course.findOne(options).complete(function(err, course) {
+    assert.ok(!err);
+    assert.ok(course);
+    return callback(course);
   });
 };

--- a/node_modules/col-rest/lib/rest/assets.js
+++ b/node_modules/col-rest/lib/rest/assets.js
@@ -225,6 +225,25 @@ module.exports = function(client) {
   };
 
   /**
+   * Migrate assets
+   *
+   * @param  {Course}         course                          The Canvas course in which the user is interacting with the API
+   * @param  {Number}         destinationUserId               Course-associated SuiteC id for destination user
+   * @param  {Function}       callback                        Standard callback function
+   * @param  {Object}         callback.err                    An error that occurred, if any
+   * @param  {Object}         callback.body                   The JSON response from the REST API
+   * @param  {Response}       callback.response               The response object as returned by requestjs
+   * @see col-assets/lib/rest.js for more information
+   */
+  client.assets.migrateAssets = function(course, destinationUserId, callback) {
+    var requestUrl = client.util.apiPrefix(course) + '/assets/migrate';
+    var data = {
+      'destinationUserId': destinationUserId
+    }
+    client.request(requestUrl, 'POST', data, null, callback);
+  };
+
+  /**
    * Create a new comment on an asset
    *
    * @param  {Course}         course                          The Canvas course in which the user is interacting with the API

--- a/node_modules/col-rest/lib/rest/course.js
+++ b/node_modules/col-rest/lib/rest/course.js
@@ -34,11 +34,30 @@ module.exports = function(client) {
    * @param  {Object}         callback.err                    An error that occurred, if any
    * @param  {Object}         callback.body                   The JSON response from the REST API
    * @param  {Response}       callback.response               The response object as returned by requestjs
-   * @see col-categories/lib/rest.js for more information
+   * @see col-course/lib/rest.js for more information
    */
   client.course.getCourse = function(course, callback) {
     var requestUrl = client.util.apiPrefix(course) + '/course';
     client.request(requestUrl, 'GET', null, null, callback);
+  };
+
+  /**
+   * Get active courses associated with the current user's Canvas account
+   *
+   * @param  {Course}         course                          The Canvas course in which the user is interacting with the API
+   * @param  {Object}         [opts]                          A set of options to filter the results by
+   * @param  {Boolean}        [opts.admin]                    Whether to only return courses in which the user is an admin
+   * @param  {Boolean}        [opts.assetLibrary]             Whether to only return courses in which the asset library is enabled
+   * @param  {Boolean}        [opts.excludeCurrent]           Whether to exclude the current course
+   * @param  {Function}       callback                        Standard callback function
+   * @param  {Object}         callback.err                    An error that occurred, if any
+   * @param  {Object}         callback.body                   The JSON response from the REST API
+   * @param  {Response}       callback.response               The response object as returned by requestjs
+   * @see col-course/lib/rest.js for more information
+   */
+  client.course.getUserCourses = function(course, opts, callback) {
+    var requestUrl = client.util.apiPrefix(course) + '/courses';
+    client.request(requestUrl, 'GET', opts, null, callback);
   };
 
   /**
@@ -50,7 +69,7 @@ module.exports = function(client) {
    * @param  {Object}         callback.err                    An error that occurred, if any
    * @param  {Object}         callback.body                   The JSON response from the REST API
    * @param  {Response}       callback.response               The response object as returned by requestjs
-   * @see col-categories/lib/rest.js for more information
+   * @see col-course/lib/rest.js for more information
    */
   client.course.updateDailyNotifications = function(course, enabled, callback) {
     var requestUrl = client.util.apiPrefix(course) + '/course/daily_notifications';
@@ -69,7 +88,7 @@ module.exports = function(client) {
    * @param  {Object}         callback.err                    An error that occurred, if any
    * @param  {Object}         callback.body                   The JSON response from the REST API
    * @param  {Response}       callback.response               The response object as returned by requestjs
-   * @see col-categories/lib/rest.js for more information
+   * @see col-course/lib/rest.js for more information
    */
   client.course.updateWeeklyNotifications = function(course, enabled, callback) {
     var requestUrl = client.util.apiPrefix(course) + '/course/weekly_notifications';

--- a/public/app/app.states.js
+++ b/public/app/app.states.js
@@ -49,15 +49,15 @@
         'templateUrl': '/app/assetlibrary/addlinkcontainer/addlinkcontainer.html',
         'controller': 'AssetLibraryAddLinkContainerController'
       })
-      .state('assetlibrarycategories', {
-        'url': '/assetlibrary/categories',
-        'templateUrl': '/app/assetlibrary/categories/categories.html',
-        'controller': 'AssetLibraryCategoriesController'
-      })
       .state('assetlibraryaddbookmarklet', {
         'url': '/assetlibrary/addbookmarklet',
         'templateUrl': '/app/assetlibrary/addbookmarklet/addbookmarklet.html',
         'controller': 'AssetLibraryAddBookmarkletController'
+      })
+      .state('assetlibrarymanage', {
+        'url': '/assetlibrary/manage',
+        'templateUrl': '/app/assetlibrary/manageassets/manageassets.html',
+        'controller': 'AssetLibraryManageAssetsController'
       })
       .state('assetlibrarylist', {
         'url': '/assetlibrary?category&user&keywords&type',

--- a/public/app/assetlibrary/assetLibraryFactory.js
+++ b/public/app/assetlibrary/assetLibraryFactory.js
@@ -148,6 +148,19 @@
     };
 
     /**
+     * Migrate user assets to another course
+     *
+     * @param  {Number}    destinationUserId                          The course-specific SuiteC user id to be associated with migrated assets
+     * @return {Promise}                                              $http promise
+     */
+    var migrateAssets = function(destinationUserId) {
+      var opts = {
+        'destinationUserId': destinationUserId
+      };
+      return $http.post(utilService.getApiUrl('/assets/migrate'), opts);
+    };
+
+    /**
      * Create a new comment on an asset
      *
      * @param  {Number}               id                              The id of the asset
@@ -207,6 +220,7 @@
       'createLink': createLink,
       'editAsset': editAsset,
       'deleteAsset': deleteAsset,
+      'migrateAssets': migrateAssets,
       'createComment': createComment,
       'editComment': editComment,
       'deleteComment': deleteComment,

--- a/public/app/assetlibrary/list/list.html
+++ b/public/app/assetlibrary/list/list.html
@@ -9,11 +9,11 @@
       data-search-options-type="searchOptions.type"
       class="assetlibrary-list-search-container col-xs-{{ isAdvancedSearch ? 12 : 8 }}"></search>
 
-    <!-- MANAGE CATEGORIES -->
+    <!-- MANAGE ASSETS -->
     <div class="col-xs-4 text-right" data-ng-show="!isAdvancedSearch">
-      <a data-ng-href="/assetlibrary/categories" data-ng-if="me.is_admin" class="btn btn-default">
+      <a data-ng-href="/assetlibrary/manage" data-ng-if="me.is_admin" class="btn btn-default">
         <i class="fa fa-cog"></i>
-        <span>Manage categories</span>
+        <span>Manage assets</span>
       </a>
     </div>
   </div>

--- a/public/app/assetlibrary/manageassets/manageassets.css
+++ b/public/app/assetlibrary/manageassets/manageassets.css
@@ -23,61 +23,71 @@
  * ENHANCEMENTS, OR MODIFICATIONS.
  */
 
-.assetlibrary-categories-container {
+.assetlibrary-manageassets-container {
   max-width: 600px;
 }
 
-.assetlibrary-categories-container h2,
-.assetlibrary-categories-container h3 {
+.assetlibrary-manageassets-container h2,
+.assetlibrary-manageassets-container h3 {
   margin-bottom: 15px;
 }
 
-.assetlibrary-categories-info {
+.assetlibrary-manageassets-info {
   margin-bottom: 20px;
 }
 
-.assetlibrary-categories-create-form {
+.assetlibrary-manageassets-create-form {
   margin-bottom: 20px;
 }
 
-.assetlibrary-categories-edit-form .form-group {
+.assetlibrary-manageassets-edit-form .form-group {
   margin-bottom: 5px;
 }
 
-.assetlibrary-categories-list {
+.assetlibrary-manageassets-list {
   border: 1px solid #CCC;
   padding: 0;
 }
 
-.assetlibrary-categories-list li {
+.assetlibrary-manageassets-list li {
   list-style-type: none;
   padding: 10px 20px 10px 10px;
 }
 
-.assetlibrary-categories-list li:nth-child(even) {
+.assetlibrary-manageassets-list li:nth-child(even) {
   background-color: #F9F9F9;
   border-top: 1px solid #E5E5E5;
   border-bottom: 1px solid #E5E5E5;
 }
 
-.assetlibrary-categories-list li:last-child {
+.assetlibrary-manageassets-list li:last-child {
   border-bottom: none;
 }
 
-.assetlibrary-categories-list small {
+.assetlibrary-manageassets-list small {
   color: #ADABAA;
   font-weight: 400;
 }
 
-.assetlibrary-categories-list .col-actions button {
+.assetlibrary-manageassets-list .col-actions button {
   font-size: 18px;
   font-weight: 500;
   margin-top: 5px;
 }
 
-.assetlibrary-categories-list .col-actions .assetlibrary-categories-assignment-checkbox {
+.assetlibrary-manageassets-list .col-actions .assetlibrary-manageassets-assignment-checkbox {
   font-size: 18px;
   height: 18px;
   margin-top: 3px;
   width: 18px;
+}
+
+.assetlibrary-manageassets-migrate-form {
+  margin-bottom: 20px;
+}
+
+.assetlibrary-manageassets-migrate-form .input-group .input-group-btn .btn {
+  border-bottom-left-radius: 4px;
+  border-top-left-radius: 4px;
+  margin-left: 20px;
 }

--- a/public/app/assetlibrary/manageassets/manageassets.html
+++ b/public/app/assetlibrary/manageassets/manageassets.html
@@ -1,20 +1,18 @@
-<div class="clearfix assetlibrary-categories-container">
+<div class="clearfix assetlibrary-manageassets-container">
 
   <a data-ng-href="/assetlibrary" class="col-back"><i class="fa fa-angle-left"></i> Back to Asset Library</a>
 
-  <h2>Manage Categories</h2>
-
-  <p class="assetlibrary-categories-info">Categories can be used to tag items and are a great way of classifying items within the Asset Library. The Asset Library can also be filtered by category.</p>
+  <h2>Manage Assets</h2>
 
   <h3>Custom Categories</h3>
 
-  <p class="assetlibrary-categories-info">Create custom categories that can be used to tag items:</p>
+  <p class="assetlibrary-manageassets-info">Categories can be used to tag items and are a great way of classifying items within the Asset Library. The Asset Library can also be filtered by category.</p>
 
-  <form class="assetlibrary-categories-create-form" name="assetlibraryCreateCategoryForm" data-ng-submit="assetlibraryCreateCategoryForm.$valid && createCategory(newCategory)" novalidate>
+  <form class="assetlibrary-manageassets-create-form" name="assetlibraryCreateCategoryForm" data-ng-submit="assetlibraryCreateCategoryForm.$valid && createCategory(newCategory)" novalidate>
     <div class="form-group" data-ng-class="{'has-error': !assetlibraryCreateCategoryForm.$submitted && assetlibraryCreateCategoryForm.assetlibraryCategoriesName.$touched && assetlibraryCreateCategoryForm.assetlibraryCategoriesName.$invalid}">
-      <label for="assetlibrary-categories-create-name" class="sr-only">Enter a new category</label>
+      <label for="assetlibrary-manageassets-create-name" class="sr-only">Enter a new category</label>
       <div class="input-group">
-        <input type="text" id="assetlibrary-categories-create-name" name="assetlibraryCreateCategoryName" class="form-control" placeholder="Enter a new category" data-ng-model="newCategory" data-ng-maxlength="255" required>
+        <input type="text" id="assetlibrary-manageassets-create-name" name="assetlibraryCreateCategoryName" class="form-control" placeholder="Enter a new category" data-ng-model="newCategory" data-ng-maxlength="255" required>
         <span class="input-group-btn">
           <button type="submit" class="btn btn-default" data-ng-disabled="assetlibraryCreateCategoryForm.$invalid">Add</button>
         </span>
@@ -26,7 +24,7 @@
     </div>
   </form>
 
-  <ul class="assetlibrary-categories-list" data-ng-show="filteredCustomCategories.length > 0">
+  <ul class="assetlibrary-manageassets-list" data-ng-show="filteredCustomCategories.length > 0">
     <li data-ng-repeat="category in filteredCustomCategories = (categories | filter: {canvas_assignment_id: '!'})">
       <div class="row"  data-ng-if="!category.editing">
         <div class="col-xs-9">
@@ -46,10 +44,10 @@
       </div>
 
       <!-- EDIT CATEGORY -->
-      <form name="assetlibraryEditCategoryForm" class="assetlibrary-categories-edit-form " data-ng-submit="assetlibraryEditCategoryForm.$valid && editCategory(category)" data-ng-if="category.editing" novalidate>
+      <form name="assetlibraryEditCategoryForm" class="assetlibrary-manageassets-edit-form " data-ng-submit="assetlibraryEditCategoryForm.$valid && editCategory(category)" data-ng-if="category.editing" novalidate>
         <div class="form-group" data-ng-class="{'has-error': assetlibraryEditCategoryForm.assetLibraryEditCategoryName.$invalid}">
-          <label for="assetlibrary-categories-edit-name" class="sr-only">Edit a category</label>
-          <input type="text" id="assetlibrary-categories-edit-name" class="form-control" name="assetLibraryEditCategoryName" placeholder="Edit a category" data-ng-model="category.newTitle" data-ng-maxlength="255" required>
+          <label for="assetlibrary-manageassets-edit-name" class="sr-only">Edit a category</label>
+          <input type="text" id="assetlibrary-manageassets-edit-name" class="form-control" name="assetLibraryEditCategoryName" placeholder="Edit a category" data-ng-model="category.newTitle" data-ng-maxlength="255" required>
           <div class="help-block" data-ng-messages="assetlibraryEditCategoryForm.assetLibraryEditCategoryName.$error">
             <div data-ng-message="required">Please enter a category</div>
             <div data-ng-message="maxlength">A category can only be 255 characters long</div>
@@ -68,9 +66,9 @@
 
   <h3>Assignments</h3>
 
-  <p class="assetlibrary-categories-info">Check the box next to the name of an Assignment in order to sync student submissions for that Assignment to the Asset Library. Each checked Assignment will appear as a category in the Asset Library, with all submissions shared for review and commenting by other students.</p>
+  <p class="assetlibrary-manageassets-info">Check the box next to the name of an Assignment in order to sync student submissions for that Assignment to the Asset Library. Each checked Assignment will appear as a category in the Asset Library, with all submissions shared for review and commenting by other students.</p>
 
-  <ul class="assetlibrary-categories-list" data-ng-show="filteredAssignmentCategories.length > 0">
+  <ul class="assetlibrary-manageassets-list" data-ng-show="filteredAssignmentCategories.length > 0">
     <li data-ng-repeat="category in filteredAssignmentCategories = (categories | filter: {canvas_assignment_id: ''})">
       <div class="row"  data-ng-if="!category.editing">
         <div class="col-xs-9">
@@ -84,7 +82,7 @@
             <label>
               <input
                type="checkbox"
-               class="assetlibrary-categories-assignment-checkbox"
+               class="assetlibrary-manageassets-assignment-checkbox"
                data-ng-attr-title="{{category.visible ? 'Unsynchronize' : 'Synchronize'}} this assignment"
                data-ng-model="category.visible"
                data-ng-change="editAssignmentCategory(category)">
@@ -99,4 +97,33 @@
     There are no assignments.
   </div>
 
+  <h3>Migrate Assets</h3>
+
+  <p class="assetlibrary-manageassets-info">If you have instructor privileges in another course site using the Asset Library, you can copy all of your assets into that site's Asset Library. Only assets that you have submitted yourself will be copied, not assets submitted by other instructors or by students.</p>
+  
+  <div data-ng-if="assetMigration === 'pending'">
+    <i class="fa fa-spinner fa-spin"></i> Migration in progress...
+  </div>
+  <div class="alert alert-success" role="alert" data-ng-if="assetMigration === 'complete'">
+    Migration complete.
+  </div>
+  <div class="alert alert-danger" role="alert" data-ng-if="assetMigration === 'error'">
+    Migration failed.
+  </div>
+  <div data-ng-if="!assetMigration">
+    <form class="assetlibrary-manageassets-migrate-form" name="assetlibraryMigrateAssetsForm" data-ng-submit="destinationUserId && migrateAssets(destinationUserId)" novalidate data-ng-if="assetLibraryCourses.length > 0">
+      <label for="assetlibrary-manageassets-migrate-coursesite" class="sr-only">Course site</label>
+      <div class="input-group">
+        <select id="assetlibrary-manageassets-migrate-coursesite" class="form-control" data-ng-model="destinationUserId" data-value="{{destinationUserId}}" data-ng-options="course.user_id as course.name for course in assetLibraryCourses">
+          <option value="" selected>Course site</option>
+        </select>
+        <span class="input-group-btn">
+          <button type="submit" class="btn btn-default" data-ng-disabled="!destinationUserId">Migrate assets</button>
+        </span>
+      </div>
+    </form>
+    <div class="alert alert-info" data-ng-if="assetLibraryCourses.length === 0">
+      You are not an instructor in any other course sites using the Asset Library.
+    </div>
+  </div>
 </div>

--- a/public/app/shared/courseFactory.js
+++ b/public/app/shared/courseFactory.js
@@ -39,6 +39,35 @@
     };
 
     /**
+     * Get active courses associated with the current user's Canvas ID
+     *
+     * @param  {Object}     opts                      A set of options to filter on
+     * @param  {Boolean}    [opts.admin]              Whether to only return courses in which the user is an admin
+     * @param  {Boolean}    [opts.assetLibrary]       Whether to only return courses in which the asset library is enabled
+     * @param  {Boolean}    [opts.excludeCurrent]     Whether to exclude the current course
+     * @return {Promise}                              $http promise
+     */
+    var getCourses = function(opts) {
+      var url = '/courses';
+      if (opts) {
+        var params = [];
+        if (opts.admin) {
+          params.push('admin=true');
+        }
+        if (opts.assetLibrary) {
+          params.push('assetLibrary=true');
+        }
+        if (opts.excludeCurrent) {
+          params.push('excludeCurrent=true');
+        }
+        if (params.length) {
+          url = url + '?' + params.join('&');
+        }
+      }
+      return $http.get(utilService.getApiUrl(url));
+    };
+
+    /**
      * Update the daily notification settings for a course
      *
      * @param  {Boolean}        enabled         Whether daily notifications should be enabled for the course
@@ -66,6 +95,7 @@
 
     return {
       'getCourse': getCourse,
+      'getCourses': getCourses,
       'updateDailyNotifications': updateDailyNotifications,
       'updateWeeklyNotifications': updateWeeklyNotifications
     };

--- a/public/index.html
+++ b/public/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="/app/assetlibrary/addbookmarklet/addbookmarklet.css" />
   <link rel="stylesheet" href="/app/assetlibrary/addlink/addlink.css" />
   <link rel="stylesheet" href="/app/assetlibrary/addlinkcontainer/addlinkcontainer.css" />
-  <link rel="stylesheet" href="/app/assetlibrary/categories/categories.css" />
   <link rel="stylesheet" href="/app/assetlibrary/edit/edit.css" />
   <link rel="stylesheet" href="/app/assetlibrary/iconbar/iconbar.css" />
   <link rel="stylesheet" href="/app/assetlibrary/item/item.css" />
   <link rel="stylesheet" href="/app/assetlibrary/list/list.css" />
+  <link rel="stylesheet" href="/app/assetlibrary/manageassets/manageassets.css" />
   <link rel="stylesheet" href="/app/assetlibrary/upload/upload.css" />
   <link rel="stylesheet" href="/app/assetlibrary/uploadcontainer/uploadcontainer.css" />
   <link rel="stylesheet" href="/app/engagementindex/leaderboard/list.css" />
@@ -95,12 +95,12 @@
   <script src="/app/assetlibrary/addlink/assetLibraryAddLinkController.js"></script>
   <script src="/app/assetlibrary/addlink/httpPrefixDirective.js"></script>
   <script src="/app/assetlibrary/addlinkcontainer/assetLibraryAddLinkContainerController.js"></script>
-  <script src="/app/assetlibrary/categories/assetLibraryCategoriesController.js"></script>
   <script src="/app/assetlibrary/edit/assetLibraryEditController.js"></script>
   <script src="/app/assetlibrary/iconbar/assetLibraryIconBarController.js"></script>
   <script src="/app/assetlibrary/iconbar/AssetLibraryIconBarDirective.js"></script>
   <script src="/app/assetlibrary/item/assetLibraryItemController.js"></script>
   <script src="/app/assetlibrary/list/assetLibraryListController.js"></script>
+  <script src="/app/assetlibrary/manageassets/assetLibraryManageAssetsController.js"></script>
   <script src="/app/assetlibrary/search/assetLibrarySearchDirective.js"></script>
   <script src="/app/assetlibrary/upload/assetLibraryUploadController.js"></script>
   <script src="/app/assetlibrary/uploadcontainer/assetLibraryUploadContainerController.js"></script>

--- a/scripts/migrate_assets.js
+++ b/scripts/migrate_assets.js
@@ -25,56 +25,24 @@
  * ENHANCEMENTS, OR MODIFICATIONS.
  */
 
-var _ = require('lodash');
-var async = require('async');
-var contentDisposition = require('content-disposition');
-var fs = require('fs');
-var os = require('os');
-var fs = require('fs');
-var path = require('path');
-var request = require('request');
 var argv = require('yargs')
-    .usage('Usage: $0 --fromcourse [fromcourse] --fromuser [fromuser] --tocourse [tocourse] --touser [touser] --categories [categories]')
-    .demand(['fromcourse', 'fromuser', 'tocourse', 'touser'])
+    .usage('Usage: $0 --fromuser [fromuser] --touser [touser] --categories [categories]')
+    .demand(['fromuser', 'touser'])
     .boolean('categories')
-    .describe('fromcourse', 'The Collabosphere id of the course to migrate assets from')
     .describe('fromuser', 'The Collabosphere id of the user to migrate assets from')
-    .describe('tocourse', 'The Collabosphere id of the course to migrate assets to')
     .describe('touser', 'The Collabosphere id of the user to migrate assets to')
     .describe('categories', 'Whether to migrate categories')
     .help('h')
     .alias('h', 'help')
     .argv;
 
-var AssetsAPI = require('col-assets');
-var CategoriesAPI = require('col-categories');
 var DB = require('col-core/lib/db');
 var log = require('col-core/lib/logger')('scripts/migrate_assets');
+var MigrateAssetsAPI = require('col-assets/lib/migrate');
 var UserAPI = require('col-users');
-var UserConstants = require('col-users/lib/constants');
-
-// Extract the information about the course and user to migrate assets from
-var fromCourse = argv.fromcourse;
-var fromUser = argv.fromuser;
-var toCourse = argv.tocourse;
-var toUser = argv.touser;
-
-var processStartTime = Date.now();
-// Variable that will keep track of the source user context for interaction with the API
-var fromCtx = null;
-// Variable that will keep track of the destination user context for interaction with the API
-var toCtx = null;
-// Variable that will keep track of an admin user context for interaction with the API
-var toAdminCtx = null;
-// Variable that will keep track of the mapping between source and destination categories
-var categoryMapping = {};
-// Variable that will keep track of how many assets have successfully migrated and
-// how many have failed to migrate for every asset type
-var results = {};
 
 /**
- * Connect to the Collabosphere database and kick
- * off the asset migration
+ * Connect to the Collabosphere database and kick off asset migration
  */
 var init = function() {
   // Apply global utilities
@@ -89,300 +57,50 @@ var init = function() {
     log.info('Connected to the database');
 
     // Create the context for interaction with the API
-    createContexts(function() {
-      // Migrate all categories
-      migrateCategories(function() {
-        // Migrate all assets
-        migrateAssets();
+    createSourceContext(argv.fromuser, function(err, fromCtx) {
+      if (err) {
+        return log.error({'err': err}, 'Could not create context for source user');
+      }
+
+      var opts = {
+        'categories': argv.categories,
+        'destinationUserId': argv.touser,
+        // When running shell script, user accounts are not required to match or be admins.
+        'validateUserAccounts': false
+      }
+
+      MigrateAssetsAPI.migrate(fromCtx, opts, function(err, results) {
+        if (err) {
+          return log.error({'err': err}, 'Migration failed');
+        }
+
+        log.info('Migration succeeded.');            
       });
     });
   });
 };
 
 /**
- * Create mock contexts to use for interaction with the API
+ * Create a mock context for the source user
  *
+ * @param  {Number}           userId              Collabosphere id for the source user
  * @param  {Function}         callback            Standard callback function
+ * @param  {Context}          callback.err        Error if any
+ * @param  {Context}          callback.fromCtx    Context for source user
  */
-var createContexts = function(callback) {
-  // Create the mock source user context
-  UserAPI.getUser(fromUser, function(err, fromUserObj) {
+var createSourceContext = function(userId, callback) {
+  UserAPI.getUser(userId, function(err, userObj) {
     if (err) {
-      log.error({'fromUser': fromUser, 'err': err}, 'Unable to retrieve user to migrate from');
       return callback(err);
     }
 
     fromCtx = {
-      'user': fromUserObj,
-      'course': fromUserObj.course
+      'user': userObj,
+      'course': userObj.course
     };
 
-    // Create the mock destination user context
-    UserAPI.getUser(toUser, function(err, toUserObj) {
-      if (err) {
-        log.error({'toUser': toUser, 'err': err}, 'Unable to retrieve user to migrate to');
-        return callback(err);
-      }
-
-      toCtx = {
-        'user': toUserObj,
-        'course': toUserObj.course
-      };
-
-      // Create the mock admin destination user context
-      toAdminCtx = {
-        'user': {
-          'is_admin': true
-        },
-        'course': toUserObj.course
-      };
-
-      return callback();
-    });
+    return callback(null, fromCtx);
   });
-};
-
-/**
- * Migrate all categories
- *
- * @param  {Function}         callback            Standard callback function
- */
-var migrateCategories = function(callback) {
-  if (!argv.categories) {
-    return callback();
-  }
-
-  // Get the categories in the source course
-  CategoriesAPI.getCategories(fromCtx, true, false, function(err, fromCategories) {
-    if (err) {
-      log.error({'err': err}, 'Unable to retrieve the source categories');
-      return callback(err);
-    }
-
-    // Get the categories in the destination course
-    CategoriesAPI.getCategories(toCtx, true, false, function(err, toCategories) {
-      if (err) {
-        log.error({'err': err}, 'Unable to retrieve the destination categories');
-        return callback(err);
-      }
-
-      // Derive the mapping between the existing categories based on
-      // exact title matches
-      _.each(fromCategories, function(fromCategory) {
-        _.each(toCategories, function(toCategory) {
-          if (fromCategory.title === toCategory.title) {
-            categoryMapping[fromCategory.id] = toCategory.id;
-          }
-        });
-      });
-
-      // Migrate the categories that could not be mapped
-      var migratedCategories = 0;
-      async.eachSeries(fromCategories, function(fromCategory, done) {
-        if (!categoryMapping[fromCategory.id]) {
-          migrateCategory(fromCategory.toJSON(), function(err) {
-            if (!err) {
-              migratedCategories++;
-            }
-            return done();
-          });
-        } else {
-          return done();
-        }
-      }, function() {
-        log.info({'categories': migratedCategories}, 'Finished migrating categories');
-        return callback();
-      });
-    });
-  });
-};
-
-/**
- * Migrate a category
- *
- * @param  {Category}         category            The category to migrate
- * @param  {Function}         callback            Standard callback function
- * @param  {Object}           callback.err        An error that occurred, if any
- */
-var migrateCategory = function(category, callback) {
-  CategoriesAPI.createCategory(toAdminCtx, category.title, undefined, undefined, function(err, newCategory) {
-    if (err) {
-      log.error({'category': category, 'err': err}, 'Failed to migrate category');
-      return callback(err);
-    }
-
-    categoryMapping[category.id] = newCategory.id;
-    return callback();
-  });
-};
-
-/**
- * Migrate the assets that need to be migrated
- */
-var migrateAssets = function() {
-  var options = {
-    'where': {
-      'course_id': fromCourse,
-    },
-    'order': 'created_at ASC',
-    'include': [
-      {
-        'model': DB.User,
-        'as': 'users',
-        'required': true,
-        'attributes': UserConstants.BASIC_USER_FIELDS,
-        'where': {
-          'id': fromUser
-        }
-      },
-      {
-        'model': DB.Category,
-        'attributes': ['id']
-      }
-    ]
-  };
-
-  DB.Asset.findAll(options).complete(function(err, assets) {
-    if (err) {
-      return log.error({'err': err}, 'Failed to get the assets to migrate');
-    }
-
-    async.eachSeries(assets, function(asset, callback) {
-      migrateAsset(asset.toJSON(), callback);
-    }, function() {
-      log.info({'total': assets.length, 'results': results}, 'Finished migrating assets');
-    });
-  });
-};
-
-/**
- * Migrate an asset
- *
- * @param  {Asset}            asset               The asset to migrate
- * @param  {Function}         callback            Standard callback function
- */
-var migrateAsset = function(asset, callback) {
-  var type = asset.type;
-
-  // Callback executed when the asset has finished migrating
-  var migrateCallback = function(err, newAsset) {
-    results[type] = results[type] || {
-      'success': 0,
-      'error': 0
-    };
-
-    if (err) {
-      log.error({'asset': asset, 'err': err}, 'Failed to migrate an asset');
-      results[type].error++;
-    } else {
-      log.info({'asset': asset, 'newAsset': newAsset}, 'Successfully migrated an asset');
-      results[type].success++;
-    }
-    return callback();
-  };
-
-  if (asset.type === 'link') {
-    migrateLink(asset, migrateCallback);
-  } else if (asset.type === 'file') {
-    migrateFile(asset, migrateCallback);
-  } else if (asset.type === 'whiteboard') {
-    log.info({'asset': asset}, 'Skipping whiteboard migration');
-    return callback();
-  } else {
-    log.error({'asset': asset}, 'Unrecognized asset type');
-    return callback();
-  }
-};
-
-/**
- * Migrate a link asset
- *
- * @param  {Asset}            link                The link to migrate
- * @param  {Function}         callback            Standard callback function
- */
-var migrateLink = function(link, callback) {
-  var categories = getMappedCategories(link.categories);
-  AssetsAPI.createLink(toCtx, link.title, link.url, {
-    'categories': categories,
-    'description': link.description || undefined,
-    'source': link.source || undefined,
-    'thumbnail_url': link.thumbnail_url || undefined,
-    'image_url': link.image_url || undefined,
-    'embed_id': link.embed_id || undefined,
-    'embed_key': link.embed_key || undefined,
-    'embed_code': link.embed_code || undefined
-  }, callback);
-};
-
-/**
- * Migrate a file asset
- *
- * @param  {Asset}            file                The file to migrate
- * @param  {Function}         callback            Standard callback function
- */
-var migrateFile = function(file, callback) {
-  var downloadDir = path.join(os.tmpdir(), processStartTime.toString());
-  fs.stat(downloadDir, function(err, stat) {
-    // Download the file to a temporary folder
-    if (err) {
-      if (err.code === 'ENOENT') {
-        fs.mkdirSync(downloadDir);
-      } else {
-        log.error({downloadDir: downloadDir, errorCode: err.code}, 'Failed to create temp directory during file migration');
-        return callback(err);
-      }
-    }
-    request(file.download_url).on('response', function(res) {
-      // Extract the name of the file
-      var disposition = contentDisposition.parse(res.headers['content-disposition']);
-      var filename = disposition.parameters.filename;
-      var filePath = path.join(downloadDir, filename);
-
-      // Function that will clean up the temporary file
-      var cleanTempFile = function(err) {
-        fs.unlink(filePath, function() {
-          return callback(err);
-        });
-      };
-
-      res.pipe(fs.createWriteStream(filePath))
-      .on('error', cleanTempFile)
-      .on('finish', function() {
-
-        // Create the file asset
-        var categories = getMappedCategories(file.categories);
-        AssetsAPI.createFile(toCtx, file.title, {
-          'mimetype': file.mime,
-          'file': filePath,
-          'filename': file.title
-        }, {
-          'categories': categories,
-          'description': file.description || undefined,
-          'thumbnail_url': file.thumbnail_url || undefined,
-          'image_url': file.image_url || undefined,
-          'embed_id': file.embed_id || undefined,
-          'embed_key': file.embed_key || undefined,
-          'embed_code': file.embed_code || undefined
-        }, cleanTempFile);
-      });
-    });
-  });
-};
-
-/**
- * Map a list of categories from the source course to the
- * corresponding categories in the destination course
- *
- * @param  {Number[]}         categories          The ids of the source course categories to map
- * @return {Number[]}                             The mapped destination course category ids
- */
-var getMappedCategories = function(categories) {
-  return _.chain(categories)
-          .map(function(category) {
-            return categoryMapping[category.id];
-          })
-          .compact()
-          .value();
 };
 
 init();


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-528

This large PR is split into three commits for more manageable review.

The first commit moves asset migration logic into a module which is accessible both from the existing script and from a REST endpoint. Validation, sanity checks and tests are added.

The second commit creates a REST endpoint to list all courses associated with a user's Canvas account. We need this in order to display asset migration options to the user. The course listing includes filters relevant to this use case: 1) show only courses where I am an admin; 2) show only courses that are using the Asset Library; 3) don't show the current course.

The third commit includes front-end changes. The "Manage Categories" page becomes a "Manage Assets" page. The asset migration interface is added below the category options.