### PR TITLE
COL-752 Script to update LTI configurations in Canvas

### DIFF
--- a/node_modules/col-activities/lib/notifications/daily.js
+++ b/node_modules/col-activities/lib/notifications/daily.js
@@ -47,7 +47,7 @@ var collect = module.exports.collect = function(callback) {
   var start = Date.now();
 
   // 1. Get all the active courses
-  CourseAPI.getCourses(function(err, courses) {
+  CourseAPI.getCourses(null, function(err, courses) {
     if (err) {
       return log.error({'err': err}, 'Unable to retrieve the courses when sending notifications');
     }

--- a/node_modules/col-activities/lib/notifications/weekly.js
+++ b/node_modules/col-activities/lib/notifications/weekly.js
@@ -48,7 +48,7 @@ var collect = module.exports.collect = function(callback) {
   var start = Date.now();
 
   // Get all active courses.
-  CourseAPI.getCourses(function(err, courses) {
+  CourseAPI.getCourses(null, function(err, courses) {
     if (err) {
       log.error({'err': err}, 'Unable to retrieve courses for weekly notifications.');
       return callback();

--- a/node_modules/col-canvas/lib/api.js
+++ b/node_modules/col-canvas/lib/api.js
@@ -556,6 +556,259 @@ var getDiscussionEntries = module.exports.getDiscussionEntries = function(course
   return getDataFromCanvas(course.canvas, url, callback);
 };
 
+/* External tools */
+
+/**
+ * Get the external tool configurations for an account
+ *
+ * @param  {Canvas}         canvas                    The Canvas instance to query
+ * @param  {Number}         accountId                 The id of the account
+ * @param  {Function}       callback                  Standard callback function
+ * @param  {Object}         callback.err              An error that occurred, if any
+ * @param  {Object[]}       callback.tools            The external tool configurations for the given account
+ */
+var getExternalToolsForAccount = module.exports.getExternalToolsForAccount = function(canvas, accountId, callback) {
+  log.debug({
+    'account_id': accountId,
+    'canvas_api_domain': canvas.canvas_api_domain
+  }, 'Getting external tool configurations');
+
+  var url = util.format('/api/v1/accounts/%d/external_tools', accountId);
+  return getDataFromCanvas(canvas, url, callback);
+};
+
+/**
+ * Get the external tool configurations for a course
+ *
+ * @param  {Course}         course                    The course for which to get the external tool configurations
+ * @param  {Function}       callback                  Standard callback function
+ * @param  {Object}         callback.err              An error that occurred, if any
+ * @param  {Object[]}       callback.tools            The external tool configurations for the given course
+ */
+var getExternalToolsForCourse = module.exports.getExternalToolsForCourse = function(course, callback) {
+  log.debug({
+    'course': course.id,
+    'canvas_course_id': course.canvas_course_id,
+    'canvas_api_domain': course.canvas_api_domain
+  }, 'Getting external tool configurations');
+
+  var url = util.format('/api/v1/courses/%d/external_tools', course.canvas_course_id);
+  return getDataFromCanvas(course.canvas, url, callback);
+};
+
+/**
+ * Update an external tool in an account context
+ *
+ * @param  {Canvas}         canvas                    The Canvas instance to query
+ * @param  {Number}         accountId                 The Canvas id of the account under which the tool is configured
+ * @param  {Number}         toolId                    The Canvas id of the tool
+ * @param  {String}         toolName                  The name of the tool
+ * @param  {String}         appBaseURI                The base URI for the SuiteC app that will provide the configuration
+ * @param  {Function}       callback                  Standard callback function
+ * @param  {Object}         callback.err              An error that occurred, if any
+ * @param  {Object[]}       callback.discussions      The external tool configurations for the given course
+ */
+var updateExternalToolForAccount = module.exports.updateExternalToolForAccount = function(canvas, accountId, toolId, toolName, appBaseURI, callback) {
+  var requestUrl = util.format('%s/api/v1/accounts/%d/external_tools/%d', getCanvasBaseURI(canvas), accountId, toolId);
+  var configUrl = util.format('%s/lti/%s.xml', appBaseURI, toolName);
+  var opts = {
+    'url': requestUrl,
+    'method': 'PUT',
+    'headers': {
+      'Authorization': util.format('Bearer %s', canvas.api_key)
+    },
+    'form': {
+      'config_type': 'by_url',
+      'config_url': configUrl,
+      'consumer_key': canvas.lti_key,
+      'shared_secret': canvas.lti_secret
+    }
+  };
+
+  log.debug({
+    'account': accountId,
+    'canvas_api_domain': canvas.canvas_api_domain,
+    'toolId': toolId,
+    'toolName': toolName
+  }, 'Updating external tool configurations');
+
+  request(opts, function(err, response, body) {
+    if (err || response.statusCode !== 200) {
+      log.error({
+        'err': err,
+        'canvas': canvas.canvas_api_domain,
+        'statusCode': response.statusCode,
+        'account': accountId
+      }, 'Failed to update external tools for account');
+      return callback({'code': 500, 'msg': 'Failed to update external tools for account'});
+    }
+
+    var data = null;
+    try {
+      data = JSON.parse(body);
+    } catch (parseErr) {
+      log.error({'err': parseErr, 'account': accountId, 'canvas': canvas.canvas_api_domain}, 'Failed to parse external tool update for account');
+      return callback({'code': 500, 'msg': 'Failed to parse external tool update for account'});
+    }
+
+    return callback(null, data);
+  });
+};
+
+/**
+ * Update an external tool in a course context
+ *
+ * @param  {Course}         course                    The course under which the tool is configured
+ * @param  {Number}         toolId                    The Canvas id of the tool
+ * @param  {String}         toolName                  The name of the tool
+ * @param  {String}         appBaseURI                The base URI for the SuiteC app that will provide the configuration
+ * @param  {Function}       callback                  Standard callback function
+ * @param  {Object}         callback.err              An error that occurred, if any
+ * @param  {Object[]}       callback.discussions      The external tool configurations for the given course
+ */
+var updateExternalToolForCourse = module.exports.updateExternalToolForCourse = function(course, toolId, toolName, appBaseURI, callback) {
+  var requestUrl = util.format('%s/api/v1/courses/%d/external_tools/%d', getCanvasBaseURI(course.canvas), course.canvas_course_id, toolId);
+  var configUrl = util.format('%s/lti/%s.xml', appBaseURI, toolName);
+  var opts = {
+    'url': requestUrl,
+    'method': 'PUT',
+    'headers': {
+      'Authorization': util.format('Bearer %s', course.canvas.api_key)
+    },
+    'form': {
+      'config_type': 'by_url',
+      'config_url': configUrl,
+      'consumer_key': course.canvas.lti_key,
+      'shared_secret': course.canvas.lti_secret
+    }
+  };
+
+  log.debug({
+    'course': course.id,
+    'canvas_api_domain': course.canvas_api_domain,
+    'toolId': toolId,
+    'toolName': toolName
+  }, 'Updating external tool configurations');
+
+  request(opts, function(err, response, body) {
+    if (err || response.statusCode !== 200) {
+      log.error({
+        'err': err,
+        'canvas': course.canvas_api_domain,
+        'statusCode': response.statusCode,
+        'course': course.id
+      }, 'Failed to update external tools for course');
+      return callback({'code': 500, 'msg': 'Failed to update external tools for course'});
+    }
+
+    var data = null;
+    try {
+      data = JSON.parse(body);
+    } catch (parseErr) {
+      log.error({'err': parseErr, 'course': course.id, 'canvas': course.canvas_api_domain}, 'Failed to parse external tool update for course');
+      return callback({'code': 500, 'msg': 'Failed to parse external tool update for course'});
+    }
+
+    return callback(null, data);
+  });
+};
+
+/* Courses and accounts */
+
+/**
+ * Get properties of a Canvas account
+ *
+ * @param  {Canvas}         canvas                      The Canvas instance to query
+ * @param  {Number}         accountId                   The id of the account
+ * @param  {Function}       callback                    Standard callback function
+ * @param  {Object}         callback.err                An error that occurred, if any
+ * @param  {Object}         callback.accountProperties  Account properties 
+ */
+var getAccountProperties = module.exports.getAccountProperties = function(canvas, accountId, callback) {
+  log.debug({
+    'account': accountId,
+    'canvas_api_domain': canvas.canvas_api_domain
+  }, 'Getting Canvas account properties');
+
+  var url = util.format('%s/api/v1/accounts/%d', getCanvasBaseURI(canvas), accountId);
+  var requestOpts = {
+    'url': url,
+    'method': 'GET',
+    'headers': {
+      'Authorization': util.format('Bearer %s', canvas.api_key)
+    }
+  };
+
+  request(requestOpts, function(err, response, body) {
+    if (err || response.statusCode !== 200) {
+      log.error({
+        'err': err,
+        'canvas': canvas.canvas_api_domain,
+        'statusCode': response.statusCode,
+        'account': accountId
+      }, 'Failed to get Canvas account properties');
+      return callback({'code': 500, 'msg': 'Failed to get Canvas account properties'});
+    }
+
+    var data = null;
+    try {
+      data = JSON.parse(body);
+    } catch (parseErr) {
+      log.error({'err': parseErr, 'account': accountId, 'canvas': canvas.canvas_api_domain}, 'Failed to parse Canvas account properties');
+      return callback({'code': 500, 'msg': 'Failed to parse Canvas account properties'});
+    }
+
+    return callback(null, data);
+  });
+};
+
+/**
+ * Get properties of a Canvas course
+ *
+ * @param  {Course}         course                      The course for which to get properties
+ * @param  {Function}       callback                    Standard callback function
+ * @param  {Object}         callback.err                An error that occurred, if any
+ * @param  {Object}         callback.courseProperties   Course properties 
+ */
+var getCourseProperties = module.exports.getCourseProperties = function(course, callback) {
+  log.debug({
+    'course': course.id,
+    'canvas_course_id': course.canvas_course_id,
+    'canvas_api_domain': course.canvas_api_domain
+  }, 'Getting Canvas course properties');
+
+  var url = util.format('%s/api/v1/courses/%d', getCanvasBaseURI(course.canvas), course.canvas_course_id);
+  var requestOpts = {
+    'url': url,
+    'method': 'GET',
+    'headers': {
+      'Authorization': util.format('Bearer %s', course.canvas.api_key)
+    }
+  };
+
+  request(requestOpts, function(err, response, body) {
+    if (err || response.statusCode !== 200) {
+      log.error({
+        'err': err,
+        'canvas': canvas.canvas_api_domain,
+        'statusCode': response.statusCode,
+        'course': ctx.course.id
+      }, 'Failed to get Canvas course properties');
+      return callback({'code': 500, 'msg': 'Failed to get Canvas course properties'});
+    }
+
+    var data = null;
+    try {
+      data = JSON.parse(body);
+    } catch (parseErr) {
+      log.error({'err': parseErr, 'course': course.id, 'canvas': canvas.canvas_api_domain}, 'Failed to parse Canvas course properties');
+      return callback({'code': 500, 'msg': 'Failed to parse Canvas course properties'});
+    }
+
+    return callback(null, data);
+  });
+};
+
 /* Utilities */
 
 /**

--- a/node_modules/col-canvas/lib/poller.js
+++ b/node_modules/col-canvas/lib/poller.js
@@ -114,7 +114,7 @@ var runOnce = module.exports.runOnce = function(callback) {
   var start = Date.now();
 
   // Get all the active courses that need to be polled
-  CourseAPI.getCourses(function(err, courses) {
+  CourseAPI.getCourses(null, function(err, courses) {
     if (err) {
       log.error({'err': err}, 'Failed to get all the courses, aborting poller');
       return callback(err);

--- a/node_modules/col-course/lib/api.js
+++ b/node_modules/col-course/lib/api.js
@@ -345,18 +345,19 @@ var deactivateCourse = module.exports.deactivateCourse = function(courseId, call
 };
 
 /**
- * Get all the courses from the database
+ * Get a group of courses
  *
+ * @param  {Object}     [filters]               Query filters. Defualts to all active courses.
  * @param  {Function}   callback                Standard callback function
  * @param  {Object}     callback.err            An error that occurred, if any
  * @param  {Course[]}   callback.courses        The courses in the database. The associated `Canvas` object will be retrieved as well
  */
-var getCourses = module.exports.getCourses = function(callback) {
-  var where = {
+var getCourses = module.exports.getCourses = function(filters, callback) {
+  var filters = filters || {
     'active': true
   };
   var options = {
-    'where': where,
+    'where': filters,
     'include': [{
       'model': DB.Canvas,
       'as': 'canvas'

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "socket.io": "1.7.2",
     "validator": "6.2.1",
     "xml2js": "0.4.17",
-    "yargs": "6.6.0"
+    "yargs": "7.0.2"
   },
   "bundledDependencies": [
     "col-activities",

--- a/scripts/20170117-col629/rename_and_hide_suitec_folders.js
+++ b/scripts/20170117-col629/rename_and_hide_suitec_folders.js
@@ -57,7 +57,7 @@ var init = function() {
 
 var updateFolders = function() {
   // Get all active courses.
-  CourseAPI.getCourses(function(err, courses) {
+  CourseAPI.getCourses(null, function(err, courses) {
     if (err) {
       log.error({'err': err}, 'Failed to get courses');
       return callback(err);

--- a/scripts/update_lti.js
+++ b/scripts/update_lti.js
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+var yargs = require('yargs');
+var argv = yargs
+    .usage('Usage: $0 --canvas [canvas] --suitec [suitec]')
+    .demand(['canvas', 'suitec'])
+    .describe('canvas', 'Canvas API domain on which tools should be reset')
+    .describe('suitec', 'Base URL for the SuiteC instance to which tools should be pointed')
+    .example('$0 --canvas bcourses.berkeley.edu --suitec https://app.ets-berkeley-suitec.net')
+    .wrap(100)
+    .argv;
+
+var _ = require('lodash');
+var async = require('async');
+
+var DB = require('col-core/lib/db');
+var log = require('col-core/lib/logger')('scripts/reset_lti');
+var CanvasAPI = require('col-canvas');
+var CourseAPI = require('col-course');
+
+// Keep track of results.
+var results = {
+  'success': [],
+  'notfound': [],
+  'error': []
+};
+
+// Keep track of the number of courses to display progress.
+var courseCount = null;
+
+/**
+ * Connect to the database and kick off.
+ */
+var init = function() {
+  require('col-core/lib/globals');
+
+  DB.init(function(err) {
+    if (err) {
+      return log.error({'err': err}, 'Unable to establish a database connection');
+    }
+
+    log.info('Connected to the database');
+
+    CourseAPI.getCourses({'canvas_api_domain': argv.canvas}, function(err, courses) {
+      if (err) {
+        log.error({'err': err}, 'Unable to retrieve courses for LTI reset');
+        return callback();
+      }
+
+      courseCount = courses.length;
+
+      async.eachOfSeries(courses, updateToolsForCourse, function() {
+        log.info('Finished. ' + results.success.length + ' tools were successfully updated.');
+        if (results.notfound.length) {
+          log.info({'Not found': results.notfound}, + results.notfound.length + ' tools were not found.');
+        }
+        if (results.error.length) {
+          log.info({'Errors': results.error}, + results.error.length + ' tools had errors.');
+        }
+
+        DB.getSequelize().close();
+      });
+    });
+  });
+};
+
+/**
+ * Update SuiteC tools associated with a Canvas course.
+ *
+ * @param  {Course}           course              The course to update
+ * @param  {Number}           index               Index in the list of courses, used to show progress
+ * @param  {Function}         callback            Standard callback function
+ */
+var updateToolsForCourse = function(course, index, callback) {
+  log.info({'course': course.id}, 'Updating course ' + (index + 1) + ' of ' + courseCount);
+
+  // Get active tools in the course which we haven't yet tried to process.
+  var toolsToUpdate = getTools(course);
+  if (_.isEmpty(toolsToUpdate)) {
+    return callback();
+  }
+
+  CanvasAPI.getExternalToolsForCourse(course, function(err, courseTools) {
+    if (err) {
+      log.error({'err': err, 'course': course.id}, 'Failed to get external tool configurations for course');
+      results.error = results.error.concat(toolsToUpdate);
+      return callback();
+    }
+
+    async.eachOfSeries(toolsToUpdate, function(tool, index, done) {
+      // If the tool doesn't show under the course, it may be configured under a higher-level account. Move on to
+      // the next tool.
+      if (!_.find(courseTools, {'id': tool.id})) {
+        return done();
+      }
+
+      // If we've found the tool configuration, attempt to update.
+      CanvasAPI.updateExternalToolForCourse(course, tool.id, tool.name, argv.suitec, function(err, data) {
+        if (err) {
+          log.error({'err': err, 'course': course.id, 'tool': tool}, 'Failed to update tool');
+          results.error.push(tool);
+        } else {
+          log.info({'tool': tool, 'course': course.id}, 'Updated tool at the course level');
+          results.success.push(tool);
+        }
+
+        // Whether we've succeeded or errored, we shouldn't try this tool again. Null out the array at this index.
+        toolsToUpdate[index] = null;
+        return done();
+      });
+
+    }, function() {
+      // Remove elements that were nulled out during iteration.
+      toolsToUpdate = _.compact(toolsToUpdate);
+      if (_.isEmpty(toolsToUpdate)) {
+        return callback();
+      }
+
+      // If we still have tools to update, get the parent account ID and look for configurations there.
+      CanvasAPI.getCourseProperties(course, function(err, courseProperties) {
+        if (err) {
+          log.error({'err': err, 'course': course.id}, 'Failed to get course properties');
+          results.error = results.error.concat(toolsToUpdate);
+          return callback();
+        }
+        if (!courseProperties.account_id) {
+          // If we can't find a parent account ID, mark the remaining tools as not found.
+          results.notfound = results.notfound.concat(toolsToUpdate);
+          return callback();
+        }
+
+        return updateToolsForAccount(course.canvas, courseProperties.account_id, toolsToUpdate, callback);
+      });
+    });
+  });
+};
+
+/**
+ * Update SuiteC tools associated with a Canvas account.
+ *
+ * @param  {Canvas}           canvas              The Canvas object to update
+ * @param  {Number}           accountId           The id of the account to update
+ * @param  {Object[]}         toolsToUpdate       Tools to be updated 
+ * @param  {Function}         callback            Standard callback function
+ */
+var updateToolsForAccount = function(canvas, accountId, toolsToUpdate, callback) {
+  CanvasAPI.getExternalToolsForAccount(canvas, accountId, function(err, accountTools) {
+    if (err) {
+      log.error({'err': err, 'accountId': accountId}, 'Failed to get external tool configurations');
+      results.error = results.error.concat(toolsToUpdate);
+      return callback();
+    }
+
+    async.eachOfSeries(toolsToUpdate, function(tool, index, done) {
+      // If the tool doesn't show under this account, it may be configured under a higher-level account. Move on to
+      // the next tool.
+      if (!_.find(accountTools, {'id': tool.id})) {
+        return done();
+      }
+
+      // If we've found the tool configuration, attempt to update.
+      CanvasAPI.updateExternalToolForAccount(canvas, accountId, tool.id, tool.name, argv.suitec, function(err, data) {
+        if (err) {
+          log.error({'err': err, 'account': accountId, 'tool': tool}, 'Failed to update tool');
+          results.error.push(tool);
+        } else {
+          log.info({'tool': tool, 'account': accountId}, 'Updated tool at the account level');
+          results.success.push(tool);
+        }
+
+        // Whether we've succeeded or errored, we shouldn't try this tool again. Null out the array at this index.
+        toolsToUpdate[index] = null;
+        return done();
+      });
+
+    }, function() {
+      // Remove elements that were nulled out during iteration.
+      toolsToUpdate = _.compact(toolsToUpdate);
+      if (_.isEmpty(toolsToUpdate)) {
+        return callback();
+      }
+
+      // If we still have tools to update, get the parent account ID and look for configurations there.
+      CanvasAPI.getAccountProperties(canvas, accountId, function(err, accountProperties) {
+        if (err) {
+          log.error({'err': err, 'account': accountId}, 'Failed to get account properties');
+          results.error = results.error.concat(toolsToUpdate);
+          return callback();
+        }
+        if (!accountProperties.parent_account_id) {
+          // If we can't find a parent account ID, mark the remaining tools as not found.
+          results.notfound = results.notfound.concat(toolsToUpdate);
+          return callback();
+        }
+
+        return updateToolsForAccount(canvas, accountProperties.parent_account_id, toolsToUpdate, callback);
+      });
+    });
+  });
+};
+
+/**
+ * Get configuration info for the SuiteC tools in a given course.
+ *
+ * @param  {Course}           course              The course for which to return information
+ * @return {Object[]}         callback            Configuration information for tools
+ */
+var getTools = function(course) {
+  var tools = [];
+  _.each(['assetlibrary', 'dashboard', 'engagementindex', 'whiteboards'], function(toolName) {
+
+    // Attempt to parse out Canvas tool ids from the URL values in the database.
+    var toolId;
+    if ((toolId = course[toolName + '_url']) && (toolId = toolId.match(/\d+$/)) && (toolId = Number(toolId[0]))) {
+      var toolProperties = {
+        'id': toolId,
+        'name': toolName
+      };
+
+      // If another course has already updated or errored on this tool configuration, don't retry.
+      if (!_.find(results.success, toolProperties) && !_.find(results.error, toolProperties)) {
+        tools.push(_.assign(toolProperties, {'courseId': course.id}));
+      }
+    }
+  });
+  return tools;
+};
+
+init();


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-752

This repointing script is more complex than its Junction cousin since we're dealing with multiple Canvases and can't provide account IDs as a configuration option. To figure out where a given tool is configured, we may need to iterate up through parent accounts.