### PR TITLE
NOJIRA, fix package.json syntax with awkward license reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,7 @@
   "bugs": {
     "url": "https://jira.ets.berkeley.edu/jira/browse/COL"
   },
-  "licenses": [
-    {
-      "type": "UC Berkeley",
-      "url": "http://ipira.berkeley.edu/software-copyright-notice-and-disclaimer"
-    }
-  ],
+  "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "async": "2.1.4",
     "body-parser": "1.16.0",


### PR DESCRIPTION
See https://docs.npmjs.com/files/package.json#license

Stop the "license" complaining in `eb-master` builds. 