### PR TITLE
COL-839, profile search prototype: User-only w/ autosuggest keeps you on profile page

### DIFF
--- a/public/app/app.states.js
+++ b/public/app/app.states.js
@@ -81,7 +81,7 @@
         'templateUrl': '/app/dashboard/profile.html',
         'controller': 'ProfileController'
       })
-      .state('dashboard.profile.user', {
+      .state('userprofile', {
         'url': '/profile/:userId',
         'templateUrl': '/app/dashboard/profile.html',
         'controller': 'ProfileController'

--- a/public/app/dashboard/profile.html
+++ b/public/app/dashboard/profile.html
@@ -9,7 +9,14 @@
     <div class="profile-summary-column">
       <div class="profile-summary-banner">
         <h1 data-ng-bind="user.canvas_full_name"></h1>
-        <aggregated-search class="profile-summary-search" data-search-options-keywords="searchOptions.keywords" />
+        <label for="findUser" class="sr-only">Search for users</label>
+        <oi-select name="findUser" class="profile-summary-search"
+          autofocus
+          oi-options="user.id as user.canvas_full_name for user in otherUsers track by user.id | orderBy: 'canvas_full_name.toLowerCase()'"
+          oi-select-options="{'dropdownFilter': 'userProfileSearchDropdown'}"
+          ng-model="nextUserId"
+          placeholder="Search for other people"
+          tabindex="-1"></oi-select>
       </div>
       <div>
         Write4Change (St. Paul, Minnesota, USA)

--- a/public/app/dashboard/search/profileSearchAutosuggestFilter.js
+++ b/public/app/dashboard/search/profileSearchAutosuggestFilter.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+(function(angular) {
+
+  'use strict';
+
+  angular.module('collabosphere').filter('userProfileSearchDropdown', ['$sce', function($sce) {
+    return function(label, query, option) {
+      var html = option.is_admin ? '<i class="fa fa-graduation-cap"></i> ' + label : label;
+
+      return $sce.trustAsHtml(html);
+    };
+  }]);
+
+}(window.angular));

--- a/public/index.html
+++ b/public/index.html
@@ -115,6 +115,7 @@
   <script src="/app/assetlibrary/uploadcontainer/assetLibraryUploadContainerController.js"></script>
   <script src="/app/dashboard/search/aggregatedSearchController.js"></script>
   <script src="/app/dashboard/search/aggregatedSearchDirective.js"></script>
+  <script src="/app/dashboard/search/profileSearchAutosuggestFilter.js"></script>
   <script src="/app/dashboard/profileFactory.js"></script>
   <script src="/app/dashboard/profileController.js"></script>
   <script src="/app/engagementindex/leaderboard/leaderboardController.js"></script>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-839

Search is hard, so let's start with something simple. Put focus on search and you get list of all course users. Start typing and list narrows. Click or hit return on a user and page reloads with selected profile.  See screenshot.

Perhaps we'll end up with a more sophisticated search but... One step at a time.

![image](https://cloud.githubusercontent.com/assets/7606442/25417629/45961f02-29fa-11e7-9ca3-3b1f2e6666d5.png)
