### PR TITLE
COL-482 COL-824 COL-837 New activity types

### DIFF
--- a/node_modules/col-activities/lib/default.js
+++ b/node_modules/col-activities/lib/default.js
@@ -49,6 +49,12 @@ var Default = module.exports = [
     'enabled': true
   },
   {
+    'type': 'get_view_asset',
+    'title': 'Receive a view in the Asset Library',
+    'points': 0,
+    'enabled': true
+  },
+  {
     'type': 'get_like',
     'title': 'Receive a like in the Asset Library',
     'points': 1,
@@ -115,8 +121,26 @@ var Default = module.exports = [
     'enabled': true
   },
   {
+    'type': 'get_whiteboard_add_asset',
+    'title': 'Have one\'s asset added to a whiteboard',
+    'points': 0,
+    'enabled': true
+  },
+  {
     'type': 'whiteboard_chat',
     'title': 'Leave a chat message on a whiteboard',
+    'points': 0,
+    'enabled': true
+  },
+  {
+    'type': 'remix_whiteboard',
+    'title': 'Remix a whiteboard',
+    'points': 0,
+    'enabled': true
+  },
+  {
+    'type': 'get_remix_whiteboard',
+    'title': 'Have one\'s whiteboard remixed',
     'points': 0,
     'enabled': true
   }

--- a/node_modules/col-activities/tests/test-csv.js
+++ b/node_modules/col-activities/tests/test-csv.js
@@ -42,12 +42,7 @@ describe('Activities', function() {
       var instructor = TestsUtil.generateInstructor();
       TestsUtil.getAssetLibraryClient(null, null, instructor, function(client1, course, instructor) {
 
-        // Disable the `view_asset` activity to reduce noise in activity logging
-        var activityTypeOverride = [{
-          'type': 'view_asset',
-          'enabled': false
-        }];
-        ActivitiesTestUtil.assertEditActivityTypeConfiguration(client1, course, activityTypeOverride, function() {
+        ActivitiesTestUtil.assertEditActivityTypeConfiguration(client1, course, ActivitiesTestUtil.OVERRIDE_VIEWS_DISABLED, function() {
 
           // Verify that the activity CSV export is empty before any activities have taken place
           ActivitiesTestUtil.assertExportActivities(client1, course, 0, function(activities) {
@@ -117,12 +112,7 @@ describe('Activities', function() {
         TestsUtil.getAssetLibraryClient(null, course, null, function(studentClient1, course, studentUser1) {
           TestsUtil.getAssetLibraryClient(null, course, null, function(studentClient2, course, studentUser2) {
 
-            // Disable the `view_asset` activity to reduce noise in activity logging
-            var activityTypeOverride = [{
-              'type': 'view_asset',
-              'enabled': false
-            }];
-            ActivitiesTestUtil.assertEditActivityTypeConfiguration(instructorClient, course, activityTypeOverride, function() {
+            ActivitiesTestUtil.assertEditActivityTypeConfiguration(instructorClient, course, ActivitiesTestUtil.OVERRIDE_VIEWS_DISABLED, function() {
 
               // Generate a few activities by creating a link and liking it
               ActivitiesTestUtil.assertCreateLinkActivity(studentClient1, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset) {

--- a/node_modules/col-activities/tests/test-points.js
+++ b/node_modules/col-activities/tests/test-points.js
@@ -143,7 +143,7 @@ describe('Activity Points', function() {
 
           // Verify that viewing an asset does not update points by default
           TestsUtil.getAssetLibraryClient(null, course, null, function(client2, course, user2) {
-            ActivitiesTestUtil.assertViewAssetActivity(client2, course, asset.id, function() {
+            ActivitiesTestUtil.assertViewAssetActivity(client2, client1, course, asset.id, function() {
 
               // Assign points to asset view
               var instructorUser = TestsUtil.generateInstructor();
@@ -156,12 +156,28 @@ describe('Activity Points', function() {
                 ActivitiesTestUtil.assertEditActivityTypeConfiguration(instructorClient, course, activityTypeOverride, function() {
 
                   // Verify that viewing an asset now updates points
-                  ActivitiesTestUtil.assertViewAssetActivity(client2, course, asset.id, function() {
+                  ActivitiesTestUtil.assertViewAssetActivity(client2, client1, course, asset.id, function() {
 
                     // Verify that a user viewing their own asset does not update points
-                    ActivitiesTestUtil.assertViewAssetActivity(client1, course, asset.id, function() {
+                    ActivitiesTestUtil.assertViewAssetActivity(client1, client1, course, asset.id, function() {
 
-                      return callback();
+                      // Assign points to receiving an asset view
+                      var activityTypeOverride = [{
+                        'type': 'get_view_asset',
+                        'points': 1
+                      }];
+                      ActivitiesTestUtil.assertEditActivityTypeConfiguration(instructorClient, course, activityTypeOverride, function() {
+
+                        // Verify that viewing an asset still updates points
+                        ActivitiesTestUtil.assertViewAssetActivity(client2, client1, course, asset.id, function() {
+
+                          // Verify that a user viewing their own asset still does not update points
+                          ActivitiesTestUtil.assertViewAssetActivity(client1, client1, course, asset.id, function() {
+
+                            return callback();
+                          });
+                        });
+                      });
                     });
                   });
                 });

--- a/node_modules/col-activities/tests/util.js
+++ b/node_modules/col-activities/tests/util.js
@@ -724,40 +724,44 @@ var assertLikeActivity = module.exports.assertLikeActivity = function(likerClien
 /**
  * Assert that an asset can be viewed and activity points are earned
  *
- * @param  {RestClient}         client                          The REST client representing the user viewing the asset
+ * @param  {RestClient}         viewerClient                    The REST client representing the user viewing the asset
+ * @param  {RestClient}         creatorClient                    The REST client representing the user that created the asset
  * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
  * @param  {Number}             assetId                         The id of the viewed asset
  * @param  {Function}           callback                        Standard callback function
  * @throws {AssertionError}                                     Error thrown when an assertion failed
  */
-var assertViewAssetActivity = module.exports.assertViewAssetActivity = function(client, course, assetId, callback) {
+var assertViewAssetActivity = module.exports.assertViewAssetActivity = function(viewerClient, creatorClient, course, assetId, callback) {
   // Get the points that are earned when viewing an asset
-  assertGetActivityTypeConfiguration(client, course, function(configuration) {
+  assertGetActivityTypeConfiguration(viewerClient, course, function(configuration) {
     var viewPoints = _.find(configuration, {'type': 'view_asset'}).points;
+    var getViewPoints = _.find(configuration, {'type': 'get_view_asset'}).points;
 
     // Get the me object for the user viewing the asset
-    UsersTestUtil.assertGetMe(client, course, null, function(me) {
-      // View the asset
-      AssetsTestUtil.assertGetAsset(client, course, assetId, null, null, function(asset) {
+    UsersTestUtil.assertGetMe(viewerClient, course, null, function(viewerMe) {
+      // Get the me object for the asset creator
+      UsersTestUtil.assertGetMe(creatorClient, course, null, function(creatorMe) {
 
-        // If viewer is among asset creators
-        if (_.find(asset.users, {'id': me.id})) {
-          // Points are not changed and last_activity timestamp is not updated
-            assertPoints(client, course, me, 0, false, callback);
+        // View the asset
+        AssetsTestUtil.assertGetAsset(viewerClient, course, assetId, null, null, function(asset) {
 
-        // If viewer is not among asset creators
-        } else {
-          // If no points are allocated to asset view
-          if (!viewPoints) {
-            // Points are not changed, but last_activity timestamp is updated
-            assertPoints(client, course, me, 0, true, callback);
+          // If viewer is among asset creators
+          if (_.find(asset.users, {'id': viewerMe.id})) {
+            // Viewer's points are not changed and last_activity timestamp is not updated
+            assertPoints(viewerClient, course, viewerMe, 0, false, function() {
+              // Creator's points are not changed and last_activity timestamp is not updated
+              assertPoints(creatorClient, course, creatorMe, 0, false, callback);
+            });
 
-          // If points are allocated to asset view
+          // If viewer is not among asset creators
           } else {
-            // Points are changed and last_activity timestamp is updated
-            assertPoints(client, course, me, viewPoints, true, callback);
+            // Viewer's points are changed (or not changed if viewPoints is 0) and last_activity timestamp is updated
+            assertPoints(viewerClient, course, viewerMe, viewPoints, true, function() {
+              // Creator's points are changed (or not changed if getViewPoints is 0) and last_activity timestamp is not updated
+              assertPoints(creatorClient, course, creatorMe, getViewPoints, false, callback);
+            });
           }
-        }
+        });
       });
     });
   });
@@ -887,6 +891,20 @@ var assertEditActivityTypeConfiguration = module.exports.assertEditActivityTypeC
     });
   });
 };
+
+/**
+ * Override to disable asset view activities. For testing purposes, this reduces noise in activity logging.
+ */
+var OVERRIDE_VIEWS_DISABLED = module.exports.OVERRIDE_VIEWS_DISABLED = [
+  {
+    'type': 'view_asset',
+    'enabled': false
+  },
+  {
+    'type': 'get_view_asset',
+    'enabled': false
+  }
+];
 
 /**
  * Assert that the configuration for an activity type in a course can be edited

--- a/node_modules/col-assets/lib/api.js
+++ b/node_modules/col-assets/lib/api.js
@@ -207,7 +207,7 @@ var incrementViewsIfRequired = function(ctx, asset, incrementViews, callback) {
     return callback(null, asset);
   }
 
-  // If the user is viewing their own asset, do not increment the view count or create an activity.
+  // If the user is viewing their own asset, do not increment the view count or create activities.
   var isAssetOwner = _.find(asset.users, {'id': ctx.user.id});
   if (isAssetOwner) {
     return callback(null, asset);
@@ -225,7 +225,13 @@ var incrementViewsIfRequired = function(ctx, asset, incrementViews, callback) {
         return callback(err);
       }
 
-      return callback(null, asset);
+      createGetViewActivities(ctx, asset, function(err) {
+        if (err) {
+          return callback(err);
+        }
+
+        return callback(null, asset);
+      });
     });
   });
 };
@@ -1894,6 +1900,33 @@ var createGetLikeActivities = function(ctx, asset, type, callback) {
         return errorCallback(err);
       }
 
+      return done();
+    });
+  });
+};
+
+/**
+ * Create a `get_view_asset` activity for each author of an asset
+ *
+ * @param  {Context}        ctx               Standard context containing the current user and the current course
+ * @param  {Asset}          asset             The asset receiving the view
+ * @param  {Function}       callback          Standard callback function
+ * @param  {Object}         callback.err      An error that occurred, if any
+ * @api private
+ */
+var createGetViewActivities = function(ctx, asset, callback) {
+  var done = _.after(asset.users.length, callback);
+  var errorCallback = _.once(callback);
+  _.each(asset.users, function(user) {
+    ActivitiesAPI.createActivity(ctx.course, user, 'get_view_asset', asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, null, ctx.user, function(err) {
+      if (err) {
+        log.error({
+          'err': err,
+          'user': user.id,
+          'asset': asset.id
+        }, 'Failed to create a get_view_asset activity');
+        return errorCallback(err);
+      }
       return done();
     });
   });

--- a/node_modules/col-core/lib/db.js
+++ b/node_modules/col-core/lib/db.js
@@ -31,6 +31,7 @@ var ActivitiesDefaults = require('col-activities/lib/default');
 
 var CollabosphereConstants = require('./constants');
 var log = require('./logger')('col-core/db');
+var UserConstants = require('col-users/lib/constants');
 
 // A sequelize instance that will be connected to the database
 var sequelize = null;
@@ -516,6 +517,12 @@ var setUpModel = function(sequelize) {
         if (!_.isEmpty(asset.categories)) {
           asset.categories = _.sortBy(asset.categories, 'title');
         }
+
+        // Filter out unwanted user properties
+        var userFields = _.concat(UserConstants.BASIC_USER_FIELDS, 'is_admin');
+        asset.users = _.map(asset.users, function(user) {
+          return _.pick(user.toJSON(), userFields);
+        });
 
         delete asset.asset_users;
 

--- a/scripts/20170426-col482/add_activity_enums.sql
+++ b/scripts/20170426-col482/add_activity_enums.sql
@@ -1,0 +1,13 @@
+-- Add new enum values for `type` column in `activities` table
+
+ALTER TYPE enum_activities_type ADD VALUE 'get_view_asset';
+ALTER TYPE enum_activities_type ADD VALUE 'get_whiteboard_add_asset';
+ALTER TYPE enum_activities_type ADD VALUE 'remix_whiteboard';
+ALTER TYPE enum_activities_type ADD VALUE 'get_remix_whiteboard';
+
+-- Add new enum values for `type` column in `activity_types` table
+
+ALTER TYPE enum_activity_types_type ADD VALUE 'get_view_asset';
+ALTER TYPE enum_activity_types_type ADD VALUE 'get_whiteboard_add_asset';
+ALTER TYPE enum_activity_types_type ADD VALUE 'remix_whiteboard';
+ALTER TYPE enum_activity_types_type ADD VALUE 'get_remix_whiteboard';


### PR DESCRIPTION
This PR contains two commits.

The first includes a database migration and defaults for new activity types:
- `get_view_asset` (https://jira.ets.berkeley.edu/jira/browse/COL-482)
- `get_whiteboard_add_asset` (https://jira.ets.berkeley.edu/jira/browse/COL-824)
- `remix_whiteboard`, `get_remix_whiteboard` (https://jira.ets.berkeley.edu/jira/browse/COL-837)
These are awkward names but consistency in naming reciprocals (`get_` + original activity name) seems worth keeping.

The second commit includes logic and tests for `get_view_asset` only.