### PR TITLE
COL-737, link names on asset detail to profile if target tool is available

### DIFF
--- a/public/app/assetlibrary/item/item.html
+++ b/public/app/assetlibrary/item/item.html
@@ -116,7 +116,10 @@
                   <div class="media-object col-avatar" data-ng-style="{'background-image': 'url(' + user.canvas_image + ')'}"></div>
                 </div>
                 <div class="media-left media-middle assetlibrary-item-metadata-authors-name">
-                  <a ui-sref="assetlibrarylist({'user': user.id})" ui-sref-opts="{'inherit': false}">
+                  <a tool-href data-tool="dashboard" data-course="me.course" data-id="user.id" data-ng-if="me.course.dashboard_url">
+                    <i class="fa fa-graduation-cap" data-ng-if="user.is_admin"></i> {{user.canvas_full_name}}
+                  </a>
+                  <a ui-sref="assetlibrarylist({'user': user.id})" ui-sref-opts="{'inherit': false}" data-ng-if="!me.course.dashboard_url">
                     <i class="fa fa-graduation-cap" data-ng-if="user.is_admin"></i> {{user.canvas_full_name}}
                   </a>
                   <span data-ng-if="me.id === user.id">(me)</span>
@@ -193,7 +196,10 @@
       <div class="media-body media-middle">
         <form name="assetlibraryNewCommentForm" class="assetlibrary-item-newcomment-form" data-ng-submit="assetlibraryNewCommentForm.$valid && createComment()" novalidate>
           <div class="assetlibrary-item-addcomment-commenter">
-            <a ui-sref="assetlibrarylist({'user': me.id})" ui-sref-opts="{'inherit': false}">
+            <a tool-href data-tool="dashboard" data-course="me.course" data-id="me.id" data-ng-if="me.course.dashboard_url">
+              <i class="fa fa-graduation-cap" data-ng-if="me.is_admin"></i> {{me.canvas_full_name}}
+            </a>
+            <a ui-sref="assetlibrarylist({'user': me.id})" ui-sref-opts="{'inherit': false}" data-ng-if="!me.course.dashboard_url">
               <i class="fa fa-graduation-cap" data-ng-if="me.is_admin"></i> {{me.canvas_full_name}}
             </a> (me)
           </div>
@@ -220,7 +226,11 @@
       </div>
       <div class="media-body media-top">
         <div class="assetlibrary-item-addcomment-commenter">
-          <a ui-sref="assetlibrarylist({'user': comment.user.id})" ui-sref-opts="{'inherit': false}">
+          <a tool-href data-tool="dashboard" data-course="me.course" data-id="comment.user.id" data-ng-if="me.course.dashboard_url">
+            <i class="fa fa-graduation-cap" data-ng-if="comment.user.is_admin"></i> {{comment.user.canvas_full_name}}
+            <span data-ng-if="me.id === comment.user.id">(me)</span>
+          </a>
+          <a ui-sref="assetlibrarylist({'user': comment.user.id})" ui-sref-opts="{'inherit': false}" data-ng-if="!me.course.dashboard_url">
             <i class="fa fa-graduation-cap" data-ng-if="comment.user.is_admin"></i> {{comment.user.canvas_full_name}}
             <span data-ng-if="me.id === comment.user.id">(me)</span>
           </a>
@@ -279,7 +289,7 @@
       </div>
     </div>
   </div>
-  
+
   <!-- COPYRIGHT -->
   <div data-ng-include="'/app/shared/copyright.html'"></div>
 </div>

--- a/public/app/engagementindex/leaderboard/leaderboardController.js
+++ b/public/app/engagementindex/leaderboard/leaderboardController.js
@@ -75,18 +75,12 @@
         });
       }
 
-      courseFactory.getCourse().success(function(course) {
-        // Offer links to user profile if the necessary LTI tool is installed
-        // NOTE: we use 'toolProvider' because other logic hinges on '$scope.course'
-        $scope.toolProvider = course;
-        $scope.dashboardToolInstalled = !!utilService.getGenericDashboardUrl(course);
-        $scope.getUserDashboardUrl = utilService.getUserDashboardUrl;
-
-        // Admins also get course notification settings
-        if ($scope.me.is_admin) {
+      // Admins also get course notification settings
+      if ($scope.me.is_admin) {
+        courseFactory.getCourse().success(function(course) {
           $scope.course = course;
-        }
-      });
+        });
+      }
     };
 
     /**

--- a/public/app/engagementindex/leaderboard/list.html
+++ b/public/app/engagementindex/leaderboard/list.html
@@ -50,8 +50,8 @@
           </div>
           <div class="media-body media-middle">
             <i class="fa fa-graduation-cap" data-ng-if="user.is_admin"></i>
-            <span data-ng-bind="user.canvas_full_name" data-ng-if="!dashboardToolInstalled"></span>
-            <a data-ng-href="{{getUserDashboardUrl(toolProvider, user)}}" target="_parent" data-ng-if="dashboardToolInstalled">
+            <span data-ng-bind="user.canvas_full_name" data-ng-if="!me.course.dashboard_url"></span>
+            <a tool-href data-tool="dashboard" data-course="me.course" data-id="user.id" data-ng-if="me.course.dashboard_url">
               <span data-ng-bind="user.canvas_full_name"></span>
             </a>
           </div>

--- a/public/app/shared/toolHrefDirective.js
+++ b/public/app/shared/toolHrefDirective.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+(function(angular) {
+
+  'use strict';
+
+  /*!
+   * Constructs URLs for linking from one SuiteC LTI tool to another.
+   */
+  angular.module('collabosphere').directive('toolHref', function() {
+    return {
+      // Directive matches on attribute name.
+      // @see https://docs.angularjs.org/guide/directive#template-expanding-directive
+      restrict: 'A',
+
+      // @see https://docs.angularjs.org/guide/directive#isolating-the-scope-of-a-directive
+      scope: {
+        tool: '=',
+        course: '=',
+        id: '='
+      },
+
+      'link': function(scope, elem, attrs) {
+        var getToolUrl = function(course, tool) {
+          switch (tool) {
+            case 'assetlibrary': {
+              return course.assetlibrary_url;
+            }
+            case 'dashboard': {
+              return course.dashboard_url;
+            }
+            case 'engagementindex': {
+              return course.engagementindex_url;
+            }
+            case 'whiteboards': {
+              return course.whiteboards_url;
+            }
+            default: {
+              return '';
+            }
+          }
+        };
+        var queryArgs = scope.id ? '?_id=' + scope.id : '';
+        elem.attr('href', getToolUrl(scope.course, attrs.tool) + queryArgs);
+        elem.attr('target', '_parent');
+      }
+    };
+  });
+
+}(window.angular));

--- a/public/app/shared/utilService.js
+++ b/public/app/shared/utilService.js
@@ -89,29 +89,6 @@
     };
 
     /**
-     * URL of Dashboard tool, if added to the course
-     *
-     * @param  {Object}       course          Course with one or more SuiteC tools
-     * @return {String}                       URL without an appended user id
-     */
-    var getGenericDashboardUrl = function(course) {
-      return course.dashboard_url;
-    };
-
-    /**
-     * If the appropriate LTI tool has been added to the course site then
-     * return URL of profile per user id.
-     *
-     * @param  {Object}       course          Course with one or more SuiteC tools
-     * @param  {Object}       user            Member of course
-     * @return {String}                       URL with necessary query args
-     */
-    var getUserDashboardUrl = function(course, user) {
-      var dashboardUrl = getGenericDashboardUrl(course);
-      return dashboardUrl && user ? dashboardUrl + '?_id=' + user.id : null;
-    };
-
-    /**
      * Adjust the height of the current iFrame to the size of its content.
      * This will only happen when Collabosphere is embedded as an LTI tool in
      * a different application
@@ -348,12 +325,10 @@
 
     return {
       'getApiUrl': getApiUrl,
-      'getGenericDashboardUrl': getGenericDashboardUrl,
       'getLaunchParams': getLaunchParams,
       'getParentUrlData': getParentUrlData,
       'getScrollInformation': getScrollInformation,
       'getToolUrl': getToolUrl,
-      'getUserDashboardUrl': getUserDashboardUrl,
       'resizeIFrame': resizeIFrame,
       'scrollTo': scrollTo,
       'scrollToTop': scrollToTop,

--- a/public/index.html
+++ b/public/index.html
@@ -92,6 +92,7 @@
   <script src="/app/shared/infiniteScrollDirective.js"></script>
   <script src="/app/shared/sanitizeFilter.js"></script>
   <script src="/app/shared/syncDisabledController.js"></script>
+  <script src="/app/shared/toolHrefDirective.js"></script>
   <script src="/app/shared/uniqueFilter.js"></script>
   <script src="/app/shared/userFactory.js"></script>
   <script src="/app/shared/utilService.js"></script>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-737

`crossLtiSupport` (i.e., linking between LTI tools) is now a shared utility. Future cross-LTI actions might include linking to assets from profile page.