### PR TITLE
COL-846 Do not pass null email to users API

### DIFF
--- a/node_modules/col-canvas/lib/poller.js
+++ b/node_modules/col-canvas/lib/poller.js
@@ -393,11 +393,13 @@ var handleUser = function(ctx, users, canvasUser, callback) {
   var defaults = {
     'canvas_course_role': courseRole,
     'canvas_enrollment_state': enrollmentState,
-    'canvas_full_name': canvasUser.name,
-    'canvas_email': canvasUser.email
+    'canvas_full_name': canvasUser.name
   };
   if (image) {
     defaults.canvas_image = image;
+  }
+  if (email) {
+    defaults.canvas_email = email;
   }
   UsersAPI.getOrCreateUser(canvasUser.id, ctx.course, defaults, function(err, user) {
     if (err) {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-846

Superstrict validation in col-users/lib/api.js says that undefined email is OK, null email is not. Make the poller honor the contract.