### PR TITLE
COL-769, when 'My Assets' is empty on profile then offer Upload / Add Link asset

### DIFF
--- a/public/app/assetlibrary/addbookmarklet/addbookmarklet.html
+++ b/public/app/assetlibrary/addbookmarklet/addbookmarklet.html
@@ -1,4 +1,4 @@
-<a data-ng-href="/assetlibrary" class="col-back"><i class="fa fa-angle-left"></i> Back to Asset Library</a>
+<div data-ng-include="'/app/assetlibrary/backtoreferrer.html'"></div>
 
 <div class="text-center">
   <div id="assetlibrary-addbookmarklet-container" class="text-left">

--- a/public/app/assetlibrary/addlinkcontainer/addlinkcontainer.html
+++ b/public/app/assetlibrary/addlinkcontainer/addlinkcontainer.html
@@ -1,3 +1,3 @@
-<a data-ng-href="/assetlibrary" class="col-back"><i class="fa fa-angle-left"></i> Back to Asset Library</a>
+<div data-ng-include="'/app/assetlibrary/backtoreferrer.html'"></div>
 
 <div class="assetlibrary-addlinkcontainer" data-ng-include="'/app/assetlibrary/addlink/addlink.html'"></div>

--- a/public/app/assetlibrary/assetLibraryService.js
+++ b/public/app/assetlibrary/assetLibraryService.js
@@ -29,14 +29,19 @@
 
   angular.module('collabosphere').service('assetLibraryService', function(analyticsService, deepLinkId, utilService, $state) {
 
-    var assetViewRedirect = function(assetId) {
-      // Track the asset deep link
-      analyticsService.track('Deep link asset', {
-        'asset_id': assetId,
-        'referer': document.referrer
-      });
+    var assetViewRedirect = function(id) {
+      if (id.match(/^assetlibrary/)) {
+        // Pattern match identifies id as a "router state name" (see app.states.js)
+        $state.go(id);
+      } else {
+        // Track the asset deep link
+        analyticsService.track('Deep link asset', {
+          'asset_id': id,
+          'referer': document.referrer
+        });
 
-      $state.go('assetlibrarylist.item', {'assetId': assetId});
+        $state.go('assetlibrarylist.item', {'assetId': id});
+      }
     };
 
     if (deepLinkId) {

--- a/public/app/assetlibrary/backToReferrerController.js
+++ b/public/app/assetlibrary/backToReferrerController.js
@@ -23,69 +23,29 @@
  * ENHANCEMENTS, OR MODIFICATIONS.
  */
 
-.dashboard-splash-container {
-  margin-bottom: 30px;
-}
+(function(angular) {
 
-.myactivity-container {
-  display: flex;
-}
+  'use strict';
 
-.myactivity-column {
-  border-radius: 4px;
-  border: 1px solid lightgrey;
-  margin: 5px;
-  padding: 10px 10px 10px 10px;
-}
+  angular.module('collabosphere').controller('BackToReferrerController', function(me, referringId, referringTool, $scope) {
 
-.myactivity-profile-column {
-  display: inline-block;
-  padding-right: 20px;
-  vertical-align: top;
-}
+    // Make the me object available to the scope
+    $scope.me = me;
 
-.myactivity-profile-avatar {
-  border-radius: 50%;
-  width: 100px;
-}
+    /**
+     * Bundle the properties forwarded by toolHrefDirective. This allows user to link between LTI tools.
+     */
+    var bundle = function() {
+      if (referringTool) {
+        $scope.referringTool = {
+          'id': referringId,
+          'name': referringTool
+        };
+      }
+    };
 
-.myactivity-profile-column h2 {
-  margin-bottom: 0;
-}
+    bundle();
 
-.myactivity-profile-column div {
-  border-top: 1px solid lightgrey;
-  margin-top: 5px;
-}
+  });
 
-.myactivity-profile-column img {
-  padding: 10px 10px 10px 10px;
-  vertical-align: bottom;
-}
-
-.myactivity-mock-img {
-  height: 144px;
-}
-
-.activity-timeline {
-  margin-bottom: 75px;
-  width: 570px;
-}
-
-.activity-timeline-label {
-  font-size: 13px;
-  font-weight: 300;
-}
-
-.featured-assets-container {
-  margin-bottom: 30px;
-}
-
-.featured-list-name {
-  font-weight: bolder;
-}
-
-.featured-list-filters {
-  display: inline-block;
-  white-space: nowrap;
-}
+}(window.angular));

--- a/public/app/assetlibrary/backtoreferrer.html
+++ b/public/app/assetlibrary/backtoreferrer.html
@@ -1,0 +1,5 @@
+<div data-ng-controller="BackToReferrerController">
+  <a data-ng-href="/assetlibrary" class="col-back" data-ng-if="!referringTool"><i class="fa fa-angle-left"></i> Back to Asset Library</a>
+
+  <a tool-href data-tool="dashboard" data-course="me.course" data-id="referringTool.id" class="col-back" data-ng-if="referringTool.name === 'dashboard'"><i class="fa fa-angle-left"></i> Back to Dashboard</a>
+</div>

--- a/public/app/assetlibrary/item/assetLibraryItemController.js
+++ b/public/app/assetlibrary/item/assetLibraryItemController.js
@@ -38,12 +38,6 @@
     // Variable that will keep track of whether the user has come in via a whiteboard
     $scope.whiteboardReferral = $stateParams.whiteboard_referral;
 
-    // Variable set by directive which enables linking across tools.
-    $scope.referringTool = referringTool;
-
-    // Variable describes state of the referring tool. E.g., Dashboard tool per user id.
-    $scope.referringId = referringId;
-
     // Variable that will keep track of the current asset
     $scope.asset = null;
 
@@ -364,6 +358,18 @@
     };
 
     /**
+     * Bundle the properties forwarded by toolHrefDirective. This allows user to link between LTI tools.
+     */
+    var getReferringTool = function() {
+      if (referringTool) {
+        $scope.referringTool = {
+          'id': referringId,
+          'name': referringTool
+        };
+      }
+    };
+
+    /**
      * Close the current browser window. This is used when an asset has been opened
      * in a separate tab and the user wants to be taken back to where the asset was
      * launched from
@@ -400,6 +406,8 @@
 
     // Load the selected asset
     getCurrentAsset();
+    // If referringTool is not null then offer user a link to go back.
+    getReferringTool();
     // Scroll to the top of the page as the current scroll position could be somewhere
     // deep in the asset library list
     utilService.scrollToTop();

--- a/public/app/assetlibrary/item/item.html
+++ b/public/app/assetlibrary/item/item.html
@@ -1,7 +1,7 @@
 <div data-ng-show="state.current.name === 'assetlibrarylist.item'">
   <a ui-sref="assetlibrarylist($parent.searchOptions)" class="col-back" data-ng-click="backToAssetLibrary()" data-ng-if="!whiteboardReferral && !referringTool"><i class="fa fa-angle-left"></i> Back to Asset Library</a>
 
-  <a tool-href data-tool="dashboard" data-course="me.course" data-id="referringId" class="col-back" data-ng-if="referringTool === 'dashboard'"><i class="fa fa-angle-left"></i> Back to Dashboard</a>
+  <a tool-href data-tool="dashboard" data-course="me.course" data-id="referringTool.id" class="col-back" data-ng-if="referringTool.name === 'dashboard'"><i class="fa fa-angle-left"></i> Back to Dashboard</a>
 
   <button type="button" class="btn btn-link col-back" data-ng-if="whiteboardReferral" data-ng-click="closeWindow()"><i class="fa fa-angle-left"></i> Back to whiteboard</button>
 

--- a/public/app/assetlibrary/uploadcontainer/uploadcontainer.html
+++ b/public/app/assetlibrary/uploadcontainer/uploadcontainer.html
@@ -1,3 +1,3 @@
-<a data-ng-href="/assetlibrary" class="col-back"><i class="fa fa-angle-left"></i> Back to Asset Library</a>
+<div data-ng-include="'/app/assetlibrary/backtoreferrer.html'"></div>
 
 <div class="assetlibrary-uploadcontainer" data-ng-include="'/app/assetlibrary/upload/upload.html'"></div>

--- a/public/app/dashboard/splash.html
+++ b/public/app/dashboard/splash.html
@@ -16,20 +16,49 @@
          data-labels-width="200"></div>
   </div>
 
-  <div class="featured-assets-container" data-ng-if="featuredAssets.length">
+  <div class="featured-assets-container" data-ng-if="isMyProfile || featuredAssets.length">
     <h3>
-      <span class="featured-list-name" data-ng-bind="isMyProfile ? 'My Assets:' : 'Assets:'"></span>
-      <a data-ng-click="sortFeaturedAssets('recent')" data-ng-if="sortAssetsBy !== 'recent'">Recent</a>
-      <span data-ng-if="sortAssetsBy === 'recent'">Recent</span>
-      |
-      <a data-ng-click="sortFeaturedAssets('likes')" data-ng-if="sortAssetsBy !== 'likes'">Most Impactful</a>
-      <span data-ng-if="sortAssetsBy === 'likes'">Most Impactful</span>
+      <span class="featured-list-name" data-ng-bind="isMyProfile ? 'My Assets' : 'Assets'"></span>
+      <div class="featured-list-filters" data-ng-if="featuredAssets.length">
+        :
+        <a data-ng-click="sortFeaturedAssets('recent')" data-ng-if="sortAssetsBy !== 'recent'">Recent</a>
+        <span data-ng-if="sortAssetsBy === 'recent'">Recent</span>
+        |
+        <a data-ng-click="sortFeaturedAssets('likes')" data-ng-if="sortAssetsBy !== 'likes'">Most Impactful</a>
+        <span data-ng-if="sortAssetsBy === 'likes'">Most Impactful</span>
+      </div>
     </h3>
 
     <div class="col-list-container">
       <ul>
+        <!-- UPLOAD / ADD LINK -->
+        <li class="list-inline col-xs-6 col-sm-4 col-md-3" data-ng-if="isMyProfile && !featuredAssets.length">
+          <div class="col-list-item-container col-list-add-tile">
+            <div class="col-list-item-tile">
+              <div class="assetlibrary-list-item-add-container">
+                <div class="assetlibrary-list-item-add-table">
+                  <a tool-href data-tool="assetlibrary" data-referring-tool="dashboard" data-referring-id='user.id' data-course="me.course" data-id="routerStateUploadAsset" class="text-center col-pane">
+                    <i class="fa fa-laptop"></i>
+                    <div class="assetlibrary-list-item-add-action">Upload</div>
+                  </a>
+                  <a tool-href data-tool="assetlibrary" data-referring-tool="dashboard" data-referring-id='user.id' data-course="me.course" data-id="routerStateAddLink" class="text-center col-pane">
+                    <i class="fa fa-link"></i>
+                    <div class="assetlibrary-list-item-add-action">Add Link</div>
+                  </a>
+                </div>
+              </div>
+            </div>
+            <div class="col-list-item-actions">
+              <a tool-href data-tool="assetlibrary" data-referring-tool="dashboard" data-referring-id='user.id' data-course="me.course" data-id="routerStateBookmarkletInfo" class="text-center col-pane">
+                Add assets more easily
+                <i class="fa fa-bookmark pull-left"></i>
+              </a>
+            </div>
+          </div>
+        </li>
+
         <li class="assetlibrary-list-item list-inline col-xs-6 col-sm-4 col-md-3" data-ng-repeat="asset in featuredAssets">
-        <a tool-href data-tool="assetlibrary" data-referring-tool="dashboard" data-referring-id='user.id' data-course="me.course" data-id="asset.id" data-ng-if="me.course.assetlibrary_url">
+        <a tool-href data-tool="assetlibrary" data-referring-tool="dashboard" data-referring-id='user.id' data-course="me.course" data-id="asset.id">
             <div class="col-list-item-container">
               <div class="col-list-item-tile">
                 <img class="img-responsive" data-ng-src="{{asset.thumbnail_url}}" data-ng-if="asset.thumbnail_url">

--- a/public/app/dashboard/splashController.js
+++ b/public/app/dashboard/splashController.js
@@ -29,27 +29,31 @@
 
   angular.module('collabosphere').controller('SplashController', function(assetLibraryFactory, dashboardFactory, deepLinkId, me, userFactory, $scope) {
 
-    // Make the me object available to the scope
+    // Value of 'id' in toolUrlDirective can be router-state, asset id, etc.
+    $scope.routerStateAddLink = 'assetlibraryaddlink';
+    $scope.routerStateBookmarkletInfo = 'assetlibraryaddbookmarklet';
+    $scope.routerStateUploadAsset = 'assetlibraryupload';
+
     $scope.me = me;
     $scope.sortAssetsBy = 'recent';
 
     var getUserActivity = function(userId) {
       dashboardFactory.getActivitiesForUser(userId).success(function(activities) {
         $scope.userActivity = {
-          "Added an asset": activities.add_asset,
-          "Liked an asset": activities.like,
-          "Viewed an asset": activities.view_asset,
-          "Commented on an asset": activities.asset_comment,
-          "Added an asset to a whiteboard": activities.whiteboard_add_asset,
-          "Exported a whiteboard": activities.export_whiteboard
+          'Added an asset': activities.add_asset,
+          'Liked an asset': activities.like,
+          'Viewed an asset': activities.view_asset,
+          'Commented on an asset': activities.asset_comment,
+          'Added an asset to a whiteboard': activities.whiteboard_add_asset,
+          'Exported a whiteboard': activities.export_whiteboard
         };
 
         $scope.userAssetActivity = {
-          "Viewed my assets": activities.get_view_asset,
-          "Liked my assets": activities.get_like,
-          "Commented on my assets": activities.get_asset_comment,
-          "Replied to my comments": activities.get_asset_comment_reply,
-          "Added my assets to a whiteboard": activities.get_whiteboard_add_asset
+          'Viewed my assets': activities.get_view_asset,
+          'Liked my assets': activities.get_like,
+          'Commented on my assets': activities.get_asset_comment,
+          'Replied to my comments': activities.get_asset_comment_reply,
+          'Added my assets to a whiteboard': activities.get_whiteboard_add_asset
         };
       });
     };

--- a/public/app/shared/toolHrefDirective.js
+++ b/public/app/shared/toolHrefDirective.js
@@ -65,6 +65,7 @@
             }
           }
         };
+        // Note: Value of '_id' arg can be router-state, asset id, etc.
         var queryArgs = scope.id ? '?_id=' + scope.id : '';
         if (attrs.referringTool) {
           queryArgs = queryArgs ? queryArgs + '&' : '?';

--- a/public/app/whiteboards/create/create.html
+++ b/public/app/whiteboards/create/create.html
@@ -35,3 +35,5 @@
     </div>
   </div>
 </form>
+
+<div data-ng-include="'/app/shared/copyright.html'"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -103,6 +103,7 @@
   <script src="/app/assetlibrary/addlink/assetLibraryAddLinkController.js"></script>
   <script src="/app/assetlibrary/addlink/httpPrefixDirective.js"></script>
   <script src="/app/assetlibrary/addlinkcontainer/assetLibraryAddLinkContainerController.js"></script>
+  <script src="/app/assetlibrary/backToReferrerController.js"></script>
   <script src="/app/assetlibrary/edit/assetLibraryEditController.js"></script>
   <script src="/app/assetlibrary/iconbar/assetLibraryIconBarController.js"></script>
   <script src="/app/assetlibrary/iconbar/AssetLibraryIconBarDirective.js"></script>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-769

UX Jira: https://jira.ets.berkeley.edu/jira/browse/COL-763

User on profile page, with no assets, can click to upload a new asset or learn more about bookmarklet. For these target pages to have "Back to Dashboard" we must extend the cross-tool-href paradigm by allowing `id` to carry a router-state name, as seen in `app.states.js`.