### PR TITLE
COL-655 Handle timeouts on whiteboard PNG generation

### DIFF
--- a/node_modules/col-whiteboards/lib/api.js
+++ b/node_modules/col-whiteboards/lib/api.js
@@ -1607,6 +1607,12 @@ var getWhiteboardAsPng = function(whiteboard, callback) {
       return callback({'code': 500, 'msg': 'Failed to convert the whiteboard to PNG'});
     }
 
+    // If PNG generation for a single whiteboard takes more than 30 seconds, something isn't right.
+    var childProcessTimeout = setTimeout(function() {
+      childProcess.kill();
+      log.error({'whiteboard': whiteboard.id}, 'The whiteboardToPng script timed out');
+    }, 30000);
+
     // Feed the process the whiteboard elements
     var elements = _.map(whiteboard.whiteboardElements, 'element');
     elements = JSON.stringify(elements);
@@ -1630,6 +1636,7 @@ var getWhiteboardAsPng = function(whiteboard, callback) {
 
     // Once the PNG has been generated (or the script fails), return to the caller
     childProcess.on('close', function(code) {
+      clearTimeout(childProcessTimeout);
       if (code !== 0) {
         log.error({
           'code': code,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-655

Production logs suggest that successful runs of whiteboardToPng.js generally complete in less than 5 seconds, occasionally between 5 and 10.