### PR TITLE
NOJIRA, update .gitignore with: apache/suitec.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.log
 logs/*.log
 
-apache/collabosphere.conf
+apache/suitec.conf
 
 config/*
 !config/default.json


### PR DESCRIPTION
An overdue fix. PDG devs will need to regenerate Apache config locally to pick up new LTI tool (dashboard). We don't want the generated `suitec.conf` to end up in Git repo.

cc: @paulkerschen @sandeepmjay 