### PR TITLE
COL-772 Revert to eventdrops-compatible d3 version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "angular-strap": "2.3.10",
     "angular-ui-router": "0.2.18",
     "bootstrap": "3.3.7",
-    "d3": "4.2.8",
+    "d3": "3.5.17",
     "event-drops": "marmelab/eventDrops#08210231b851854ae3526e54ebfe04fc0b0f1092",
     "fontawesome": "4.4.0",
     "highcharts-release": "4.1.10",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-772

Bower cache struck again, misleading me as to what major version of d3 I was using.