### PR TITLE
COL-646 Update user's last_activity on poller reactivation

### DIFF
--- a/node_modules/col-course/lib/api.js
+++ b/node_modules/col-course/lib/api.js
@@ -296,7 +296,15 @@ var activateCourse = module.exports.activateCourse = function(ctx, callback) {
         return callback({'code': 500, 'msg': err.message});
       }
 
-      return callback();
+      // Update user's last_activity attribute to ensure that the poller does not deactivate on its next sweep
+      ctx.user.update({'last_activity': new Date()}).complete(function(err) {
+        if (err) {
+          log.error({'course': course, 'err': err}, 'Failed to update last activity timestamp for a user');
+          return callback({'code': 500, 'msg': err.message});
+        }
+
+        return callback();
+      });
     });
   });
 };

--- a/node_modules/col-course/tests/test-course.js
+++ b/node_modules/col-course/tests/test-course.js
@@ -27,6 +27,7 @@ var assert = require('assert');
 
 var CourseAPI = require('col-course');
 var TestsUtil = require('col-tests');
+var UsersTestUtil = require('col-users/tests/util');
 
 var CourseTestUtil = require('./util');
 
@@ -227,10 +228,23 @@ describe('Course', function() {
           dbCourse.save().complete(function(err, dbCourse) {    
             assert.ok(!err);
 
-            // Activate course through API
-            CourseTestUtil.assertActivateCourse(client, course, function() {
+            // Assert that instructor has no activity
+            UsersTestUtil.assertGetMe(client, course, null, function(instructorMe) {
+              assert.ok(!instructorMe.last_activity);
 
-              return callback();
+              // Get current time
+              var now = new Date().toISOString();
+
+              // Activate course through API
+              CourseTestUtil.assertActivateCourse(client, course, function() {
+
+                // Assert that instructor's last activity has been updated
+                UsersTestUtil.assertGetMe(client, course, null, function(instructorMe) {
+                  assert.ok(instructorMe.last_activity >= now);
+
+                  return callback();
+                });
+              });
             });
           });
         });


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-646

Updating this timestamp ensures that poller reactivation will stick even if there's been no other activity logged in the meantime.