### PR TITLE
COL-642 Do not timestamp whiteboard exports in Canvas filesystem

### DIFF
--- a/node_modules/col-assets/lib/api.js
+++ b/node_modules/col-assets/lib/api.js
@@ -588,7 +588,7 @@ var createFile = module.exports.createFile = function(ctx, title, file, opts, ca
   }
 
   // Upload the file to Canvas
-  CanvasAPI.uploadFileToCanvas(ctx, file.file, function(err, canvasItem) {
+  CanvasAPI.uploadFileToCanvas(ctx, file.file, null, function(err, canvasItem) {
     if (err) {
       return callback(err);
     }

--- a/node_modules/col-canvas/lib/api.js
+++ b/node_modules/col-canvas/lib/api.js
@@ -106,11 +106,12 @@ var getCanvases = module.exports.getCanvases = function(callback) {
  *
  * @param  {Context}        ctx                   Standard context containing the current user and the current course
  * @param  {String}         filePath              The path of the file that should be uploaded
+ * @param  {String}         [remoteName]          The name the file should be given in the Canvas filesystem. Defaults to course id + timestamp + local filename
  * @param  {Function}       callback              Standard callback function
  * @param  {Object}         callback.err          An error that occurred, if any
  * @param  {Object}         callback.fileInfo     The metadata of the file as returned by Canvas
  */
-var uploadFileToCanvas = module.exports.uploadFileToCanvas = function(ctx, filePath, callback) {
+var uploadFileToCanvas = module.exports.uploadFileToCanvas = function(ctx, filePath, remoteName, callback) {
   reloadCanvasObject(ctx.course.canvas, function(err) {
     if (err) {
       return callback(err);
@@ -118,7 +119,7 @@ var uploadFileToCanvas = module.exports.uploadFileToCanvas = function(ctx, fileP
 
     // Step 1: Tell Canvas that we want to upload a file. Canvas will give us some information about
     // where we should ship the file to in step 2
-    notifyCanvasOfUpload(ctx, filePath, function(err, uploadInfo) {
+    notifyCanvasOfUpload(ctx, filePath, remoteName, function(err, uploadInfo) {
       if (err) {
         return callback(err);
       }
@@ -216,12 +217,13 @@ var checkCanvasUploadFolder = function(ctx, callback) {
  *
  * @param  {Context}        ctx                   Standard context containing the current user and the current course
  * @param  {String}         filePath              The path for the file that should be uploaded
+ * @param  {String}         [remoteName]          The name the file should be given in the Canvas filesystem. Defaults to course id + timestamp + local filename
  * @param  {Function}       callback              Standard callback function
  * @param  {Object}         callback.err          An error that occurred, if any
  * @param  {Object}         callback.uploadInfo   The signed information that allows us to upload the file
  * @api private
  */
-var notifyCanvasOfUpload = function(ctx, filePath, callback) {
+var notifyCanvasOfUpload = function(ctx, filePath, remoteName, callback) {
   checkCanvasUploadFolder(ctx, function(err) {
     if (err) {
       return callback(err);
@@ -236,9 +238,10 @@ var notifyCanvasOfUpload = function(ctx, filePath, callback) {
     var d = new Date();
     var parentFolder = util.format('%s/%d/%d/%d/%d', CANVAS_UPLOAD_PATH, d.getFullYear(), d.getMonth(), d.getDate(), d.getHours());
 
-    // Prefix the file with an epoch timestamp. This is a crude attempt at avoiding
-    // file name collisions
-    var filename = util.format('%d_%d_%s', ctx.course.id, d.getTime(), path.basename(filePath));
+    // Unless a remote filename has been explicitly passed in, prefix the filename with course id and timestamp.
+    // This is a crude attempt at avoiding name collisions.
+    remoteName = remoteName || util.format('%d_%d_%s', ctx.course.id, d.getTime(), path.basename(filePath));
+
     var opts = {
       'url': url,
       'method': 'POST',
@@ -247,7 +250,7 @@ var notifyCanvasOfUpload = function(ctx, filePath, callback) {
       },
       'form': {
         // Some information about the file
-        'name': filename,
+        'name': remoteName,
         'filesize': fileInfo.size,
         'content_type': contentType,
 

--- a/node_modules/col-whiteboards/lib/api.js
+++ b/node_modules/col-whiteboards/lib/api.js
@@ -1551,12 +1551,13 @@ var getWhiteboardAsPngFile = function(whiteboard, callback) {
 
         // Upload the file to Canvas
         var ctx = {'course': course};
-        CanvasAPI.uploadFileToCanvas(ctx, imagePath, function(err, canvasItem) {
+        var remoteName = util.format('%d_whiteboard_%d.png', ctx.course.id, whiteboard.id);
+        CanvasAPI.uploadFileToCanvas(ctx, imagePath, remoteName, function(err, canvasItem) {
           if (err) {
             log.error({
               'err': err,
               'whiteboard': whiteboard.id
-            }, 'Could not upload  the PNG representation of the board to Canvas');
+            }, 'Could not upload the PNG representation of the board to Canvas');
             return cleanUpFile(imagePath, callback, err);
           }
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-642

Whiteboard image uploads to Canvas should have consistent filenames so that the new will overwrite the old.

Filenames on the local filesystem keep their timestamps so that multiple iterations of the write-upload-delete process won't trip over each other.