### PR TITLE
COL-655 Introduce configurable timeouts for background jobs

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -15,7 +15,8 @@
   "canvasPoller": {
     "enabled": true,
     "delay": 15,
-    "deactivationThreshold": 90
+    "deactivationThreshold": 90,
+    "timeout": 600
   },
   "cookie": {
     "secret": "String to encrypt the cookies with. Change me in production"
@@ -45,5 +46,8 @@
     "enabled": true,
     "url": "http://localhost:2001/process",
     "apiKey": "some shared secret"
+  },
+  "whiteboardThumbnails": {
+    "timeout": 300
   }
 }

--- a/node_modules/col-core/lib/api.js
+++ b/node_modules/col-core/lib/api.js
@@ -337,12 +337,6 @@ var initializeCanvasPoller = function() {
   }
 };
 
-// Number of milliseconds to wait for poller activity before reporting a warning
-var POLLER_INACTIVITY_THRESHOLD = 300000;
-
-// Number of milliseconds to wait for whiteboard thumbnails activity before reporting a warning
-var WHITEBOARD_THUMBNAILS_INACTIVITY_THRESHOLD = 300000;
-
 // Timestamp for last completed thumbnail generation
 var lastWhiteboardThumbnails = Date.now();
 
@@ -376,7 +370,7 @@ var getStatus = module.exports.getStatus = function(callback) {
 
     // Check for recent poller activity
     var lastCoursePoll = CanvasPoller.getLastCoursePoll();
-    if (Date.now() - lastCoursePoll < POLLER_INACTIVITY_THRESHOLD) {
+    if (Date.now() - lastCoursePoll < (config.get('canvasPoller.timeout') * 1000)) {
       status.poller = true;
     } else {
       status.poller = false;
@@ -384,7 +378,7 @@ var getStatus = module.exports.getStatus = function(callback) {
     }
 
     // Check for recent whiteboard thumbnail activity
-    if (Date.now() - lastWhiteboardThumbnails < WHITEBOARD_THUMBNAILS_INACTIVITY_THRESHOLD) {
+    if (Date.now() - lastWhiteboardThumbnails < (config.get('whiteboardThumbnails.timeout') * 1000)) {
       status.whiteboardThumbnails = true;
     } else {
       status.whiteboardThumbnails = false;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-655

Some SuiteC courses are now large enough that polling a single course takes longer than our five-minute timeout, which is raising false alarms. Bump the timeout to ten minutes and make it configurable.