### PR TITLE
COL-816, organize referringTool props prior to 'back to results' feature

### DIFF
--- a/public/app/app.bootstrap.js
+++ b/public/app/app.bootstrap.js
@@ -64,7 +64,7 @@
     var m = queryArgs.match(/.*[\?&]_id=([0-9a-zA-Z]+).*/);
     // '_id' might otherwise carry hashtag for search
     m = m || queryArgs.match(/.*[\?&]_id=(%23\w*[a-zA-Z_\-\.]+\w*)/);
-    parameters.deep_link_id = (m && m.length > 0) ? decodeURIComponent(m[1]) : null;
+    parameters.requested_id = (m && m.length > 0) ? decodeURIComponent(m[1]) : null;
 
     // '_referring_tool' (optional) is origin of the href.
     var tool = queryArgs.match(/.*[\?&]_referring_tool=([a-z]+).*/);
@@ -99,9 +99,17 @@
     }).then(function(results) {
       collabosphere.constant('me', results.me.data);
       collabosphere.constant('config', results.config.data);
-      collabosphere.constant('deepLinkId', parameters.deep_link_id);
-      collabosphere.constant('referringTool', parameters.referring_tool);
-      collabosphere.constant('referringId', parameters.referring_id);
+
+      // Bundle info on referring tool
+      if (parameters.referring_tool) {
+        collabosphere.constant('referringTool', {
+          name: parameters.referring_tool,
+          referringId: parameters.referring_id,
+          requestedId: parameters.requested_id
+        });
+      } else {
+        collabosphere.constant('referringTool', null);
+      }
     });
   };
 

--- a/public/app/assetlibrary/assetLibraryService.js
+++ b/public/app/assetlibrary/assetLibraryService.js
@@ -27,7 +27,7 @@
 
   'use strict';
 
-  angular.module('collabosphere').service('assetLibraryService', function(analyticsService, deepLinkId, utilService, $state) {
+  angular.module('collabosphere').service('assetLibraryService', function(analyticsService, referringTool, utilService, $state) {
 
     var assetViewRedirect = function(id) {
       var hashtag = id.match(/^#(.*)/);
@@ -50,9 +50,9 @@
       }
     };
 
-    if (deepLinkId) {
+    if (referringTool && referringTool.requestedId) {
       // Link to asset from tools other than assetlibrary (eg, user profile)
-      assetViewRedirect(deepLinkId);
+      assetViewRedirect(referringTool.requestedId);
 
     } else if (window.parent) {
       // Get the parent window's URL. In case any SuiteC data is present,

--- a/public/app/assetlibrary/backToReferrerController.js
+++ b/public/app/assetlibrary/backToReferrerController.js
@@ -27,26 +27,13 @@
 
   'use strict';
 
-  angular.module('collabosphere').controller('BackToReferrerController', function(me, referringId, referringTool, $scope) {
+  angular.module('collabosphere').controller('BackToReferrerController', function(me, referringTool, $scope) {
 
     // Make the me object available to the scope
     $scope.me = me;
 
-    /**
-     * Bundle the properties forwarded by toolHrefDirective. This allows user to link between LTI tools.
-     *
-     * @return {void}
-     */
-    var bundle = function() {
-      if (referringTool) {
-        $scope.referringTool = {
-          'id': referringId,
-          'name': referringTool
-        };
-      }
-    };
-
-    bundle();
+    // The following allows user to link between LTI tools
+    $scope.referringTool = referringTool;
 
   });
 

--- a/public/app/assetlibrary/backtoreferrer.html
+++ b/public/app/assetlibrary/backtoreferrer.html
@@ -1,5 +1,11 @@
 <div data-ng-controller="BackToReferrerController">
   <a data-ng-href="/assetlibrary" class="col-back" data-ng-if="!referringTool"><i class="fa fa-angle-left"></i> Back to Asset Library</a>
 
-  <a tool-href data-tool="dashboard" data-course="me.course" data-id="referringTool.id" class="col-back" data-ng-if="referringTool.name === 'dashboard'"><i class="fa fa-angle-left"></i> Back to Dashboard</a>
+  <a class="col-back"
+    tool-href
+    data-tool="dashboard"
+    data-referring-tool="assetlibrary"
+    data-course="me.course"
+    data-id="referringTool.referringId"
+    data-ng-if="referringTool.name === 'dashboard'"><i class="fa fa-angle-left"></i> Back to Dashboard</a>
 </div>

--- a/public/app/assetlibrary/item/assetLibraryItemController.js
+++ b/public/app/assetlibrary/item/assetLibraryItemController.js
@@ -27,7 +27,7 @@
 
   'use strict';
 
-  angular.module('collabosphere').controller('AssetLibraryItemController', function(assetLibraryFactory, me, referringId, referringTool, utilService, $alert, $rootScope, $sce, $scope, $state, $stateParams) {
+  angular.module('collabosphere').controller('AssetLibraryItemController', function(assetLibraryFactory, me, referringTool, utilService, $alert, $rootScope, $sce, $scope, $state, $stateParams) {
 
     // Make the me object available to the scope
     $scope.me = me;
@@ -391,20 +391,6 @@
     };
 
     /**
-     * Bundle the properties forwarded by toolHrefDirective. This allows user to link between LTI tools.
-     *
-     * @return {void}
-     */
-    var getReferringTool = function() {
-      if (referringTool) {
-        $scope.referringTool = {
-          'id': referringId,
-          'name': referringTool
-        };
-      }
-    };
-
-    /**
      * Close the current browser window. This is used when an asset has been opened
      * in a separate tab and the user wants to be taken back to where the asset was
      * launched from
@@ -448,7 +434,7 @@
     // Load activities for the selected asset
     getAssetActivities();
     // If referringTool is not null then offer user a link to go back.
-    getReferringTool();
+    $scope.referringTool = referringTool;
     // Scroll to the top of the page as the current scroll position could be somewhere
     // deep in the asset library list
     utilService.scrollToTop();

--- a/public/app/assetlibrary/item/item.html
+++ b/public/app/assetlibrary/item/item.html
@@ -1,7 +1,13 @@
 <div data-ng-show="state.current.name === 'assetlibrarylist.item'">
   <a ui-sref="assetlibrarylist($parent.searchOptions)" class="col-back" data-ng-click="backToAssetLibrary()" data-ng-if="!whiteboardReferral && !referringTool"><i class="fa fa-angle-left"></i> Back to Asset Library</a>
 
-  <a tool-href data-tool="dashboard" data-course="me.course" data-id="referringTool.id" class="col-back" data-ng-if="referringTool.name === 'dashboard'"><i class="fa fa-angle-left"></i> Back to Dashboard</a>
+  <a class="col-back"
+    tool-href
+    data-tool="dashboard"
+    data-referring-tool="assetlibrary"
+    data-course="me.course"
+    data-id="referringTool.referringId"
+    data-ng-if="referringTool.name === 'dashboard'"><i class="fa fa-angle-left"></i> Back to Dashboard</a>
 
   <button type="button" class="btn btn-link col-back" data-ng-if="whiteboardReferral" data-ng-click="closeWindow()"><i class="fa fa-angle-left"></i> Back to whiteboard</button>
 
@@ -119,7 +125,12 @@
                   <div class="media-object col-avatar" data-ng-style="{'background-image': 'url(' + user.canvas_image + ')'}"></div>
                 </div>
                 <div class="media-left media-middle assetlibrary-item-metadata-authors-name">
-                  <a tool-href data-tool="dashboard" data-course="me.course" data-id="user.id" data-ng-if="me.course.dashboard_url">
+                  <a tool-href
+                    data-tool="dashboard"
+                    data-referring-tool="assetlibrary"
+                    data-course="me.course"
+                    data-id="user.id"
+                    data-ng-if="me.course.dashboard_url">
                     <i class="fa fa-graduation-cap" data-ng-if="user.is_admin"></i> {{user.canvas_full_name}}
                   </a>
                   <a ui-sref="assetlibrarylist({'user': user.id})" ui-sref-opts="{'inherit': false}" data-ng-if="!me.course.dashboard_url">
@@ -207,7 +218,12 @@
       <div class="media-body media-middle">
         <form name="assetlibraryNewCommentForm" class="assetlibrary-item-newcomment-form" data-ng-submit="assetlibraryNewCommentForm.$valid && createComment()" novalidate>
           <div class="assetlibrary-item-addcomment-commenter">
-            <a tool-href data-tool="dashboard" data-course="me.course" data-id="me.id" data-ng-if="me.course.dashboard_url">
+            <a tool-href
+              data-tool="dashboard"
+              data-referring-tool="assetlibrary"
+              data-course="me.course"
+              data-id="me.id"
+              data-ng-if="me.course.dashboard_url">
               <i class="fa fa-graduation-cap" data-ng-if="me.is_admin"></i> {{me.canvas_full_name}}
             </a>
             <a ui-sref="assetlibrarylist({'user': me.id})" ui-sref-opts="{'inherit': false}" data-ng-if="!me.course.dashboard_url">
@@ -237,7 +253,12 @@
       </div>
       <div class="media-body media-top">
         <div class="assetlibrary-item-addcomment-commenter">
-          <a tool-href data-tool="dashboard" data-course="me.course" data-id="comment.user.id" data-ng-if="me.course.dashboard_url">
+          <a tool-href
+            data-tool="dashboard"
+            data-referring-tool="assetlibrary"
+            data-course="me.course"
+            data-id="comment.user.id"
+            data-ng-if="me.course.dashboard_url">
             <i class="fa fa-graduation-cap" data-ng-if="comment.user.is_admin"></i> {{comment.user.canvas_full_name}}
             <span data-ng-if="me.id === comment.user.id">(me)</span>
           </a>

--- a/public/app/dashboard/profile.html
+++ b/public/app/dashboard/profile.html
@@ -25,7 +25,13 @@
       </div>
       <div>
         <span data-ng-repeat="hashtag in user.hashtags">
-          <a tool-href data-tool="assetlibrary" data-id="hashtag" data-referring-tool="dashboard" data-referring-id="user.id" data-course="me.course" data-ng-bind="hashtag"></a>
+          <a tool-href
+            data-tool="assetlibrary"
+            data-referring-tool="dashboard"
+            data-id="hashtag"
+            data-referring-id="user.id"
+            data-course="me.course"
+            data-ng-bind="hashtag"></a>
         </span>
       </div>
     </div>
@@ -33,7 +39,10 @@
       <div class="profile-summary-column-square">
         <div class="profile-summary-column-square-content">
           <h2>
-            <a tool-href data-tool="engagementindex" data-course="me.course">
+            <a tool-href
+              data-tool="engagementindex"
+              data-referring-tool="dashboard"
+              data-course="me.course">
               Engagement Index
             </a>
           </h2>
@@ -45,7 +54,11 @@
             <span data-ng-bind="userRank"></span> out of <span data-ng-bind="courseUserCount"></span>
           </div>
           <div data-ng-if="(user.id === me.id) && !user.share_points">
-            Sharing off. <a tool-href data-tool="engagementindex" data-course="me.course">Turn on?</a>
+            Sharing off.
+            <a tool-href
+              data-tool="engagementindex"
+              data-referring-tool="dashboard"
+              data-course="me.course">Turn on?</a>
           </div>
         </div>
       </div>
@@ -92,11 +105,23 @@
             <div class="col-list-item-tile">
               <div class="assetlibrary-list-item-add-container">
                 <div class="assetlibrary-list-item-add-table">
-                  <a tool-href data-tool="assetlibrary" data-referring-tool="dashboard" data-referring-id="user.id" data-course="me.course" data-id="routerStateUploadAsset" class="text-center col-pane">
+                  <a class="text-center col-pane"
+                    tool-href
+                    data-tool="assetlibrary"
+                    data-referring-tool="dashboard"
+                    data-referring-id="user.id"
+                    data-course="me.course"
+                    data-id="routerStateUploadAsset">
                     <i class="fa fa-laptop"></i>
                     <div class="assetlibrary-list-item-add-action">Upload</div>
                   </a>
-                  <a tool-href data-tool="assetlibrary" data-referring-tool="dashboard" data-referring-id="user.id" data-course="me.course" data-id="routerStateAddLink" class="text-center col-pane">
+                  <a class="text-center col-pane"
+                    tool-href
+                    data-tool="assetlibrary"
+                    data-referring-tool="dashboard"
+                    data-referring-id="user.id"
+                    data-course="me.course"
+                    data-id="routerStateAddLink">
                     <i class="fa fa-link"></i>
                     <div class="assetlibrary-list-item-add-action">Add Link</div>
                   </a>
@@ -104,7 +129,13 @@
               </div>
             </div>
             <div class="col-list-item-actions">
-              <a tool-href data-tool="assetlibrary" data-referring-tool="dashboard" data-referring-id="user.id" data-course="me.course" data-id="routerStateBookmarkletInfo" class="text-center col-pane">
+              <a class="text-center col-pane"
+                tool-href
+                data-tool="assetlibrary"
+                data-referring-tool="dashboard"
+                data-referring-id="user.id"
+                data-course="me.course"
+                data-id="routerStateBookmarkletInfo">
                 Add assets more easily
                 <i class="fa fa-bookmark pull-left"></i>
               </a>
@@ -113,7 +144,13 @@
         </li>
 
         <li class="assetlibrary-list-item list-inline col-xs-6 col-sm-4 col-md-3" data-ng-repeat="asset in featuredAssets">
-          <a tool-href data-tool="assetlibrary" data-referring-tool="dashboard" data-referring-id="user.id" data-course="me.course" data-id="asset.id">
+          <a tool-href
+            data-tool="assetlibrary"
+            data-referring-tool="dashboard"
+            data-referring-id="user.id"
+            data-course="me.course"
+            data-id="asset.id">
+
             <div class="col-list-item-container">
               <div class="col-list-item-tile">
                 <img class="img-responsive" data-ng-src="{{asset.thumbnail_url}}" data-ng-if="asset.thumbnail_url">
@@ -162,7 +199,13 @@
       </div>
       <ul>
         <li class="assetlibrary-list-item list-inline col-xs-6 col-sm-4 col-md-3" data-ng-repeat="asset in communityAssets">
-          <a tool-href data-tool="assetlibrary" data-referring-tool="dashboard" data-referring-id="user.id" data-course="me.course" data-id="asset.id">
+          <a tool-href
+            data-tool="assetlibrary"
+            data-referring-tool="dashboard"
+            data-referring-id="user.id"
+            data-course="me.course"
+            data-id="asset.id">
+
             <div class="col-list-item-container">
               <div class="col-list-item-tile">
                 <img class="img-responsive" data-ng-src="{{asset.thumbnail_url}}" data-ng-if="asset.thumbnail_url">

--- a/public/app/dashboard/profileController.js
+++ b/public/app/dashboard/profileController.js
@@ -27,7 +27,7 @@
 
   'use strict';
 
-  angular.module('collabosphere').controller('ProfileController', function(assetLibraryFactory, profileFactory, deepLinkId, me, userFactory, utilService, $scope) {
+  angular.module('collabosphere').controller('ProfileController', function(assetLibraryFactory, me, profileFactory, referringTool, userFactory, utilService, $scope) {
 
     // Value of 'id' in toolUrlDirective can be router-state, asset id, etc.
     $scope.routerStateAddLink = 'assetlibraryaddlink';
@@ -135,8 +135,8 @@
 
     var init = function() {
       // Determine user
-      if (deepLinkId) {
-        userFactory.getUser(deepLinkId).success(function(user) {
+      if (referringTool && referringTool.requestedId) {
+        userFactory.getUser(referringTool.requestedId).success(function(user) {
           loadProfile(user);
         });
       } else {

--- a/public/app/engagementindex/leaderboard/list.html
+++ b/public/app/engagementindex/leaderboard/list.html
@@ -51,7 +51,12 @@
           <div class="media-body media-middle">
             <i class="fa fa-graduation-cap" data-ng-if="user.is_admin"></i>
             <span data-ng-bind="user.canvas_full_name" data-ng-if="!me.course.dashboard_url"></span>
-            <a tool-href data-tool="dashboard" data-course="me.course" data-id="user.id" data-ng-if="me.course.dashboard_url">
+            <a tool-href
+              data-tool="dashboard"
+              data-referring-tool="engagementindex"
+              data-course="me.course"
+              data-id="user.id"
+              data-ng-if="me.course.dashboard_url">
               <span data-ng-bind="user.canvas_full_name"></span>
             </a>
           </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-816

`referringTool` is now a bundle, packaged in `app.bootstrap`. IMO, more intuitive and simplifies front-end code. The `data-referring-tool` attribute is now required.