### PR TITLE
COL-587 List users with case-insensitive ordering

### DIFF
--- a/node_modules/col-users/lib/api.js
+++ b/node_modules/col-users/lib/api.js
@@ -296,7 +296,7 @@ var getAllUsers = module.exports.getAllUsers = function(ctx, options, callback) 
       'canvas_enrollment_state': options.enrollmentStates
     },
     'attributes': attributes,
-    'order': [['canvas_full_name', 'ASC']]
+    'order': 'lower(canvas_full_name) ASC'
   };
   DB.User.findAll(queryOptions).complete(function(err, users) {
     if (err) {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-587

This fixes a frequent test failure. The test expects case-insensitive ordering; code was performing a case-sensitive ordering; whether or not they matched depended entirely on the random strings.