### PR TITLE
NOJIRA Fix to LTI repointing script

### DIFF
--- a/scripts/update_lti.js
+++ b/scripts/update_lti.js
@@ -236,7 +236,7 @@ var getTools = function(course) {
 
     // Attempt to parse out Canvas tool ids from the URL values in the database.
     var toolId;
-    if ((toolId = course[toolName + '_url']) && (toolId = toolId.match(/\d+$/)) && (toolId = Number(toolId[0]))) {
+    if ((toolId = course[toolName + '_url']) && (toolId = toolId.match(/external_tools\/(\d+)/)) && (toolId = Number(toolId[1]))) {
       var toolProperties = {
         'id': toolId,
         'name': toolName


### PR DESCRIPTION
A small but important fix to ensure the LTI script is grabbing a real tool ID instead of a surprising number from a surprising URL.