### PR TITLE
COL-732 COL-733 Add per-asset and per-user activity APIs

### DIFF
--- a/node_modules/col-activities/lib/api.js
+++ b/node_modules/col-activities/lib/api.js
@@ -195,6 +195,113 @@ var exportActivities = module.exports.exportActivities = function(ctx, callback)
 };
 
 /**
+ * Get activities for a given user id
+ *
+ * @param  {Context}            ctx                               Standard context containing the current user and the current course
+ * @param  {Number}             userId                            The user id for which activities should be returned
+ * @param  {Function}           callback                          Standard callback function
+ * @param  {Object}             callback.err                      An error that occurred, if any
+ * @param  {Object}             callback.activities               The activities for the user, grouped by type
+ */
+var getActivitiesForUserId = module.exports.getActivitiesForUserId = function(ctx, userId, callback) {
+  // Parameter validation
+  var validationSchema = Joi.object().keys({
+    'userId': Joi.number().required()
+  });
+
+  var validationResult = Joi.validate({
+    'userId': userId,
+  }, validationSchema);
+
+  if (validationResult.error) {
+    return callback({'code': 400, 'msg': validationResult.error.details[0].message});
+  }
+
+  // Only course administrators and the user in question are authorized to view activities
+  if (!ctx.user.is_admin && Number(userId) !== ctx.user.id) {
+    log.error({'user': userId, 'course': ctx.course.id}, 'Unauthorized to retrieve activities for user');
+    return callback({'code': 401, 'msg': 'Unauthorized to retrieve activities for user'});
+  }
+
+  var options = {
+    'where': {
+      'id': userId,
+      'course_id': ctx.course.id
+    },
+    'include': {
+      'model': DB.Activity,
+      'attributes': ['id', 'type', 'created_at'],
+      'order': 'created_at ASC'
+    }
+  };
+
+  DB.User.findOne(options).complete(function(err, user) {
+    if (err) {
+      log.error({'err': err, 'user': userId, 'course': ctx.course.id}, 'Failed to get activities for user');
+      return callback({'code': 500, 'msg': err.message});
+    } else if (!user) {
+      log.debug({'err': err, 'user': userId, 'course': ctx.course.id}, 'A user with the specified id was not found in the course');
+      return callback({'code': 404, 'msg': 'A user with the specified id was not found in the course'});
+    }
+    
+    var activitiesByType = groupActivitiesByType(user.activities);
+    return callback(null, activitiesByType);
+  });
+};
+
+/**
+ * Get activities for a given asset id
+ *
+ * @param  {Context}            ctx                               Standard context containing the current user and the current course
+ * @param  {Number}             assetId                           The asset id for which activities should be returned
+ * @param  {Function}           callback                          Standard callback function
+ * @param  {Object}             callback.err                      An error that occurred, if any
+ * @param  {Object}             callback.activities               The activities for the asset, grouped by type
+ */
+var getActivitiesForAssetId = module.exports.getActivitiesForAssetId = function(ctx, assetId, callback) {
+  // Parameter validation
+  var validationSchema = Joi.object().keys({
+    'assetId': Joi.number().required()
+  });
+
+  var validationResult = Joi.validate({
+    'assetId': assetId,
+  }, validationSchema);
+
+  if (validationResult.error) {
+    return callback({'code': 400, 'msg': validationResult.error.details[0].message});
+  }
+
+  var options = {
+    'where': {
+      'id': assetId,
+      'course_id': ctx.course.id
+    },
+    'include': {
+      'model': DB.Activity,
+      'where': {
+        'type': {'$in': ['add_asset', 'view_asset', 'like', 'asset_comment', 'whiteboard_add_asset']}
+      },
+      'attributes': ['id', 'type', 'created_at'],
+      'order': 'created_at ASC'
+    }
+  };
+
+  DB.Asset.findOne(options).complete(function(err, asset) {
+    if (err) {
+      log.error({'err': err, 'asset': assetId, 'course': ctx.course.id}, 'Failed to get activities for asset');
+      return callback({'code': 500, 'msg': err.message});
+    } else if (!asset) {
+      log.debug({'err': err, 'asset': assetId, 'course': ctx.course.id}, 'An asset with the specified id was not found in the course');
+      return callback({'code': 404, 'msg': 'An asset with the specified id was not found in the course'});
+    }
+
+    var activitiesByType = groupActivitiesByType(asset.activities);
+    return callback(null, activitiesByType);
+  });
+};
+
+/**
  * Create an activity that contributes points to the engagement index
  *
  * @param  {Course}           course                              The course to which the activity should be associated
@@ -352,6 +459,24 @@ var getLastActivityForCourse = module.exports.getLastActivityForCourse = functio
 
     return callback(null, lastActivityTimestamp);
   });
+};
+
+/**
+ * Group an activity series by type for a slimmer payload
+ *
+ * @param   {Activity[]}     activities          The activities to group
+ * @return  {Object}                             Activities grouped by type
+ * @api private
+ */
+var groupActivitiesByType = function(activities) {
+  return _.reduce(activities, function(grouped, activity) {
+    grouped[activity.type] = grouped[activity.type] || [];
+    grouped[activity.type].push({
+      'id': activity.id,
+      'date': activity.created_at
+    });
+    return grouped;
+  }, {});
 };
 
 /**

--- a/node_modules/col-activities/lib/rest.js
+++ b/node_modules/col-activities/lib/rest.js
@@ -56,6 +56,32 @@ Collabosphere.apiRouter.get('/activities.csv', function(req, res) {
 });
 
 /*!
+ * Get all activities for a given user id
+ */
+Collabosphere.apiRouter.get('/activities/user/:userId', function(req, res) {
+  ActivitiesAPI.getActivitiesForUserId(req.ctx, req.params.userId, function(err, activities) {
+    if (err) {
+      return res.status(err.code).send(err.msg);
+    }
+
+    return res.status(200).send(activities);
+  });
+});
+
+/*!
+ * Get all activities for a given asset id
+ */
+Collabosphere.apiRouter.get('/activities/asset/:assetId', function(req, res) {
+  ActivitiesAPI.getActivitiesForAssetId(req.ctx, req.params.assetId, function(err, activities) {
+    if (err) {
+      return res.status(err.code).send(err.msg);
+    }
+
+    return res.status(200).send(activities);
+  });
+});
+
+/*!
  * Get the activity type configuration for a course
  */
 Collabosphere.apiRouter.get('/activities/configuration', function(req, res) {

--- a/node_modules/col-activities/tests/test-activities.js
+++ b/node_modules/col-activities/tests/test-activities.js
@@ -1,0 +1,165 @@
+/**
+ * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+var TestsUtil = require('col-tests');
+
+var ActivitiesTestUtil = require('./util');
+
+describe('Activities', function() {
+
+  describe('Get activity series for user', function() {
+    /**
+     * Test that verifies the format of a per-user activity series
+     */
+    it('returns activities grouped by type', function(callback) {
+      ActivitiesTestUtil.setupCourseWithActivity(function(dbCourse, course, users) {
+        
+        ActivitiesTestUtil.assertGetActivitiesForUserId(users.oliver.client, course, users.oliver.me.id, function(activities) {
+          // Oliver has created an asset and nothing else
+          ActivitiesTestUtil.assertActivities(activities, {'add_asset': 1});
+
+          ActivitiesTestUtil.assertGetActivitiesForUserId(users.nico.client, course, users.nico.me.id, function(activities) {
+            // Nico left one comment and his asset got two comments
+            ActivitiesTestUtil.assertActivities(activities, {'add_asset': 1, 'asset_comment': 1, 'get_asset_comment': 2});
+            
+            ActivitiesTestUtil.assertGetActivitiesForUserId(users.simon.client, course, users.simon.me.id, function(activities) {
+              // Simon left two comments
+              ActivitiesTestUtil.assertActivities(activities, {'add_asset': 1, 'asset_comment': 2});
+
+              ActivitiesTestUtil.assertGetActivitiesForUserId(users.paul.client, course, users.paul.me.id, function(activities) {
+                // Paul's asset got two comments
+                ActivitiesTestUtil.assertActivities(activities, {'add_asset': 1, 'get_asset_comment': 2});
+
+                ActivitiesTestUtil.assertGetActivitiesForUserId(users.annesophie.client, course, users.annesophie.me.id, function(activities) {
+                  // Anne-Sophie left one comment, which got a reply
+                  ActivitiesTestUtil.assertActivities(activities, {'add_asset': 1, 'asset_comment': 1, 'get_asset_comment_reply': 1});
+
+                  return callback();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    /**
+     * Test that verifies authorization when retrieving a per-user activity series
+     */
+    it('verifies authorization', function(callback) {
+      ActivitiesTestUtil.setupCourseWithActivity(function(dbCourse, course, users) {
+        // Oliver can't view Ray's activity
+        ActivitiesTestUtil.assertGetActivitiesForUserIdFails(users.oliver.client, course, users.ray.me.id, 401, function() {
+          // A course instructor can view Ray's activity
+          var instructor = TestsUtil.generateInstructor();
+          TestsUtil.getAssetLibraryClient(null, course, instructor, function(instructorClient, course, instructor) {
+            ActivitiesTestUtil.assertGetActivitiesForUserId(instructorClient, course, users.ray.me.id, function(activities) {
+
+              // An instructor in a different course can't view Ray's activity
+              var otherInstructor = TestsUtil.generateInstructor();
+              TestsUtil.getAssetLibraryClient(null, null, otherInstructor, function(otherInstructorClient, otherCourse, otherInstructor) {
+                ActivitiesTestUtil.assertGetActivitiesForUserIdFails(otherInstructorClient, otherCourse, users.ray.me.id, 404, function() {
+
+                  return callback();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    /**
+     * Test that verifies validation when retrieving a per-user activity series
+     */
+    it('is validated', function(callback) {
+      ActivitiesTestUtil.setupCourseWithActivity(function(dbCourse, course, users) {
+        var instructor = TestsUtil.generateInstructor();
+        TestsUtil.getAssetLibraryClient(null, course, instructor, function(instructorClient, course, instructor) {
+          // Return 400 on non-numeric user ID
+          ActivitiesTestUtil.assertGetActivitiesForUserIdFails(instructorClient, course, 'Colonel Not-A-Number', 400, function() {
+            // Return 404 on a nonexistent user ID
+            ActivitiesTestUtil.assertGetActivitiesForUserIdFails(instructorClient, course, 99999, 404, function() {
+
+              return callback();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('Get activity series for asset', function() {
+    /**
+     * Test that verifies the format of a per-asset activity series
+     */
+    it('returns activities', function(callback) {
+      ActivitiesTestUtil.setupCourseWithActivity(function(dbCourse, course, users) {
+        ActivitiesTestUtil.assertGetActivitiesForAssetId(users.oliver.client, course, users.oliver.asset.id, function(activities) {
+          // Nothing has happened to Oliver's asset since creation
+          ActivitiesTestUtil.assertActivities(activities, {'add_asset': 1});
+
+          ActivitiesTestUtil.assertGetActivitiesForAssetId(users.oliver.client, course, users.nico.asset.id, function(activities) {
+            // Nico's asset has a creation event and two comments
+            ActivitiesTestUtil.assertActivities(activities, {'add_asset': 1, 'asset_comment': 2});
+
+            return callback();
+          });
+        });
+      });
+    });
+
+    /**
+     * Test that verifies validation when retrieving a per-asset activity series
+     */
+    it('is validated', function(callback) {
+      ActivitiesTestUtil.setupCourseWithActivity(function(dbCourse, course, users) {
+        // Return 400 on non-numeric asset ID
+        ActivitiesTestUtil.assertGetActivitiesForAssetIdFails(users.oliver.client, course, 'eggshell_white', 400, function() {
+          // Return 404 on a nonexistent asset ID
+          ActivitiesTestUtil.assertGetActivitiesForAssetIdFails(users.oliver.client, course, 99999, 404, function() {
+
+            return callback();
+          });
+        });
+      });
+    });
+
+    /**
+     * Test that verifies authorization when retrieving a per-asset activity series
+     */
+    it('verifies authorization', function(callback) {
+      ActivitiesTestUtil.setupCourseWithActivity(function(dbCourse, course, users) {
+        // A user in a different course can't see asset activity
+        TestsUtil.getAssetLibraryClient(null, null, null, function(otherClient, otherCourse, otherUser) {
+          ActivitiesTestUtil.assertGetActivitiesForAssetIdFails(otherClient, otherCourse, users.oliver.asset.id, 404, function() {
+
+            return callback();
+          });
+        });
+      });
+    }); 
+  });
+});

--- a/node_modules/col-activities/tests/util.js
+++ b/node_modules/col-activities/tests/util.js
@@ -327,6 +327,82 @@ var assertCreateCommentActivity = module.exports.assertCreateCommentActivity = f
 };
 
 /**
+ * Assert that activities for a user can be retrieved
+ *
+ * @param  {RestClient}         client                            The REST client to make the request with
+ * @param  {Course}             course                            The Canvas course in which the user is interacting with the API
+ * @param  {Number}             userId                            The SuiteC id of the user for which activities are requested
+ * @param  {Function}           callback                          Standard callback function
+ * @param  {Object}             callback.activities               The returned activities, grouped by type
+ * @throws {AssertionError}                                       Error thrown when an assertion failed
+ */
+var assertGetActivitiesForUserId = module.exports.assertGetActivitiesForUserId = function(client, course, userId, callback) {
+  client.activities.getActivitiesForUserId(course, userId, function(err, activities, response) {
+    assert.ok(!err);
+
+    return callback(activities);
+  });
+};
+
+/**
+ * Assert that activities for a user cannot be retrieved
+ *
+ * @param  {RestClient}         client                            The REST client to make the request with
+ * @param  {Course}             course                            The Canvas course in which the user is interacting with the API
+ * @param  {Number}             userId                            The SuiteC id of the user for which activities are requested
+ * @param  {Number}             code                              The expected HTTP error code
+ * @param  {Function}           callback                          Standard callback function
+ * @throws {AssertionError}                                       Error thrown when an assertion failed
+ */
+var assertGetActivitiesForUserIdFails = module.exports.assertGetActivitiesForUserIdFails = function(client, course, userId, code, callback) {
+  client.activities.getActivitiesForUserId(course, userId, function(err, activities, response) {
+    assert.ok(err);
+    assert.strictEqual(err.code, code);
+    assert.ok(!activities);
+
+    return callback();
+  });
+};
+
+/**
+ * Assert that activities for an asset can be retrieved
+ *
+ * @param  {RestClient}         client                            The REST client to make the request with
+ * @param  {Course}             course                            The Canvas course in which the user is interacting with the API
+ * @param  {Number}             assetId                           The id of the asset for which activities are requested
+ * @param  {Function}           callback                          Standard callback function
+ * @param  {Object}             callback.activities               The returned activities, grouped by type
+ * @throws {AssertionError}                                       Error thrown when an assertion failed
+ */
+var assertGetActivitiesForAssetId = module.exports.assertGetActivitiesForAssetId = function(client, course, assetId, callback) {
+  client.activities.getActivitiesForAssetId(course, assetId, function(err, activities, response) {
+    assert.ok(!err);
+
+    return callback(activities);
+  });
+};
+
+/**
+ * Assert that activities for an asset cannot be retrieved
+ *
+ * @param  {RestClient}         client                            The REST client to make the request with
+ * @param  {Course}             course                            The Canvas course in which the user is interacting with the API
+ * @param  {Number}             assetId                           The id of the asset for which activities are requested
+ * @param  {Number}             code                              The expected HTTP error code
+ * @param  {Function}           callback                          Standard callback function
+ * @throws {AssertionError}                                       Error thrown when an assertion failed
+ */
+var assertGetActivitiesForAssetIdFails = module.exports.assertGetActivitiesForAssetIdFails = function(client, course, assetId, code, callback) {
+  client.activities.getActivitiesForAssetId(course, assetId, function(err, activities, response) {
+    assert.ok(err);
+    assert.strictEqual(err.code, code);
+    assert.ok(!activities);
+
+    return callback();
+  });
+};
+
+/**
  * Get the me objects for a set of REST clients
  *
  * @param  {RestClient[]}   clients     The REST clients for which to get the me objects
@@ -683,6 +759,24 @@ var assertViewAssetActivity = module.exports.assertViewAssetActivity = function(
           }
         }
       });
+    });
+  });
+};
+
+/**
+ * Assert that activities are well-formed and have the expected counts per type
+ *
+ * @param  {Object}            activities                          Activities grouped by type
+ * @param  {Object}            expectedActivityCounts              Expected activity counts by type
+ * @throws {AssertionError}                                        Error thrown when an assertion failed
+ */
+var assertActivities = module.exports.assertActivities = function(activities, expectedActivityCounts) {
+  assert.strictEqual(_.size(activities), _.size(expectedActivityCounts));
+  _.each(activities, function(activitySeries, type) {
+    assert.strictEqual(activitySeries.length, expectedActivityCounts[type]);
+    _.each(activitySeries, function(activity) {
+      assert.ok(activity.id);
+      assert.ok(activity.date);
     });
   });
 };
@@ -1127,7 +1221,7 @@ var setupCourseWithActivity = module.exports.setupCourseWithActivity = function(
     //  - To Nico - Anne Sophie and Simon commented on your asset '...'
     //  - To Anne-Sophie - Simon replied to your comment '...'
     //  - To Simon - Paul commented on your whiteboard '...'
-    //  - To Paul - Today's activity
+    //  - To Paul - Simon and Nico commented on your asset '...'
     AssetsTestUtil.assertCreateComment(users.annesophie.client, course, users.nico.asset.id, 'This is a comment by Anne-Sophie', null, function(anneSophiesComment) {
       AssetsTestUtil.assertCreateComment(users.simon.client, course, users.nico.asset.id, 'This is a reply by Simon', anneSophiesComment.id, function(simonsReply) {
         WhiteboardsTestUtil.assertEditWhiteboard(users.simon.client, course, users.simon.whiteboard.id, users.simon.whiteboard.title, [users.simon.me.id, users.paul.me.id], function() {

--- a/node_modules/col-core/lib/db.js
+++ b/node_modules/col-core/lib/db.js
@@ -861,6 +861,7 @@ var setUpModel = function(sequelize) {
       'allowNull': false
     }
   });
+  User.hasMany(Activity);
 
   // The actor is the user that triggered the activity when different than the user earning the activity
   // points. For example, when John replies to a comment from Bella, two separate records will be created as

--- a/node_modules/col-rest/lib/rest/activities.js
+++ b/node_modules/col-rest/lib/rest/activities.js
@@ -75,6 +75,38 @@ module.exports = function(client) {
     client.jsonPost(requestUrl, activityTypeUpdates, null, callback);
   };
 
+  /**
+   * Get activities for a user ID
+   *
+   * @param  {Course}         course                            The Canvas course in which the user is interacting with the API
+   * @param  {Number}         userId                            The SuiteC id of the user for which activities should be returned
+   * @param  {Function}       callback                          Standard callback function
+   * @param  {Object}         callback.err                      An error that occurred, if any
+   * @param  {Object}         callback.body                     The JSON response from the REST API
+   * @param  {Response}       callback.response                 The response object as returned by requestjs
+   * @see col-activities/lib/rest.js for more information
+   */
+  client.activities.getActivitiesForUserId = function(course, userId, callback) {
+    var requestUrl = client.util.apiPrefix(course) + '/activities/user/' + client.util.encodeURIComponent(userId);
+    client.request(requestUrl, 'GET', null, null, callback);
+  };
+
+  /**
+   * Get activities for an asset ID
+   *
+   * @param  {Course}         course                            The Canvas course in which the user is interacting with the API
+   * @param  {Number}         assetId                           The id of the asset for which activities should be returned
+   * @param  {Function}       callback                          Standard callback function
+   * @param  {Object}         callback.err                      An error that occurred, if any
+   * @param  {Object}         callback.body                     The JSON response from the REST API
+   * @param  {Response}       callback.response                 The response object as returned by requestjs
+   * @see col-activities/lib/rest.js for more information
+   */
+  client.activities.getActivitiesForAssetId = function(course, assetId, callback) {
+    var requestUrl = client.util.apiPrefix(course) + '/activities/asset/' + client.util.encodeURIComponent(assetId);
+    client.request(requestUrl, 'GET', null, null, callback);
+  };
+
   /*
    * Manually trigger the weekly email notification for a course
    * @param  {Course}         course                            The Canvas course in which the user is interacting with the API


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-732
https://jira.ets.berkeley.edu/jira/browse/COL-733

For the moment these are slim payloads, returning only an id and timestamp for relevant activities. Event details can be added in as required.