### PR TITLE
COL-737, enable linking to user profile by id (default: me)

### DIFF
--- a/node_modules/col-users/lib/rest.js
+++ b/node_modules/col-users/lib/rest.js
@@ -41,6 +41,19 @@ Collabosphere.apiRouter.get('/users/me', function(req, res) {
 });
 
 /*!
+ * Get user of current course by id
+ */
+Collabosphere.apiRouter.get('/users/id/:id', function(req, res) {
+  UsersAPI.getUsers(req.ctx, [req.params.id], function(err, users) {
+    if (err) {
+      return res.status(err.code).send(err.msg);
+    }
+
+    return res.status(200).send(users[0]);
+  });
+});
+
+/*!
  * Get all users in the current course
  */
 Collabosphere.apiRouter.get('/users', function(req, res) {

--- a/public/app/app.bootstrap.js
+++ b/public/app/app.bootstrap.js
@@ -55,9 +55,15 @@
    * @see https://css-tricks.com/snippets/jquery/get-query-params-object/
    */
   var getQueryParameters = function() {
-    return decodeURIComponent(document.location.search).replace(/(^\?)/,'').split('&').map(function(n) {
+    var queryArgs = decodeURIComponent(document.location.search).replace(/(^\?)/,'');
+    var parameters = queryArgs.split('&').map(function(n) {
       return n = n.split('='), this[n[0]] = n[1], this;
     }.bind({}))[0];
+
+    // Extract '_id' from embedded toolUrl to support deep-linking from other SuiteC tool or email, possible.
+    var m = queryArgs.match(/.*[\?&]_id=([0-9a-zA-Z]+).*/);
+    parameters.deep_link_id = (m && m.length > 0) ? m[1] : null;
+    return parameters;
   };
 
   /**
@@ -80,6 +86,7 @@
     }).then(function(results) {
       collabosphere.constant('me', results.me.data);
       collabosphere.constant('config', results.config.data);
+      collabosphere.constant('deepLinkId', parameters.deep_link_id);
     });
   };
 

--- a/public/app/app.states.js
+++ b/public/app/app.states.js
@@ -81,6 +81,11 @@
         'templateUrl': '/app/dashboard/splash.html',
         'controller': 'SplashController'
       })
+      .state('profile', {
+        'url': '/profile/:userId',
+        'templateUrl': '/app/dashboard/splash.html',
+        'controller': 'SplashController'
+      })
 
       // Engagement Index routes
       .state('engagementindex', {

--- a/public/app/dashboard/myactivity.html
+++ b/public/app/dashboard/myactivity.html
@@ -1,10 +1,10 @@
 <div class="myactivity-container">
   <div class="myactivity-column profile">
     <div class="myactivity-profile-column">
-      <img class="myactivity-profile-avatar" data-ng-src="{{me.canvas_image}}" data-ng-if="me.canvas_image">
+      <img class="myactivity-profile-avatar" data-ng-src="{{user.canvas_image}}" data-ng-if="user.canvas_image">
     </div>
     <div class="myactivity-profile-column">
-      <h2 data-ng-bind="me.canvas_full_name"></h2>
+      <h2 data-ng-bind="user.canvas_full_name"></h2>
       <div>Section 001</div>
       <div>Last active: XXX</div>
     </div>

--- a/public/app/dashboard/splashController.js
+++ b/public/app/dashboard/splashController.js
@@ -27,11 +27,19 @@
 
   'use strict';
 
-  angular.module('collabosphere').controller('SplashController', function(me, $scope) {
+  angular.module('collabosphere').controller('SplashController', function(deepLinkId, me, userFactory, $scope) {
 
-    // Make the me object available to the scope
-    $scope.me = me;
+    var loadProfile = function() {
+      if (deepLinkId) {
+        userFactory.getUser(deepLinkId).success(function(user) {
+          $scope.user = user;
+        });
+      } else {
+        $scope.user = me;
+      }
+    };
 
+    loadProfile();
   });
 
 }(window.angular));

--- a/public/app/shared/userFactory.js
+++ b/public/app/shared/userFactory.js
@@ -39,6 +39,15 @@
     };
 
     /**
+     * Get user of current course by id
+     *
+     * @return {Promise<User[]>}                  $http promise returning user of the current course
+     */
+    var getUser = function(id) {
+      return $http.get(utilService.getApiUrl('/users/id/' + id));
+    };
+
+    /**
      * Get the users in the current course and their points
      *
      * @return {Promise<User[]>}                  $http promise returning the users in the current course and their points
@@ -90,6 +99,7 @@
 
     return {
       'getAllUsers': getAllUsers,
+      'getUser': getUser,
       'getLeaderboard': getLeaderboard,
       'updateSharePoints': updateSharePoints
     };


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-737

* change to `app.bootstrap.js` will parse out GET params from window.location
* new `/profile/:id` path takes advantage of `id_parameter` made available by change above
* I have put off the renaming of files, paths.  We'll refactor once official name is in.