### PR TITLE
COL-508 Configurable timezone setting for app and logs

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -47,6 +47,7 @@
     "url": "http://localhost:2001/process",
     "apiKey": "some shared secret"
   },
+  "timezone": "America/Los_Angeles",
   "whiteboardThumbnails": {
     "timeout": 300
   }

--- a/node_modules/col-activities/lib/rest.js
+++ b/node_modules/col-activities/lib/rest.js
@@ -23,6 +23,7 @@
  * ENHANCEMENTS, OR MODIFICATIONS.
  */
 
+var config = require('config');
 var moment = require('moment-timezone');
 var util = require('util');
 
@@ -43,8 +44,9 @@ Collabosphere.apiRouter.get('/activities.csv', function(req, res) {
     }
 
     // TODO: This date should be dependent on where the course is being given. Canvas doesn't give
-    // us this information however so we default it to the Pacific timezone
-    var date = moment().tz('America/Los_Angeles').format('YYYY_MM_DD_HH_mm');
+    // us this information however so we default it to app timezone
+    var timezone = config.get('timezone');
+    var date = moment().tz(timezone).format('YYYY_MM_DD_HH_mm');
     var filename = util.format('engagement_index_activities_%d_%s.csv', req.ctx.course.canvas_course_id, date);
     var dispositionHeader = util.format('attachment; filename="%s"', filename);
     res.set('Content-Disposition', dispositionHeader);

--- a/node_modules/col-core/lib/email.js
+++ b/node_modules/col-core/lib/email.js
@@ -98,6 +98,7 @@ var sendEmail = module.exports.sendEmail = function(subject, user, course, data,
 
   var baseCollabosphereProtocol = (config.get('app.https') ? 'https' : 'http');
   var baseCollabosphereUrl = baseCollabosphereProtocol + '://' + config.get('app.host');
+  var timezone = config.get('timezone');
 
   // Add a few helper functions / data points that can be used in the email templates
   data = _.extend({
@@ -116,7 +117,7 @@ var sendEmail = module.exports.sendEmail = function(subject, user, course, data,
      * @return {String}           The formatted date object. e.g., February 10 at 2:03 PM
      */
     'formatDate': function(date) {
-      return moment(date).tz('America/Los_Angeles').format('MMMM D \\a\\t h:mm A');
+      return moment(date).tz(timezone).format('MMMM D \\a\\t h:mm A');
     },
 
     /**

--- a/node_modules/col-core/lib/logger.js
+++ b/node_modules/col-core/lib/logger.js
@@ -26,6 +26,7 @@
 var _ = require('lodash');
 var bunyan = require('bunyan');
 var config = require('config');
+var moment = require('moment-timezone');
 var path = require('path');
 var prettyStream = require('bunyan-prettystream');
 
@@ -108,7 +109,42 @@ var createLogger = function(name) {
   // Wrap the error function to keep track of error counts
   logger.error = wrapErrorFunction(name, logger.error);
 
+  // Wrap all logger functions with timezone-aware timestamps
+  logger.trace = applyTimezone(name, logger.trace);
+  logger.debug = applyTimezone(name, logger.debug);
+  logger.info = applyTimezone(name, logger.info);
+  logger.warn = applyTimezone(name, logger.warn);
+  logger.error = applyTimezone(name, logger.error);
+  logger.fatal = applyTimezone(name, logger.fatal);
+
   return logger;
+};
+
+/**
+ * Wrap logger functions with timezone-aware timestamps
+ *
+ * @param  {String}     loggerName          The name of the logger for which the function will be wrapped
+ * @param  {Function}   loggerFunction      The logger function to wrap
+ * @return {Function}                       The wrapped logger function
+ * @api private
+ */
+var applyTimezone = function(loggerName, loggerFunction) {
+  return function() {
+    var args = Array.prototype.slice.call(arguments);
+    var timezone = config.get('timezone');
+    var time = moment().tz(timezone).format();
+
+    // If the first argument is an object, add the time property
+    if (typeof args[0] === 'object') {
+      args[0].time = time;
+    // Otherwise prepend the time in a new object argument
+    } else {
+      args.unshift({'time': time});
+    }
+
+    // Pass control back to Bunyan for message logging
+    return loggerFunction.apply(this, args);
+  };
 };
 
 /**

--- a/node_modules/col-whiteboards/lib/api.js
+++ b/node_modules/col-whiteboards/lib/api.js
@@ -1527,7 +1527,8 @@ var getWhiteboardAsPngFile = function(whiteboard, callback) {
     }
 
     // Flush the PNG to disk
-    var date = moment().tz('America/Los_Angeles').format('YYYY_MM_DD_HH_mm_ss');
+    var timezone = config.get('timezone');
+    var date = moment().tz(timezone).format('YYYY_MM_DD_HH_mm_ss');
     var filename = util.format('whiteboard-%d-%s.png', whiteboard.id, date);
     var imagePath = path.join(os.tmpdir(), filename);
     fs.writeFile(imagePath, data, {'encoding': 'binary'}, function(err) {

--- a/node_modules/col-whiteboards/lib/rest.js
+++ b/node_modules/col-whiteboards/lib/rest.js
@@ -24,6 +24,7 @@
  */
 
 var _ = require('lodash');
+var config = require('config');
 var moment = require('moment-timezone');
 var util = require('util');
 
@@ -208,7 +209,8 @@ Collabosphere.apiRouter.get('/whiteboards/:id/export/png', function(req, res) {
 
     // The filename is a concatenation of the whiteboard's title and the current timestamp. Only
     // alphanumerical characters will be used
-    var date = moment().tz('America/Los_Angeles').format('YYYY_MM_DD_HH_mm');
+    var timezone = config.get('timezone');
+    var date = moment().tz(timezone).format('YYYY_MM_DD_HH_mm');
     var filename = whiteboard.title + '-' + date;
     filename = filename.replace(/[^A-Za-z0-9-]/g, '-');
     res.set('Content-Disposition', util.format('attachment; filename="%s.png"', filename));


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-508

Neither of the levels in our logging stack, https://www.npmjs.com/package/bunyan or
https://www.npmjs.com/package/bunyan-prettystream (whose developer says, "This library is only really meant for development and should not be used on production environments"), allow for timestamp formatting as such. However, we can elbow our way in by wrapping the individual logger functions.