### PR TITLE
COL-462 Place copyright notice within wrapper divs

### DIFF
--- a/public/app/assetlibrary/item/item.html
+++ b/public/app/assetlibrary/item/item.html
@@ -279,9 +279,9 @@
       </div>
     </div>
   </div>
+  
+  <!-- COPYRIGHT -->
+  <div data-ng-include="'/app/shared/copyright.html'"></div>
 </div>
-
-<!-- COPYRIGHT -->
-<div data-ng-include="'/app/shared/copyright.html'"></div>
 
 <div ui-view></div>

--- a/public/app/assetlibrary/list/list.html
+++ b/public/app/assetlibrary/list/list.html
@@ -74,9 +74,8 @@
   <div class="alert alert-info assetlibrary-list-noresults" data-ng-if="isSearch && assets.length === 0">
     No matching assets were found.
   </div>
+  <!-- COPYRIGHT -->
+  <div data-ng-include="'/app/shared/copyright.html'"></div>
 </div>
-
-<!-- COPYRIGHT -->
-<div data-ng-include="'/app/shared/copyright.html'"></div>
 
 <div ui-view></div>

--- a/public/app/assetlibrary/manageassets/manageassets.html
+++ b/public/app/assetlibrary/manageassets/manageassets.html
@@ -123,7 +123,7 @@
       You are not an instructor in any other course sites using the Asset Library.
     </div>
   </div>
-</div>
 
-<!-- COPYRIGHT -->
-<div data-ng-include="'/app/shared/copyright.html'"></div>
+  <!-- COPYRIGHT -->
+  <div data-ng-include="'/app/shared/copyright.html'"></div>
+</div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-462

Follow-up to #296: some fanciness with wrapper divs and `ui-view` was causing the notice to appear twice.