### PR TITLE
COL-524 Exclude users without activity when calculating last activity for course

### DIFF
--- a/node_modules/col-activities/lib/api.js
+++ b/node_modules/col-activities/lib/api.js
@@ -332,7 +332,10 @@ var setUserLastActivity = function(user, actor, callback) {
 var getLastActivityForCourse = module.exports.getLastActivityForCourse = function(courseId, callback) {
   var userActivityOptions = {
     'where': {
-      'course_id': courseId
+      'course_id': courseId,
+      'last_activity': {
+        $ne: null
+      }
     },
     'attributes': ['last_activity'],
     'order': [

--- a/node_modules/col-canvas/tests/test-poller.js
+++ b/node_modules/col-canvas/tests/test-poller.js
@@ -1189,39 +1189,43 @@ describe('Canvas poller', function() {
      * Test that verifies that courses with no recent activity are inactivated
      */
     it('inactivates a course with activity in the distant past', function(callback) {
+      // Create a user who will get some old activity
       TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
-        // Create a link asset with no optional metadata
-        AssetsTestsUtil.assertCreateLink(client, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset) {
+        // Create a second user who does nothing; inactivation logic should ignore this user 
+        TestsUtil.getAssetLibraryClient(null, course, null, function(doNothingClient, course, doNothingUser) {
+          // Create a link asset with no optional metadata
+          AssetsTestsUtil.assertCreateLink(client, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset) {
 
-          // Set the user's last_activity in the database to the distant past
-          DB.User.findOne({'where': {'canvas_user_id': user.id}}).complete(function(err, dbUser) {
-            assert.ok(!err);
-            var ninetyOneDaysAgo = moment().subtract(91, 'days');
-            dbUser.updateAttributes({'last_activity': ninetyOneDaysAgo}).complete(function(err) {
+            // Set the user's last_activity in the database to the distant past
+            DB.User.findOne({'where': {'canvas_user_id': user.id}}).complete(function(err, dbUser) {
               assert.ok(!err);
+              var ninetyOneDaysAgo = moment().subtract(91, 'days');
+              dbUser.updateAttributes({'last_activity': ninetyOneDaysAgo}).complete(function(err) {
+                assert.ok(!err);
 
-              // Get the actual course object so we can pass it into the poller
-              getCourse(course.id, function(dbCourse) {
+                // Get the actual course object so we can pass it into the poller
+                getCourse(course.id, function(dbCourse) {
 
-                // Set poller's deactivation threshold
-                CanvasPoller.setDeactivationThreshold(config.get('canvasPoller.deactivationThreshold'));
+                  // Set poller's deactivation threshold
+                  CanvasPoller.setDeactivationThreshold(config.get('canvasPoller.deactivationThreshold'));
 
-                // Prepare the mocked requests to Canvas
-                var mockedUsers = [
-                  CanvasTestsModel.getCanvasUser(user, course)
-                ];
-                CanvasTestsUtil.mockPollingRequests(dbCourse, mockedUsers);
+                  // Prepare the mocked requests to Canvas
+                  var mockedUsers = [
+                    CanvasTestsModel.getCanvasUser(user, course)
+                  ];
+                  CanvasTestsUtil.mockPollingRequests(dbCourse, mockedUsers);
 
-                // Poll the Canvas API for information
-                CanvasPoller.handleCourse(dbCourse, null, function(err) {
-                  assert.ok(!err);
-
-                  // Assert that the course was inactivated
-                  client.course.getCourse(course, function(err, course) {
+                  // Poll the Canvas API for information
+                  CanvasPoller.handleCourse(dbCourse, null, function(err) {
                     assert.ok(!err);
-                    assert.ok(!course.active);
 
-                    return callback();
+                    // Assert that the course was inactivated
+                    client.course.getCourse(course, function(err, course) {
+                      assert.ok(!err);
+                      assert.ok(!course.active);
+
+                      return callback();
+                    });
                   });
                 });
               });


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-524

Without this constraint, null `last_activity` values preempt not-null values in the `findOne` query below.