### PR TITLE
COL-706, Impact Studio LTI tool gets general purpose name: Dashboard

### DIFF
--- a/apache/suitec.template
+++ b/apache/suitec.template
@@ -29,6 +29,7 @@
 
     RewriteEngine On
     RewriteRule ^/assetlibrary         <%= documentRoot %>/index.html
+    RewriteRule ^/dashboard            <%= documentRoot %>/index.html
     RewriteRule ^/engagementindex      <%= documentRoot %>/index.html
     RewriteRule ^/whiteboards          <%= documentRoot %>/index.html
 

--- a/node_modules/col-lti/lib/constants.js
+++ b/node_modules/col-lti/lib/constants.js
@@ -24,6 +24,11 @@
  */
 
 var Constants = module.exports = {
+  'DASHBOARD': {
+    'id': 'dashboard',
+    'title': 'Dashboard',
+    'description': 'The SuiteC Dashboard is where students and instructors begin to explore SuiteC.'
+  },
   'ASSETLIBRARY': {
     'id': 'assetlibrary',
     'title': 'Asset Library',

--- a/scripts/20170315-col707/add_dashboard_url_to_courses.sql
+++ b/scripts/20170315-col707/add_dashboard_url_to_courses.sql
@@ -1,0 +1,3 @@
+-- Add column to store of SuiteC Dashboard URL per course. Dashboard is a new SuiteC LTI tool.
+
+ALTER TABLE courses ADD dashboard_url character varying(255);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-706
https://jira.ets.berkeley.edu/jira/browse/COL-707
https://jira.ets.berkeley.edu/jira/browse/COL-708

Introduction of the new LTI tool begins with proposed naming: Dashboard. Of course, the content of the "Impact Studio" landing page is up to UX / Service Lead. Nonetheless, I'd prefer to keep under-the-hood naming descriptive, generalized and NOT based on transient grant initiatives.

Before I proceed with such naming I use this PR to get approval from da team.