### PR TITLE
COL-675 Do not sync assignment submissions unless sync explicitly enabled

### DIFF
--- a/node_modules/col-canvas/lib/api.js
+++ b/node_modules/col-canvas/lib/api.js
@@ -405,6 +405,41 @@ var hideFile = function(ctx, file, callback) {
   });
 };
 
+/**
+ * Delete a file from the Canvas filesystem.
+ *
+ * @param  {Context}        ctx                   Standard context containing the current user and the current course
+ * @param  {Object}         file                  The file information for the file to be deleted as described by the Canvas API
+ * @param  {Function}       callback              Standard callback function
+ * @param  {Object}         callback.err          An error that occurred, if any
+ * @param  {Object}         callback.response     The Canvas API response
+ * @api private
+ */
+var deleteFile = module.exports.deleteFile = function(ctx, file, callback) {
+  log.debug({'file': file.id}, 'Deleting a file from the Canvas filesystem');
+
+  var url = util.format('%s/api/v1/files/%d', getCanvasBaseURI(ctx.course.canvas), file.id);
+  var opts = {
+    'url': url,
+    'method': 'DELETE',
+    'headers': {
+      'Authorization': util.format('Bearer %s', ctx.course.canvas.api_key)
+    }
+  };
+  
+  request(opts, function(err, response, body) {
+    if (err) {
+      log.error({'err': err, 'course': ctx.course.id}, 'Failed to delete the file');
+      return callback({'code': 500, 'msg': 'Failed to delete the file'});
+    } else if (response.statusCode !== 200) {
+      log.error({'err': err, 'course': ctx.course.id, 'body': body}, 'Failed to delete the file');
+      return callback({'code': 500, 'msg': 'Failed to delete the file'});
+    }
+
+    return callback(null, response);
+  });
+};
+
 /* Course users */
 
 /**

--- a/node_modules/col-canvas/lib/poller.js
+++ b/node_modules/col-canvas/lib/poller.js
@@ -37,6 +37,7 @@ var AssetsAPI = require('col-assets');
 var CategoriesAPI = require('col-categories');
 var CollabosphereConstants = require('col-core/lib/constants');
 var CourseAPI = require('col-course');
+var DB = require('col-core/lib/db');
 var log = require('col-core/lib/logger')('col-canvas/poller');
 var UsersAPI = require('col-users');
 
@@ -482,8 +483,7 @@ var handleAssignment = function(ctx, users, categories, opts, assignment, callba
 };
 
 /**
- * Handle the category synchronisation for an assignment. If a new category
- * gets creates it will get added to the set of categories
+ * Handle the category synchronisation for an assignment, creating a new category if necessary
  *
  * @param  {Context}          ctx                                   Standard context containing the current user and the current course
  * @param  {Object}           users                                 The users in the course indexed by their `canvas_user_id` attribute
@@ -626,7 +626,8 @@ var handleSubmission = function(ctx, users, assignment, activities, submissionAs
     'objectType': CollabosphereConstants.ACTIVITY.OBJECT_TYPES.CANVAS_SUBMISSION,
     'metadata': {
       'submission_id': submission.id,
-      'attempt': submission.attempt
+      'attempt': submission.attempt,
+      'file_sync_enabled': assignment.category.visible
     },
     'user': submission.user_id
   };
@@ -634,98 +635,124 @@ var handleSubmission = function(ctx, users, assignment, activities, submissionAs
     if (err) {
       return callback(err);
 
-    // We've already seen this submission attempt, we can skip processing the attachments
-    } else if (!created && (retrievedActivity && retrievedActivity.metadata && retrievedActivity.metadata.attempt === submission.attempt)) {
+    // We've already seen this submission attempt and there's been no change in visibility settings, so we can skip processing the attachments.
+    } else if (!created && 
+      (retrievedActivity && retrievedActivity.metadata && 
+       retrievedActivity.metadata.attempt === submission.attempt && 
+       retrievedActivity.metadata.file_sync_enabled === assignment.category.visible)) {
       return callback();
     }
 
-    // Before we do anything further, we update the activity so the activity is in sync with the data
-    // from the Canvas REST API. If we didn't do this first, we might end up in a situation where we
-    // endlessly remove and create new assets. Assume we update the activity as the very last thing we do
-    // and the following scenario happens:
-    //  - A user re-submits an assignments
-    //  - The poller will:
-    //     1.  Get the activity from the DB for this user's submission
-    //     2.  As the submission attempt number is 2 and the activity's is 1, a resubmission is detected
-    //     3.  Therefore the poller will, delete the assets from the old submission
-    //     4.  Create assets for the new submission
-    //     5.  Update the activity in the database with the attempt number
-    //
-    // If step 5 fails for whatever reason, the next time the poller runs, each step will be repeated.
-    // This means that assets will be removed and the same assets will remain at the top of the asset
-    // library. This is unacceptable, so we update the activity first.
-    //
-    // When a submission is dealt with for the first time, this method won't do anything
-    updateActivityIfNecessary(retrievedActivity, submission, function(err) {
+    // If we haven't seen this submission attempt or visibility settings have changed, mark the change in the database right away. In a failure
+    // scenario, it's better to mark the change and then fail to process attachments than it would be to process attachments and then fail to mark
+    // the change. The latter scenario would result in repeated attachment processing, and would keep deleting and recreating the same assets
+    // in the event of a persistent failure.
+    updateActivityIfNecessary(retrievedActivity, submission, assignment.category.visible, function(err) {
       if (err) {
         return callback(err);
       }
 
-      // Create a context for the user who created the submission. This will ensure that
-      // any activities are created in their name
+      var submissionUser = users[submission.user_id];
+      var submissionUserId = _.get(submissionUser, 'id');
+
+      // Create a context for the submitting user, to be used in activity creation.
       ctx = {
         'course': ctx.course,
-        'user': users[submission.user_id]
+        'user': submissionUser
       };
 
-      // Get the attachments the user previously submitted, if any
-      var filters = {
-        'user': ctx.user.id,
-        'assignment': assignment.id
+      // Retrieve any existing assets for this user and assignment ID. Hit the database directly rather than going
+      // through AssetsAPI so that hidden assets will be included.
+      var queryOptions = {
+        'where': {
+          'canvas_assignment_id': assignment.id
+        },
+        'attributes': ['id', 'download_url'],
+        'include': {
+          'model': DB.User,
+          'as': 'users',
+          'attributes': ['id'],
+          'required': true,
+          'where': {
+            'id': submissionUserId
+          }
+        }
       };
-      AssetsAPI.getAssets(ctx, filters, null, null, function(err, assets) {
+      DB.Asset.findAll(queryOptions).complete(function(err, previousSubmissionAssets) {
         if (err) {
           return callback(err);
+        }
+
+        if (previousSubmissionAssets.length) {
+          log.debug(
+            {'user': submissionUserId, 'assignment': assignment.id},
+            previousSubmissionAssets.length + ' previous submission assets for this user and assignment will be removed.');
         }
 
         // Delete any assets the user previously submitted for this assignment from the asset library.
         // Note that this won't actually delete the records from the database as we still need
         // activities such as liking, adding comments, etc.. to be retained
-        var assetIds = _.map(assets.results, 'id');
+        var assetIds = _.map(previousSubmissionAssets, 'id');
         AssetsAPI.deleteAssets(ctx, assetIds, function(err) {
           if (err) {
             log.error({
               'assets': assetIds,
               'err': err
-            }, 'Failed to delete a set of assets');
+            }, 'Failed to delete a set of assets from the SuiteC database');
             return callback(err);
           }
 
-          if (submission.submission_type === 'online_url') {
-            var existingAsset = submissionAssets.byUrl[submission.url];
-            if (existingAsset) {
-              // If we've already seen this URL, add a new user to the existing asset
-              return AssetsAPI.addUserToAsset(existingAsset, ctx.user.id, callback);
+          // Delete any files uploaded to the Canvas filesystem for previous submission assets.
+          var removeFileSubmissionAssetIterator = removeFileSubmissionAsset.bind(null, ctx);
+          async.eachSeries(previousSubmissionAssets, removeFileSubmissionAssetIterator, function(err) {
+            if (err) {
+              log.error({
+                'assets': assetIds,
+                'err': err
+                }, 'Failed to delete a set of assets from the Canvas filesystem');
+              return callback(err);
 
-            } else {
-              // If we haven't yet seen this URL, create a link asset
-              log.info({'course': ctx.course.id, 'assignment': assignment.id, 'submission': submission.id}, 'Will create link asset for submission');
-
-              var opts = {
-                'assignment': assignment.id,
-                'categories': [assignment.category.id],
-                'skipCreateActivity': true
-              };
-              AssetsAPI.createLink(ctx, null, submission.url, opts, function(err, linkAsset) {
-                if (linkAsset) {
-                  // Track the newly created asset in case the same URL shows up again
-                  submissionAssets.byUrl[submission.url] = linkAsset;
-                }
-                return callback(err, linkAsset);
-              });
+            // If sync is not enabled for this assignment, return without pulling down any new attachments.
+            } else if (!assignment.category.visible) {
+              return callback();
             }
 
-          // Create a file asset for each attachment on an "upload" submission
-          } else if (submission.submission_type === 'online_upload') {
-            log.info({'course': ctx.course.id, 'assignment': assignment.id, 'submission': submission.id}, 'Will create file assets for submission attachments');
+            if (submission.submission_type === 'online_url') {
+              var existingAsset = submissionAssets.byUrl[submission.url];
+              if (existingAsset) {
+                // If we've already seen this URL, add a new user to the existing asset
+                return AssetsAPI.addUserToAsset(existingAsset, ctx.user.id, callback);
 
-            var handleFilesSubmissionAttachmentIterator = handleFilesSubmissionAttachment.bind(null, ctx, assignment, submissionAssets);
-            return async.eachSeries(submission.attachments, handleFilesSubmissionAttachmentIterator, callback);
+              } else {
+                // If we haven't yet seen this URL, create a link asset
+                log.info({'course': ctx.course.id, 'assignment': assignment.id, 'submission': submission.id}, 'Will create link asset for submission');
 
-          // Ignore all other types of submissions
-          } else {
-            return callback();
-          }
+                var opts = {
+                  'assignment': assignment.id,
+                  'categories': [assignment.category.id],
+                  'skipCreateActivity': true
+                };
+                AssetsAPI.createLink(ctx, null, submission.url, opts, function(err, linkAsset) {
+                  if (linkAsset) {
+                    // Track the newly created asset in case the same URL shows up again
+                    submissionAssets.byUrl[submission.url] = linkAsset;
+                  }
+                  return callback(err, linkAsset);
+                });
+              }
+
+            // Create a file asset for each attachment on an "upload" submission
+            } else if (submission.submission_type === 'online_upload') {
+              log.info({'course': ctx.course.id, 'assignment': assignment.id, 'submission': submission.id}, 'Will create file assets for submission attachments');
+
+              var handleFilesSubmissionAttachmentIterator = handleFilesSubmissionAttachment.bind(null, ctx, assignment, submissionAssets);
+              return async.eachSeries(submission.attachments, handleFilesSubmissionAttachmentIterator, callback);
+
+            // Ignore all other types of submissions
+            } else {
+              return callback();
+            }
+          });
         });
       });
     });
@@ -735,18 +762,20 @@ var handleSubmission = function(ctx, users, assignment, activities, submissionAs
 /**
  * Update the given activity with the submission's data
  *
- * @param  {Activity}   activity            The activity to update
- * @param  {Object}     submission          The submission whose data should be persisted
- * @param  {Function}   callback            Standard callback function
- * @param  {Object}     callback.err        An error that occurred, if any
+ * @param  {Activity}   activity             The activity to update
+ * @param  {Object}     submission           The submission whose data should be persisted
+ * @param  {Boolean}    fileSyncEnabled      Whether file attachments will be synced to the asset library
+ * @param  {Function}   callback             Standard callback function
+ * @param  {Object}     callback.err         An error that occurred, if any
  * @api private
  */
-var updateActivityIfNecessary = function(activity, submission, callback) {
-  // Update the activity to indicate this attempt has been seen
-  if (activity.metadata.attempt !== submission.attempt) {
+var updateActivityIfNecessary = function(activity, submission, fileSyncEnabled, callback) {
+  // Update the activity with most recent attempt and sync status
+  if (activity.metadata.attempt !== submission.attempt || activity.metadata.file_sync_enabled !== fileSyncEnabled) {
     var metadata = {
       'submission_id': submission.id,
-      'attempt': submission.attempt
+      'attempt': submission.attempt,
+      'file_sync_enabled': fileSyncEnabled
     };
     return ActivitiesAPI.updateActivity(activity, {'metadata': metadata}, callback);
   } else {
@@ -829,6 +858,41 @@ var handleFilesSubmissionAttachment = function(ctx, assignment, submissionAssets
 
       return callback(err);
     });
+  });
+};
+
+var downloadUrlRegex = /files\/(\d+)\/download/;
+
+/**
+ * Remove processed attachment files from a Canvas assignment submission 
+ *
+ * @param  {Context}    ctx                               Standard context containing the current user and the current course
+ * @param  {Object}     asset                             The asset for which files are to be removed
+ * @param  {Function}   callback                          Standard callback function
+ * @param  {Object}     callback.err                      An error that occurred, if any
+ */
+var removeFileSubmissionAsset = function(ctx, asset, callback) {
+  // If the asset has no download URL, don't attempt removal.
+  if (!asset.download_url) {
+    return callback();
+  }
+
+  // If the asset's download URL doesn't match the expected Canvas pattern, don't attempt removal.
+  var match = downloadUrlRegex.exec(asset.download_url);
+  var fileId = match && match[1];
+  if (!fileId) {
+    log.debug({'asset': asset.id, 'download_url': asset.download_url}, 'Could not extract Canvas file ID from download_url');
+    return callback();
+  }
+
+  // If we do have a parseable URL, delete the file from the Canvas filesystem.
+  CanvasAPI.deleteFile(ctx, {'id': fileId}, function(err, response) {
+    if (err) {
+      log.error({'err': err, 'asset': asset.id}, 'Failed to delete an asset from the Canvas filesystem');
+      return callback(err);
+    }
+
+    return callback();
   });
 };
 

--- a/node_modules/col-canvas/tests/test-poller.js
+++ b/node_modules/col-canvas/tests/test-poller.js
@@ -675,7 +675,7 @@ describe('Canvas poller', function() {
                     assert.ok(_.find(assets.results, {'type': 'file', 'title': 'File 2.1'}));
                     assert.ok(_.find(assets.results, {'type': 'file', 'title': 'File 2.2'}));
 
-                    // Verify that polling again won't create any additional assets
+                    // Verify that polling again won't create or delete any additional assets
                     assignments[0].submissions[2].attachments[0].expectProcessing = false;
                     assignments[0].submissions[3].attachments[0].expectProcessing = false;
                     assignments[0].submissions[3].attachments[1].expectProcessing = false;
@@ -690,17 +690,26 @@ describe('Canvas poller', function() {
                         // Verify that resubmitting each assignment causes the files to be deleted
                         user1Submission.attempt++;
                         user1Submission.url = 'http://www.yahoo.com';
+
                         user2Submission.attempt++;
                         user2Submission.body = 'My new essay';
+                        
+                        user3Submission.oldFilePaths = _.map(user3Submission.attachments, 'filePath');
                         user3Submission.attempt++;
                         user3Submission.attachments = [
                           new CanvasFile('image/jpeg', 'File 1-updated', 'file1-updated.jpg')
                         ];
+                        user3Submission.attachments[0].expectDeletionAtPath = user3Submission.oldFilePaths[0];
+
+                        user4Submission.oldFilePaths = _.map(user4Submission.attachments, 'filePath');
                         user4Submission.attempt++;
                         user4Submission.attachments = [
                           new CanvasFile('image/jpeg', 'File 2.1-updated', 'file2.1-updated.jpg'),
                           new CanvasFile('image/jpeg', 'File 2.2-updated', 'file2.2-updated.jpg')
                         ];
+                        user4Submission.attachments[0].expectDeletionAtPath = user4Submission.oldFilePaths[0];
+                        user4Submission.attachments[1].expectDeletionAtPath = user4Submission.oldFilePaths[1];
+
                         CanvasTestsUtil.mockPollingRequests(dbCourse, [], assignments, []);
                         CanvasPoller.handleCourse(dbCourse, {'enableAssignmentCategories': true}, function(err) {
                           assert.ok(!err);
@@ -820,10 +829,13 @@ describe('Canvas poller', function() {
               // Verify an asset was added for the submission
               AssetsTestsUtil.assertGetAssets(client1, course, null, null, null, 1, function(assets) {
                 var fileAsset = assets.results[0];
+                var oldFilePath = assignments[0].submissions[0].attachments[0].filePath;
 
                 // The user re-submits their assignment
                 assignments[0].submissions[0].attempt++;
                 assignments[0].submissions[0].attachments = [new CanvasFile('image/jpeg', 'File 1-updated', 'file1-updated.jpg')];
+                assignments[0].submissions[0].attachments[0].expectDeletionAtPath = oldFilePath;
+
                 CanvasTestsUtil.mockPollingRequests(dbCourse, [], assignments, []);
                 CanvasPoller.handleCourse(dbCourse, {'enableAssignmentCategories': true}, function(err) {
                   assert.ok(!err);

--- a/node_modules/col-canvas/tests/util.js
+++ b/node_modules/col-canvas/tests/util.js
@@ -35,6 +35,7 @@ var TestsUtil = require('col-tests/lib/util');
  * Mock all the requests that are involved in uploading a file to Canvas
  *
  * @param  {Course}   course    The course to which the file will be uploaded
+ * @return {String}   fileUrl   The final URL for the uploaded file
  */
 var mockFileUpload = module.exports.mockFileUpload = function(course) {
   var appServer = TestsUtil.getMockedCanvasAppServer(course.canvas);
@@ -101,15 +102,20 @@ var mockFileUpload = module.exports.mockFileUpload = function(course) {
   appServer.expect(confirmRequest);
 
   // 4. Hiding the file
-  var hideUrl = util.format('/api/v1/files/%d', id);
-  var hideRequest = new MockedRequest('PUT', hideUrl, 200, fileInfo);
+  var fileUrl = util.format('/api/v1/files/%d', id);
+  var hideRequest = new MockedRequest('PUT', fileUrl, 200, fileInfo);
   appServer.expect(hideRequest);
+
+  return fileUrl;
 };
 
 /**
  * As it is unfeasable to bootstrap an actual Canvas instance during the tests, the Canvas REST API
  * will be mocked. This method allows you to declare the data that should be returned during 1 polling
  * run.
+ *
+ * Note that the mocking framework is extremely particular and demands that the mocked requests be declared
+ * in the same order that they'll be received. 
  *
  * @param  {Course}                 course          The course that we'll be mocking requests for
  * @param  {CanvasUser[]}           users           The users that are registered in the course
@@ -186,17 +192,24 @@ var mockGetSubmissions = module.exports.mockGetSubmissions = function(course, as
     .map(function(submission) {
       return submission.attachments;
     })
-    .flatten()
-    .each(function(attachment) {
-      if (attachment.expectProcessing) {
-        // The download request
-        var expectedPath = url.parse(attachment.url).pathname;
-        var mockedRequest = new MockedRequest('GET', expectedPath, 200, 'The file body');
-        TestsUtil.getMockedCanvasAppServer(course.canvas).expect(mockedRequest);
+    .each(function(attachmentSet) {
+      _.each(attachmentSet, function(attachment) {
+        if (attachment.expectDeletionAtPath) {
+          var mockedDeleteRequest = new MockedRequest('DELETE', attachment.expectDeletionAtPath, 200, '');
+          TestsUtil.getMockedCanvasAppServer(course.canvas).expect(mockedDeleteRequest);
+        }
+      });
+      _.each(attachmentSet, function(attachment) {
+        if (attachment.expectProcessing) {
+          // The download request
+          var expectedPath = url.parse(attachment.url).pathname;
+          var mockedRequest = new MockedRequest('GET', expectedPath, 200, 'The file body');
+          TestsUtil.getMockedCanvasAppServer(course.canvas).expect(mockedRequest);
 
-        // The upload request
-        mockFileUpload(course);
-      }
+          // The upload request
+          attachment.filePath = mockFileUpload(course);
+        }
+      });
     })
     .value();
 };

--- a/public/app/assetlibrary/manageassets/manageassets.html
+++ b/public/app/assetlibrary/manageassets/manageassets.html
@@ -66,7 +66,8 @@
 
   <h3>Assignments</h3>
 
-  <p class="assetlibrary-manageassets-info">Check the box next to the name of an Assignment in order to sync student submissions for that Assignment to the Asset Library. Each checked Assignment will appear as a category in the Asset Library, with all submissions shared for review and commenting by other students.</p>
+  <p class="assetlibrary-manageassets-info">Check the box next to the name of an Assignment in order to sync student submissions for that Assignment to the Asset Library. Each checked Assignment will appear as a category in the Asset Library, with all submissions shared for review and commenting by other students. There may be a short delay before
+  submissions appear for a checked Assignment.</p>
 
   <ul class="assetlibrary-manageassets-list" data-ng-show="filteredAssignmentCategories.length > 0">
     <li data-ng-repeat="category in filteredAssignmentCategories = (categories | filter: {canvas_assignment_id: ''})">

--- a/scripts/20170314-col675/add_sync_files.sql
+++ b/scripts/20170314-col675/add_sync_files.sql
@@ -1,0 +1,12 @@
+-- Add a 'file_sync_enabled' key, with initial value of true, to submission activity metadata. Because built-in JSON support
+-- is still skeletal in Postgres 9.4, we just append as a string.
+
+UPDATE activities
+SET metadata = (SELECT (trim(trailing '}' from metadata::text) || ',"file_sync_enabled":true}')::json)
+WHERE type = 'submit_assignment';
+
+/**** ROLLBACK ****
+
+UPDATE activities
+SET metadata = (SELECT (trim(trailing ',"file_sync_enabled":true}' from metadata::text) || '}')::json)
+WHERE type = 'submit_assignment';


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-675

The sheer number of to-be-deleted submission files in production means that a separate cleanup script isn't practical. Instead the poller will have to clean up its act as it goes along, requiring changes to the finicky process of submission syncing and tracking.