### PR TITLE
COL-857, use 'npm test' to run mocha; drop gulp-mocha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,6 @@ before_install:
   - psql collabospheretravis -c 'create extension pg_trgm;' -U postgres
 
 script:
-  - node_modules/.bin/gulp test-travis
+  - node_modules/.bin/gulp csslint
+  - node_modules/.bin/gulp eslint
+  - NODE_ENV=travis npm test

--- a/README.md
+++ b/README.md
@@ -89,8 +89,20 @@ export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig
 
 ## In your development environment
 
+Download and run [the install script](https://github.com/ets-berkeley-edu/suitec-ops/blob/master/scripts/install-locally.sh).
+
+### Perform tests
+
 ```
-npm install
+node_modules/.bin/gulp csslint
+node_modules/.bin/gulp eslint
+NODE_ENV=test npm test
+
+```
+
+### Start the application
+
+```
 node app
 ```
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,7 +36,6 @@ var gulp = require('gulp');
 var imagemin = require('gulp-imagemin');
 var install = require('gulp-install');
 var minifyHtml = require('gulp-htmlmin');
-var mocha = require('gulp-mocha');
 var ngAnnotate = require('gulp-ng-annotate');
 var rev = require('gulp-rev');
 var revReplace = require('gulp-rev-replace');
@@ -288,40 +287,3 @@ gulp.task('csslint', function() {
     }))
     .pipe(csslint.formatter());
 });
-
-/**
- * Run the Mocha test suite
- */
-gulp.task('mocha', function() {
-  return gulp
-    .src(['node_modules/col-tests/lib/beforeTests.js', 'node_modules/col-*/tests/**/*.js'])
-    .pipe(mocha({
-      'fullStackTrace': true,
-      'grep': process.env.MOCHA_GREP,
-      'timeout': 10000
-    }))
-    .once('end', function() {
-      process.exit();
-    });
-});
-
-/**
- * Run the full Collabosphere test suite
- */
-gulp.task('test', function() {
-  // Set the environment to `test`
-  process.env.NODE_ENV = 'test';
-
-  runSequence('eslint', 'csslint', 'mocha');
-});
-
-/**
- * Run the full Collabosphere TravisCI test suite (including code coverage)
- */
-gulp.task('test-travis', function() {
-  // Set the environment to `travis`
-  process.env.NODE_ENV = 'travis';
-
-  runSequence('eslint', 'csslint', 'mocha');
-});
-

--- a/package.json
+++ b/package.json
@@ -41,11 +41,10 @@
     "gulp-imagemin": "3.1.1",
     "gulp-install": "1.1.0",
     "gulp-htmlmin": "3.0.0",
-    "gulp-mocha": "3.0.1",
     "gulp-ng-annotate": "2.0.0",
     "gulp-rev": "7.1.2",
     "gulp-rev-replace": "0.4.3",
-    "gulp-uglify": "2.0.1",
+    "gulp-uglify": "2.1.2",
     "gulp-usemin": "0.3.28",
     "ims-lti": "3.0.2",
     "joi": "10.2.0",
@@ -53,6 +52,7 @@
     "lodash": "4.17.4",
     "mime": "1.3.4",
     "mixpanel": "0.6.0",
+    "mocha": "3.3.0",
     "moment-timezone": "0.5.11",
     "node-sass": "4.4.0",
     "oauth": "0.9.15",
@@ -87,7 +87,7 @@
   ],
   "scripts": {
     "pretest": "test -f logs/test.log && rm logs/test.log || echo 'No test log to remove'",
-    "test": "gulp test"
+    "test": "mocha --full-trace --timeout 10000 node_modules/col-tests/lib/beforeTests.js node_modules/col-*/tests/**/*.js"
   },
   "engines": {
     "node": ">=6.9"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-857

Steps:
`npm test` 
or `npm test -- --grep "run tests with this pattern"`
or `npm test -- -g "run tests with this pattern"`

It's likely you'll put `NODE_ENV=test` prior to commands above.
 
Command line args are documented at https://mochajs.org