### PR TITLE
COL-568 Properly format asset titles for screen reader

### DIFF
--- a/public/app/assetlibrary/list/list.html
+++ b/public/app/assetlibrary/list/list.html
@@ -59,8 +59,10 @@
                 <i class="fa" data-ng-class="{'fa-file': (asset.type === 'file'), 'fa-link': (asset.type === 'link'), 'fa-calendar-o': (asset.type === 'whiteboard')}"></i>
               </div>
               <div class="col-list-item-metadata">
-                <span class="col-threedots">{{asset.title}}</span>
-                <small class="col-threedots">by {{asset.users.length > 1 ? asset.users.length + " collaborators" : asset.users[0].canvas_full_name}}</small>
+                <div class="col-threedots">{{asset.title}} </div>
+                <div class="col-threedots">
+                  <small>by {{asset.users.length > 1 ? asset.users.length + " collaborators" : asset.users[0].canvas_full_name}}></small>
+                </div>
               </div>
             </div>
             <div class="text-right col-list-item-actions" iconbar asset="asset" viewonly="true"></div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-568

Screen reader wants its whitespace. Also use `div` for block-level elements, instead of inline elements with `display: block` styling.