### PR TITLE
COL-820, canvas_course_sections added to 'users' table, displayed on profile page (Impact Studio)

### DIFF
--- a/node_modules/col-canvas/lib/api.js
+++ b/node_modules/col-canvas/lib/api.js
@@ -426,7 +426,7 @@ var deleteFile = module.exports.deleteFile = function(ctx, file, callback) {
       'Authorization': util.format('Bearer %s', ctx.course.canvas.api_key)
     }
   };
-  
+
   request(opts, function(err, response, body) {
     if (err) {
       log.error({'err': err, 'course': ctx.course.id}, 'Failed to delete the file');
@@ -438,6 +438,26 @@ var deleteFile = module.exports.deleteFile = function(ctx, file, callback) {
 
     return callback(null, response);
   });
+};
+
+/* Sections */
+
+/**
+ * Get all sections of course
+ *
+ * @param  {Course}         course                      The course for which to get the enrolled users
+ * @param  {Function}       callback                    Standard callback function
+ * @param  {Object}         callback.err                An error that occurred, if any
+ */
+var getCourseSections = module.exports.getCourseSections = function(course, callback) {
+  var url = util.format('/api/v1/courses/%d/sections?include[]=students', course.canvas_course_id);
+
+  log.debug({
+    'course': course.id,
+    'url': url
+  }, 'Getting course sections');
+
+  return getDataFromCanvas(course.canvas, url, callback);
 };
 
 /* Course users */
@@ -722,7 +742,7 @@ var updateExternalToolForCourse = module.exports.updateExternalToolForCourse = f
  * @param  {Number}         accountId                   The id of the account
  * @param  {Function}       callback                    Standard callback function
  * @param  {Object}         callback.err                An error that occurred, if any
- * @param  {Object}         callback.accountProperties  Account properties 
+ * @param  {Object}         callback.accountProperties  Account properties
  */
 var getAccountProperties = module.exports.getAccountProperties = function(canvas, accountId, callback) {
   log.debug({
@@ -768,7 +788,7 @@ var getAccountProperties = module.exports.getAccountProperties = function(canvas
  * @param  {Course}         course                      The course for which to get properties
  * @param  {Function}       callback                    Standard callback function
  * @param  {Object}         callback.err                An error that occurred, if any
- * @param  {Object}         callback.courseProperties   Course properties 
+ * @param  {Object}         callback.courseProperties   Course properties
  */
 var getCourseProperties = module.exports.getCourseProperties = function(course, callback) {
   log.debug({

--- a/node_modules/col-canvas/lib/poller.js
+++ b/node_modules/col-canvas/lib/poller.js
@@ -299,36 +299,60 @@ var pollUsers = function(ctx, users, callback) {
 
     log.info({'course': ctx.course.id}, 'Got ' + _.size(canvasUsers) + ' users from Canvas');
 
-    // Ensure that we have a record for each Canvas user
-    var userIterator = handleUser.bind(null, ctx, users);
-    async.eachSeries(canvasUsers, userIterator, function(err) {
+    CanvasAPI.getCourseSections(ctx.course, function(err, sections) {
       if (err) {
         return callback(err);
       }
 
-      // Mark the users that have been removed from the Canvas course as inactive
-      var unseenUserIds = _.chain(users)
-        .values()
-        .filter(function(user) {
-          return (user.canvas_enrollment_state !== 'inactive' && !user.seen);
-        })
-        .map('id')
-        .value();
+      log.info({'course': ctx.course.id}, 'Course has ' + _.size(sections) + ' sections in Canvas');
 
-      if (_.isEmpty(unseenUserIds)) {
-        return callback(null, users);
-      }
+      // Each course section, from Canvas API, contains a set of canvas_user_ids
+      var userSections = {};
+      _.each(sections, function(section) {
+        _.each(section.students, function(user) {
+          var existing = userSections[user.id];
 
-      log.debug({
-        'users': unseenUserIds,
-        'course': ctx.course.id
-      }, 'Marking one or more users as inactive');
-      UsersAPI.updateUsers(unseenUserIds, {'canvas_enrollment_state': 'inactive'}, function(err) {
+          // Array of section names will be used for db update
+          userSections[user.id] = existing ? _.concat(existing, section.name) : [section.name];
+        });
+      });
+
+      // Attach sections to canvasUser
+      _.each(canvasUsers, function(canvasUser) {
+        canvasUser.course_sections = userSections[canvasUser.id];
+      });
+
+      // Ensure that we have a record for each Canvas user
+      var userIterator = handleUser.bind(null, ctx, users);
+      async.eachSeries(canvasUsers, userIterator, function(err) {
         if (err) {
           return callback(err);
         }
 
-        return callback(null, users);
+        // Mark the users that have been removed from the Canvas course as inactive
+        var unseenUserIds = _.chain(users)
+          .values()
+          .filter(function(user) {
+            return (user.canvas_enrollment_state !== 'inactive' && !user.seen);
+          })
+          .map('id')
+          .value();
+
+        if (_.isEmpty(unseenUserIds)) {
+          return callback(null, users);
+        }
+
+        log.debug({
+          'users': unseenUserIds,
+          'course': ctx.course.id
+        }, 'Marking one or more users as inactive');
+        UsersAPI.updateUsers(unseenUserIds, {'canvas_enrollment_state': 'inactive'}, function(err) {
+          if (err) {
+            return callback(err);
+          }
+
+          return callback(null, users);
+        });
       });
     });
   });
@@ -381,9 +405,13 @@ var handleUser = function(ctx, users, canvasUser, callback) {
 
   // If we've already synced the user and their information hasn't changed, we can return early
   var user = users[canvasUser.id];
-  if (user && user.canvas_course_role === courseRole &&
-      user.canvas_enrollment_state === enrollmentState && user.canvas_full_name === canvasUser.name &&
-      user.canvas_image === image && user.canvas_email === email) {
+  if (user &&
+      user.canvas_course_role === courseRole &&
+      user.canvas_course_sections === canvasUser.course_sections &&
+      user.canvas_enrollment_state === enrollmentState &&
+      user.canvas_full_name === canvasUser.name &&
+      user.canvas_image === image &&
+      user.canvas_email === email) {
     // Mark the user as seen. This allows a second pass to remove any user that wasn't seen
     users[canvasUser.id].seen = true;
     return callback();
@@ -392,6 +420,7 @@ var handleUser = function(ctx, users, canvasUser, callback) {
   // Otherwise we create or update a record for the user
   var defaults = {
     'canvas_course_role': courseRole,
+    'canvas_course_sections': canvasUser.course_sections,
     'canvas_enrollment_state': enrollmentState,
     'canvas_full_name': canvasUser.name,
     'canvas_email': canvasUser.email
@@ -636,9 +665,9 @@ var handleSubmission = function(ctx, users, assignment, activities, submissionAs
       return callback(err);
 
     // We've already seen this submission attempt and there's been no change in visibility settings, so we can skip processing the attachments.
-    } else if (!created && 
-      (retrievedActivity && retrievedActivity.metadata && 
-       retrievedActivity.metadata.attempt === submission.attempt && 
+    } else if (!created &&
+      (retrievedActivity && retrievedActivity.metadata &&
+       retrievedActivity.metadata.attempt === submission.attempt &&
        retrievedActivity.metadata.file_sync_enabled === assignment.category.visible)) {
       return callback();
     }
@@ -864,7 +893,7 @@ var handleFilesSubmissionAttachment = function(ctx, assignment, submissionAssets
 var downloadUrlRegex = /files\/(\d+)\/download/;
 
 /**
- * Remove processed attachment files from a Canvas assignment submission 
+ * Remove processed attachment files from a Canvas assignment submission
  *
  * @param  {Context}    ctx                               Standard context containing the current user and the current course
  * @param  {Object}     asset                             The asset for which files are to be removed

--- a/node_modules/col-canvas/tests/model.js
+++ b/node_modules/col-canvas/tests/model.js
@@ -329,3 +329,27 @@ var CanvasDiscussionEntry = module.exports.CanvasDiscussionEntry = function(user
     'recent_replies': []
   };
 };
+
+/**
+ * Mock a Canvas section
+ *
+ * @param  {CanvasUser}    user          The user who created the discussion entry
+ * @param  {String}        name          The name of the section
+ * @param  {Number}        courseId      The id of course
+ * @return {Object}                      A mocked Canvas discussion entry object
+ */
+var CanvasSection = module.exports.CanvasSection = function(user, name, courseId) {
+  return {
+    'id': _.random(100000),
+    "course_id": courseId,
+    "name": name,
+    "students": [
+      {
+        "id": user.id,
+        "name": user.fullName,
+        "login_id": user.email
+      }
+    ]
+  };
+};
+

--- a/node_modules/col-canvas/tests/test-poller.js
+++ b/node_modules/col-canvas/tests/test-poller.js
@@ -46,6 +46,7 @@ var CanvasAssignment = require('./model').CanvasAssignment;
 var CanvasDiscussion = require('./model').CanvasDiscussion;
 var CanvasDiscussionEntry = require('./model').CanvasDiscussionEntry;
 var CanvasFile = require('./model').CanvasFile;
+var CanvasSection = require('./model').CanvasSection;
 var CanvasSubmission = require('./model').CanvasSubmission;
 var CanvasTestsUtil = require('./util');
 var CanvasUser = require('./model').CanvasUser;
@@ -198,12 +199,20 @@ describe('Canvas poller', function() {
         getCourse(course.id, function(dbCourse) {
 
           // Prepare the mocked requests to Canvas
+          var activeStudent = new CanvasUser('Active student', course.id, 'active', null, 'user1@berkeley.edu');
+          var activeTeacher = new CanvasUser('Active teacher', course.id, 'active', 'TeacherEnrollment');
+          var completedStudent = new CanvasUser('Completed student', course.id, 'completed', null, 'user3@berkeley.edu');
           var mockedCanvasUsers = [
-            new CanvasUser('Active student', course.id, 'active', null, 'user1@berkeley.edu'),
-            new CanvasUser('Active teacher', course.id, 'active', 'TeacherEnrollment'),
-            new CanvasUser('Completed student', course.id, 'completed', null, 'user3@berkeley.edu')
+            activeStudent,
+            activeTeacher,
+            completedStudent
           ];
-          CanvasTestsUtil.mockPollingRequests(dbCourse, mockedCanvasUsers);
+          // For the sake of simplicity, we have only one student per mock section
+          var mockedCanvasSections = [
+            new CanvasSection(activeStudent, 'Section 001', course.id),
+            new CanvasSection(completedStudent, 'Section 002', course.id)
+          ];
+          CanvasTestsUtil.mockPollingRequests(dbCourse, mockedCanvasUsers, [], [], mockedCanvasSections);
 
           // Poll the Canvas API for information
           CanvasPoller.handleCourse(dbCourse, null, function(err) {
@@ -224,12 +233,14 @@ describe('Canvas poller', function() {
               var activeStudent = getUserByName(users, 'Active student');
               UsersTestUtil.assertUser(activeStudent, {'expectEmail': true});
               assert.strictEqual(activeStudent.canvas_course_role, 'Student');
+              assert.deepEqual(activeStudent.canvas_course_sections, ['Section 001']);
               assert.strictEqual(activeStudent.canvas_enrollment_state, 'active');
               assert.strictEqual(activeStudent.canvas_email, 'user1@berkeley.edu');
 
               var completedStudent = getUserByName(users, 'Completed student');
               UsersTestUtil.assertUser(completedStudent, {'expectEmail': true});
               assert.strictEqual(completedStudent.canvas_course_role, 'Student');
+              assert.deepEqual(completedStudent.canvas_course_sections, ['Section 002']);
               assert.strictEqual(completedStudent.canvas_enrollment_state, 'completed');
               assert.strictEqual(completedStudent.canvas_email, 'user3@berkeley.edu');
 
@@ -693,7 +704,7 @@ describe('Canvas poller', function() {
 
                         user2Submission.attempt++;
                         user2Submission.body = 'My new essay';
-                        
+
                         user3Submission.oldFilePaths = _.map(user3Submission.attachments, 'filePath');
                         user3Submission.attempt++;
                         user3Submission.attachments = [
@@ -1203,7 +1214,7 @@ describe('Canvas poller', function() {
     it('inactivates a course with activity in the distant past', function(callback) {
       // Create a user who will get some old activity
       TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
-        // Create a second user who does nothing; inactivation logic should ignore this user 
+        // Create a second user who does nothing; inactivation logic should ignore this user
         TestsUtil.getAssetLibraryClient(null, course, null, function(doNothingClient, course, doNothingUser) {
           // Create a link asset with no optional metadata
           AssetsTestsUtil.assertCreateLink(client, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset) {

--- a/node_modules/col-canvas/tests/util.js
+++ b/node_modules/col-canvas/tests/util.js
@@ -115,20 +115,23 @@ var mockFileUpload = module.exports.mockFileUpload = function(course) {
  * run.
  *
  * Note that the mocking framework is extremely particular and demands that the mocked requests be declared
- * in the same order that they'll be received. 
+ * in the same order that they'll be received.
  *
  * @param  {Course}                 course          The course that we'll be mocking requests for
  * @param  {CanvasUser[]}           users           The users that are registered in the course
  * @param  {CanvasAssignment[]}     assignments     The assignments that are available in the course
  * @param  {CanvasDiscussion[]}     discussions     The discussion topics that are available in the course
+ * @param  {CanvasSections[]}       sections        The sections of the course
  */
-var mockPollingRequests = module.exports.mockPollingRequests = function(course, users, assignments, discussions) {
+var mockPollingRequests = module.exports.mockPollingRequests = function(course, users, assignments, discussions, sections) {
   // Default some parameters
   users = users || [];
   assignments = assignments || [];
   discussions = discussions || [];
+  sections = sections || [];
 
   mockGetCourseUsers(course, users);
+  mockGetCourseSections(course, sections);
 
   mockGetAssignments(course, assignments);
   _.each(assignments, function(assignment) {
@@ -154,6 +157,17 @@ var mockPollingRequests = module.exports.mockPollingRequests = function(course, 
 var mockGetCourseUsers = module.exports.mockGetCourseUsers = function(course, users) {
   var url = util.format('/api/v1/courses/%d/users', course.canvas_course_id);
   mockPagedData(course, url, users);
+};
+
+/**
+ * Mock the REST API call for getting all sections of a course
+ *
+ * @param  {Course}                 course          The course that we'll be mocking requests for
+ * @param  {CanvasSection[]}        sections        The sections of the course
+ */
+var mockGetCourseSections = module.exports.mockGetCourseSections = function(course, sections) {
+  var url = util.format('/api/v1/courses/%d/sections', course.canvas_course_id);
+  mockPagedData(course, url, sections);
 };
 
 /**

--- a/node_modules/col-core/lib/db.js
+++ b/node_modules/col-core/lib/db.js
@@ -294,6 +294,7 @@ var setUpModel = function(sequelize) {
    *
    * @property  {Number}      canvas_user_id          The id of the user in Canvas
    * @property  {String}      canvas_course_role      The role of the user in the course
+   * @property  {String}      canvas_course_sections  Array of section names per course, user enrollments
    * @property  {String}      canvas_full_name        The full name of the student
    * @property  {String}      [canvas_image]          The URL that points to a profile picture for the user
    * @property  {String}      [canvas_email]          The email of the student
@@ -309,6 +310,10 @@ var setUpModel = function(sequelize) {
     'canvas_course_role': {
       'type': Sequelize.STRING,
       'allowNull': false
+    },
+    'canvas_course_sections': {
+      'type': Sequelize.ARRAY(Sequelize.STRING),
+      'allowNull': true
     },
     'canvas_enrollment_state': {
       'type': Sequelize.ENUM(_.values(CollabosphereConstants.ENROLLMENT_STATE)),

--- a/node_modules/col-tests/lib/util.js
+++ b/node_modules/col-tests/lib/util.js
@@ -177,8 +177,8 @@ var generateCourse = module.exports.generateCourse = function(canvas, id, label,
  * @param  {String}           [userImage]             The url that points to a profile picture for the user
  * @return {User}                                     An object that contains the information about the user
  */
-var generateCanvasAdmin = module.exports.generateCanvasAdmin = function(canvas, id, givenName, familyName, loginId, userImage) {
-  return generateUser(canvas, id, 'urn:lti:instrole:ims/lis/Administrator', givenName, familyName, loginId, userImage);
+var generateCanvasAdmin = module.exports.generateCanvasAdmin = function(canvas, id, sections, givenName, familyName, loginId, userImage) {
+  return generateUser(canvas, id, 'urn:lti:instrole:ims/lis/Administrator', sections, givenName, familyName, loginId, userImage);
 };
 
 /**
@@ -193,8 +193,8 @@ var generateCanvasAdmin = module.exports.generateCanvasAdmin = function(canvas, 
  * @param  {String}           [userImage]             The url that points to a profile picture for the user
  * @return {User}                                     An object that contains the information about the user
  */
-var generateInstructor = module.exports.generateInstructor = function(canvas, id, givenName, familyName, loginId, userImage) {
-  return generateUser(canvas, id, 'urn:lti:role:ims/lis/Instructor', givenName, familyName, loginId, userImage);
+var generateInstructor = module.exports.generateInstructor = function(canvas, id, sections, givenName, familyName, loginId, userImage) {
+  return generateUser(canvas, id, 'urn:lti:role:ims/lis/Instructor', sections, givenName, familyName, loginId, userImage);
 };
 
 /**
@@ -204,13 +204,14 @@ var generateInstructor = module.exports.generateInstructor = function(canvas, id
  * @param  {Canvas}           [canvas]                The canvas instance in which the user lives
  * @param  {Number}           [id]                    The id of the user in Canvas
  * @param  {String}           [roles]                 The role of the user in the course, defaults to `Student`
+ * @param  {Array}            [sections]              The course sections in which user is enrolled
  * @param  {String}           [givenName]             The given name of the user
  * @param  {String}           [familyName]            The family name of the user
  * @param  {String}           [loginId]               The login id for the user
  * @param  {String}           [userImage]             The url that points to a profile picture for the user
  * @return {User}                                     An object that contains the information about the user
  */
-var generateUser = module.exports.generateUser = function(canvas, id, roles, givenName, familyName, loginId, userImage) {
+var generateUser = module.exports.generateUser = function(canvas, id, roles, sections, givenName, familyName, loginId, userImage) {
   givenName = givenName || randomstring.generate(10);
   familyName = familyName || randomstring.generate(15);
   return {
@@ -220,6 +221,7 @@ var generateUser = module.exports.generateUser = function(canvas, id, roles, giv
     'familyName': familyName,
     'fullName': givenName + ' ' + familyName,
     'roles': roles || 'Student',
+    'sections': sections || ['Section 001'],
     'ext_roles': roles || 'Student',
     'loginId': loginId || (_.random(1000000) + '@berkeley.edu'),
     'guid': _.random(100000),

--- a/node_modules/col-users/lib/api.js
+++ b/node_modules/col-users/lib/api.js
@@ -160,6 +160,7 @@ var getOrCreateUser = module.exports.getOrCreateUser = function(canvasUserId, co
     'course': Joi.object().required(),
     'profileInfo': Joi.object().keys({
       'canvas_course_role': Joi.string().required(),
+      'canvas_course_sections': Joi.array().items(Joi.string()).optional(),
       'canvas_enrollment_state': Joi.string().valid(_.values(CollabosphereConstants.ENROLLMENT_STATE)).required(),
       'canvas_full_name': Joi.string().required(),
       'canvas_image': Joi.string().allow('').optional(),
@@ -419,6 +420,7 @@ var updateUsers = module.exports.updateUsers = function(userIds, update, callbac
     'userIds': Joi.array().unique().min(1).items(Joi.number()),
     'update': Joi.object().min(1).keys({
       'canvas_course_role': Joi.string().optional(),
+      'canvas_course_sections': Joi.array().items(Joi.string()).optional(),
       'canvas_enrollment_state': Joi.string().optional(),
       'canvas_full_name': Joi.string().optional(),
       'canvas_image': Joi.string().optional()

--- a/node_modules/col-users/lib/constants.js
+++ b/node_modules/col-users/lib/constants.js
@@ -24,7 +24,7 @@
  */
 
 var Constants = module.exports = {
-  'BASIC_USER_FIELDS': ['id', 'canvas_user_id', 'canvas_course_role', 'canvas_enrollment_state', 'canvas_full_name', 'canvas_image'],
+  'BASIC_USER_FIELDS': ['id', 'canvas_user_id', 'canvas_course_role', 'canvas_course_sections', 'canvas_enrollment_state', 'canvas_full_name', 'canvas_image'],
   'EMAIL_FIELDS': ['canvas_email'],
   'POINTS_USER_FIELDS': ['id', 'canvas_user_id', 'canvas_course_role', 'canvas_enrollment_state', 'canvas_full_name', 'canvas_image', 'points', 'share_points', 'last_activity']
 };

--- a/node_modules/col-users/tests/util.js
+++ b/node_modules/col-users/tests/util.js
@@ -91,6 +91,7 @@ var assertMe = module.exports.assertMe = function(me, opts) {
     assert.strictEqual(me.canvas_user_id, opts.expectedMe.canvas_user_id);
     assert.strictEqual(me.course_id, opts.expectedMe.course_id);
     assert.strictEqual(me.canvas_course_role, opts.expectedMe.canvas_course_role);
+    assert.strictEqual(me.canvas_course_sections, opts.expectedMe.canvas_course_sections);
     assert.strictEqual(me.canvas_full_name, opts.expectedMe.canvas_full_name);
     assert.strictEqual(me.bookmarklet_token, opts.expectedMe.bookmarklet_token);
     assert.strictEqual(me.created_at, opts.expectedMe.created_at);
@@ -167,6 +168,7 @@ var assertUser = module.exports.assertUser = function(user, opts) {
   if (opts.expectedUser) {
     assert.strictEqual(user.id, opts.expectedUser.id);
     assert.strictEqual(user.canvas_course_role, opts.expectedUser.canvas_course_role);
+    assert.deepEqual(user.canvas_course_sections, opts.expectedUser.canvas_course_sections);
     assert.strictEqual(user.canvas_full_name, opts.expectedUser.canvas_full_name);
     assert.strictEqual(user.points, opts.expectedUser.points);
     assert.strictEqual(user.share_points, opts.expectedUser.share_points);
@@ -187,7 +189,7 @@ var assertUser = module.exports.assertUser = function(user, opts) {
  *
  * @param  {Client}             client              The REST client to make the request with
  * @param  {Course}             course              The Canvas course the user is launched in
- * @param  {Me}                 [expectedMe]        The expected Collabosphere user that should be returned
+ * @param  {Me}                 [expectedMe]        The expected user that should be returned
  * @param  {Function}           callback            Standard callback function
  * @param  {Me}                 callback.me         The me data as returned by the API
  * @throws {AssertionError}                         Error thrown when an assertion failed

--- a/node_modules/col-whiteboards/lib/api.js
+++ b/node_modules/col-whiteboards/lib/api.js
@@ -537,7 +537,7 @@ var editWhiteboard = module.exports.editWhiteboard = function(ctx, id, title, me
  * @param  {Function}       callback                        Standard callback function
  * @param  {Object}         callback.err                    An error that occurred, if any
  */
-var deleteWhiteboard = module.exports.deleteWhiteboard = function(ctx, id, callback) {  
+var deleteWhiteboard = module.exports.deleteWhiteboard = function(ctx, id, callback) {
   // Ensure that the whiteboard exists and the user is allowed to access it
   getBasicWhiteboard(ctx, id, function(err, whiteboard) {
     if (err) {
@@ -903,7 +903,7 @@ var whiteboardAddActivity = function(socket, elements, callback) {
           if (err) {
             return callback(err);
           }
-        
+
           // Create `get_whiteboard_add_asset` points for asset creators.
           var doneWithUser = _.after(asset.users.length, done);
           var doneWithError = _.once(done);
@@ -2105,7 +2105,7 @@ var createWhiteboardFromExport = module.exports.createWhiteboardFromExport = fun
       }
 
       return getWhiteboardProfile(ctx, whiteboard.id, callback);
-    });    
+    });
   });
 };
 

--- a/public/app/dashboard/profile.html
+++ b/public/app/dashboard/profile.html
@@ -19,7 +19,7 @@
           tabindex="-1"></oi-select>
       </div>
       <div>
-        Write4Change (St. Paul, Minnesota, USA)
+        <span data-ng-repeat="section in canvasCourseSections"><span data-ng-if="canvasCourseSections.length > 1"><span data-ng-if="!$first && !$last">, </span><span data-ng-if="$last"> and </span></span>{{section}}</span>
       </div>
       <div class="profile-summary-last-activity">
         Last activity:

--- a/public/app/dashboard/profileController.js
+++ b/public/app/dashboard/profileController.js
@@ -129,6 +129,7 @@
     var loadProfile = function(user) {
       $scope.isMyProfile = user.id === me.id;
       $scope.user = user;
+      $scope.canvasCourseSections = user.canvas_course_sections && user.canvas_course_sections.sort();
       $scope.showEngagementIndexBox = me.course.engagementindex_url && ($scope.isMyProfile || me.is_admin || (user.share_points && me.share_points));
       determineRank(user);
       if ($scope.isMyProfile || me.is_admin) {

--- a/scripts/20170501-col820/add_sections_to_users.sql
+++ b/scripts/20170501-col820/add_sections_to_users.sql
@@ -1,0 +1,7 @@
+-- A user can be enrolled in one or more sections
+
+ALTER TABLE users ADD canvas_course_sections varchar(255)[];
+
+/**** ROLLBACK ****
+
+ALTER TABLE users DROP canvas_course_sections;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-845

Each user will have zero or more sections per course. Requires new Canvas API call: `/api/v1/courses/%d/sections?include[]=students`. When available, section names are displayed on profile page. UX tweaks may follow.
