### PR TITLE
COL-861 Derive asset impact score from "active" activities

### DIFF
--- a/node_modules/col-activities/lib/default.js
+++ b/node_modules/col-activities/lib/default.js
@@ -28,6 +28,7 @@ var Default = module.exports = [
     'type': 'view_asset',
     'title': 'View an asset in the Asset Library',
     'points': 0,
+    'impact': 2,
     'enabled': true
   },
   {
@@ -40,6 +41,7 @@ var Default = module.exports = [
     'type': 'like',
     'title': 'Like an asset in the Asset Library',
     'points': 1,
+    'impact': 3,
     'enabled': true
   },
   {
@@ -52,14 +54,12 @@ var Default = module.exports = [
     'type': 'get_view_asset',
     'title': 'Receive a view in the Asset Library',
     'points': 0,
-    'impact': 2,
     'enabled': true
   },
   {
     'type': 'get_like',
     'title': 'Receive a like in the Asset Library',
     'points': 1,
-    'impact': 3,
     'enabled': true
   },
   {
@@ -72,13 +72,13 @@ var Default = module.exports = [
     'type': 'asset_comment',
     'title': 'Comment on an asset in the Asset Library',
     'points': 3,
+    'impact': 6,
     'enabled': true
   },
   {
     'type': 'get_asset_comment',
     'title': 'Receive a comment in the Asset Library',
     'points': 1,
-    'impact': 6,
     'enabled': true
   },
   {
@@ -121,13 +121,13 @@ var Default = module.exports = [
     'type': 'whiteboard_add_asset',
     'title': 'Add an asset to a whiteboard',
     'points': 0,
+    'impact': 8,
     'enabled': true
   },
   {
     'type': 'get_whiteboard_add_asset',
     'title': 'Have one\'s asset added to a whiteboard',
     'points': 0,
-    'impact': 8,
     'enabled': true
   },
   {
@@ -140,13 +140,13 @@ var Default = module.exports = [
     'type': 'remix_whiteboard',
     'title': 'Remix a whiteboard',
     'points': 0,
+    'impact': 10,
     'enabled': true
   },
   {
     'type': 'get_remix_whiteboard',
     'title': 'Have one\'s whiteboard remixed',
     'points': 0,
-    'impact': 10,
     'enabled': true
   }
 ];

--- a/node_modules/col-activities/tests/test-points.js
+++ b/node_modules/col-activities/tests/test-points.js
@@ -518,7 +518,7 @@ describe('Activity Points', function() {
      */
     it('updates the points', function(callback) {
       // Create an exported whiteboard and two users
-      AssetsTestUtil.setupExportedWhiteboard(function(creatorClient, course, creatorUser, exportedWhiteboard) {   
+      AssetsTestUtil.setupExportedWhiteboard(function(creatorClient1, creatorClient2, course, creatorUser1, creatorClient2, exportedWhiteboard) {   
         TestsUtil.getAssetLibraryClient(null, course, null, function(remixerClient, course, remixerUser) {
 
           // Define activity points for whiteboard remixes
@@ -537,10 +537,10 @@ describe('Activity Points', function() {
             ActivitiesTestUtil.assertEditActivityTypeConfiguration(instructorClient, course, activityTypeOverride, function() {
 
               // Verify that remixing another user's whiteboard generates activity and points
-              ActivitiesTestUtil.assertRemixWhiteboardActivities(remixerClient, creatorClient, course, exportedWhiteboard, function() {
+              ActivitiesTestUtil.assertRemixWhiteboardActivities(remixerClient, course, exportedWhiteboard, function() {
 
                 // Verify that remixing one's own whiteboard generates activity points as remixer but not as creator
-                ActivitiesTestUtil.assertRemixWhiteboardActivities(creatorClient, creatorClient, course, exportedWhiteboard, function() {
+                ActivitiesTestUtil.assertRemixWhiteboardActivities(creatorClient1, course, exportedWhiteboard, function() {
 
                   return callback();
                 });

--- a/node_modules/col-activities/tests/test-types.js
+++ b/node_modules/col-activities/tests/test-types.js
@@ -187,22 +187,22 @@ describe('Activity Types', function() {
 
         // Override multiple activity types
         var activityTypeOverride = [
-          {'type': 'get_asset_comment', 'points': 40, 'enabled': false},
-          {'type': 'get_remix_whiteboard', 'points': 50, 'enabled': false}
+          {'type': 'asset_comment', 'points': 40, 'enabled': false},
+          {'type': 'remix_whiteboard', 'points': 50, 'enabled': false}
         ];
         ActivitiesTestsUtil.assertEditActivityTypeConfiguration(client, course, activityTypeOverride, function() {
           ActivitiesTestsUtil.assertGetActivityTypeConfiguration(client, course, function(configuration) {
 
             // Verify that 'points' and 'enabled' have changed, but 'impact' has not
-            var getAssetCommentActivityType = _.find(configuration, {'type': 'get_asset_comment'});
-            assert.strictEqual(getAssetCommentActivityType.points, 40);
-            assert.strictEqual(getAssetCommentActivityType.enabled, false);
-            assert.strictEqual(getAssetCommentActivityType.impact, 6);
+            var assetCommentActivityType = _.find(configuration, {'type': 'asset_comment'});
+            assert.strictEqual(assetCommentActivityType.points, 40);
+            assert.strictEqual(assetCommentActivityType.enabled, false);
+            assert.strictEqual(assetCommentActivityType.impact, 6);
 
-            var getRemixWhiteboardActivityType = _.find(configuration, {'type': 'get_remix_whiteboard'});
-            assert.strictEqual(getRemixWhiteboardActivityType.points, 50);
-            assert.strictEqual(getRemixWhiteboardActivityType.enabled, false);
-            assert.strictEqual(getRemixWhiteboardActivityType.impact, 10);
+            var remixWhiteboardActivityType = _.find(configuration, {'type': 'remix_whiteboard'});
+            assert.strictEqual(remixWhiteboardActivityType.points, 50);
+            assert.strictEqual(remixWhiteboardActivityType.enabled, false);
+            assert.strictEqual(remixWhiteboardActivityType.impact, 10);
 
             return callback();
           });

--- a/node_modules/col-activities/tests/util.js
+++ b/node_modules/col-activities/tests/util.js
@@ -296,7 +296,7 @@ var assertCreateCommentActivity = module.exports.assertCreateCommentActivity = f
     var assetCommentPoints = _.find(configuration, {'type': 'asset_comment'}).points;
     var getAssetCommentPoints = _.find(configuration, {'type': 'get_asset_comment'}).points;
     var getAssetCommentReplyPoints = _.find(configuration, {'type': 'get_asset_comment_reply'}).points;
-    var getAssetCommentImpact = _.find(configuration, {'type': 'get_asset_comment'}).impact;
+    var assetCommentImpact = _.find(configuration, {'type': 'asset_comment'}).impact;
 
     // Get the me object for the various users
     UsersTestUtil.assertGetMe(commenterClient, course, null, function(commenterMe) {
@@ -323,7 +323,7 @@ var assertCreateCommentActivity = module.exports.assertCreateCommentActivity = f
                 // A commenter who creates a top-level comment on another user's asset
                 } else {
                   // Impact score should increment
-                  assert.strictEqual(updatedImpactScore, initialImpactScore + getAssetCommentImpact);
+                  assert.strictEqual(updatedImpactScore, initialImpactScore + assetCommentImpact);
                   assertPoints(commenterClient, course, commenterMe, assetCommentPoints, true, function() {
                     var done = _.after(creatorClients.length, callback);
                     _.each(creatorMeObjects, function(creatorMe, i) {
@@ -455,7 +455,7 @@ var assertCreateReplyActivity = module.exports.assertCreateReplyActivity = funct
     var assetCommentPoints = _.find(configuration, {'type': 'asset_comment'}).points;
     var getAssetCommentPoints = _.find(configuration, {'type': 'get_asset_comment'}).points;
     var getAssetCommentReplyPoints = _.find(configuration, {'type': 'get_asset_comment_reply'}).points;
-    var getAssetCommentImpact = _.find(configuration, {'type': 'get_asset_comment'}).impact;
+    var assetCommentImpact = _.find(configuration, {'type': 'asset_comment'}).impact;
 
     // Get the me object for the various users
     UsersTestUtil.assertGetMe(commenterClient, course, null, function(commenterMe) {
@@ -489,7 +489,7 @@ var assertCreateReplyActivity = module.exports.assertCreateReplyActivity = funct
                       var expectedIncrease = getAssetCommentReplyPoints;
 
                       // Impact score should increment
-                      assert.strictEqual(updatedImpactScore, initialImpactScore + getAssetCommentImpact);
+                      assert.strictEqual(updatedImpactScore, initialImpactScore + assetCommentImpact);
 
                       // If the parent commenter is also an asset owner, points should be added for getting
                       // a comment on the asset
@@ -504,7 +504,7 @@ var assertCreateReplyActivity = module.exports.assertCreateReplyActivity = funct
                   } else if (!commenterIsCreator && commenterMe.id === parentMe.id) {
 
                     // Impact score should increment
-                    assert.strictEqual(updatedImpactScore, initialImpactScore + getAssetCommentImpact);
+                    assert.strictEqual(updatedImpactScore, initialImpactScore + assetCommentImpact);
 
                     assertPoints(commenterClient, course, commenterMe, assetCommentPoints, true, function() {
                       var done = _.after(creatorClients.length, callback);
@@ -518,7 +518,7 @@ var assertCreateReplyActivity = module.exports.assertCreateReplyActivity = funct
                   } else if (!commenterIsCreator && commenterMe.id !== parentMe.id && parentCommenterIsCreator) {
 
                     // Impact score should increment
-                    assert.strictEqual(updatedImpactScore, initialImpactScore + getAssetCommentImpact);
+                    assert.strictEqual(updatedImpactScore, initialImpactScore + assetCommentImpact);
 
                     assertPoints(commenterClient, course, commenterMe, assetCommentPoints, true, function() {
                       assertPoints(parentClient, course, parentMe, getAssetCommentReplyPoints + getAssetCommentPoints, false, callback);
@@ -529,7 +529,7 @@ var assertCreateReplyActivity = module.exports.assertCreateReplyActivity = funct
                   } else if (!commenterIsCreator && commenterMe.id !== parentMe.id && !parentCommenterIsCreator) {
 
                     // Impact score should increment
-                    assert.strictEqual(updatedImpactScore, initialImpactScore + getAssetCommentImpact);
+                    assert.strictEqual(updatedImpactScore, initialImpactScore + assetCommentImpact);
 
                     assertPoints(commenterClient, course, commenterMe, assetCommentPoints, true, function() {
                       assertPoints(parentClient, course, parentMe, getAssetCommentReplyPoints, false, function() {
@@ -566,7 +566,7 @@ var assertDeleteCommentActivity = module.exports.assertDeleteCommentActivity = f
   assertGetActivityTypeConfiguration(commenterClient, course, function(configuration) {
     var assetCommentPoints = _.find(configuration, {'type': 'asset_comment'}).points;
     var getAssetCommentPoints = _.find(configuration, {'type': 'get_asset_comment'}).points;
-    var getAssetCommentImpact = _.find(configuration, {'type': 'get_asset_comment'}).impact;
+    var assetCommentImpact = _.find(configuration, {'type': 'asset_comment'}).impact;
 
     // Get the me object for both users
     UsersTestUtil.assertGetMe(commenterClient, course, null, function(commenterMe) {
@@ -592,7 +592,7 @@ var assertDeleteCommentActivity = module.exports.assertDeleteCommentActivity = f
               // A comment who deletes their comment on another user's asset
               } else {
                 // Impact score should decrement
-                assert.strictEqual(updatedImpactScore, initialImpactScore - getAssetCommentImpact);
+                assert.strictEqual(updatedImpactScore, initialImpactScore - assetCommentImpact);
 
                 assertPoints(commenterClient, course, commenterMe, -1 * assetCommentPoints, false, function() {
                   assertPoints(creatorClient, course, creatorMe, -1 * getAssetCommentPoints, false, callback);
@@ -624,7 +624,7 @@ var assertDeleteReplyActivity = module.exports.assertDeleteReplyActivity = funct
     var assetCommentPoints = _.find(configuration, {'type': 'asset_comment'}).points;
     var getAssetCommentPoints = _.find(configuration, {'type': 'get_asset_comment'}).points;
     var getAssetCommentReplyPoints = _.find(configuration, {'type': 'get_asset_comment_reply'}).points;
-    var getAssetCommentImpact = _.find(configuration, {'type': 'get_asset_comment'}).impact;
+    var assetCommentImpact = _.find(configuration, {'type': 'asset_comment'}).impact;
 
     // Get the me object for all users
     UsersTestUtil.assertGetMe(commenterClient, course, null, function(commenterMe) {
@@ -652,7 +652,7 @@ var assertDeleteReplyActivity = module.exports.assertDeleteReplyActivity = funct
                   // A commenter who deletes a reply to a comment of someone else on their own asset
                   } else if (commenterMe.id === creatorMe.id && commenterMe.id !== parentMe.id) {
                     // Impact score should decrement
-                    assert.strictEqual(updatedImpactScore, initialImpactScore - getAssetCommentImpact);
+                    assert.strictEqual(updatedImpactScore, initialImpactScore - assetCommentImpact);
                     assertPoints(commenterClient, course, commenterMe, -1 * (assetCommentPoints + getAssetCommentPoints), false, function() {
                       assertPoints(parentClient, course, parentMe, -1 * getAssetCommentReplyPoints, false, callback);
                     });
@@ -660,7 +660,7 @@ var assertDeleteReplyActivity = module.exports.assertDeleteReplyActivity = funct
                   // A commenter who deleted a reply to their own comment on another user's asset
                   } else if (commenterMe.id !== creatorMe.id && commenterMe.id === parentMe.id) {
                     // Impact score should decrement
-                    assert.strictEqual(updatedImpactScore, initialImpactScore - getAssetCommentImpact);
+                    assert.strictEqual(updatedImpactScore, initialImpactScore - assetCommentImpact);
                     // Commenter activity timestamp is incremented for the 'view' activity; creator activity timestamp is not.
                     assertPoints(commenterClient, course, commenterMe, -1 * assetCommentPoints, true, function() {
                       assertPoints(creatorClient, course, creatorMe, -1 * getAssetCommentPoints, false, callback);
@@ -670,7 +670,7 @@ var assertDeleteReplyActivity = module.exports.assertDeleteReplyActivity = funct
                   // creator is the same user as the parent commenter
                   } else if (commenterMe.id !== creatorMe.id && commenterMe.id !== parentMe.id && parentMe.id === creatorMe.id) {
                     // Impact score should decrement
-                    assert.strictEqual(updatedImpactScore, initialImpactScore - getAssetCommentImpact);
+                    assert.strictEqual(updatedImpactScore, initialImpactScore - assetCommentImpact);
                     // Commenter activity timestamp is incremented for the 'view' activity; creator activity timestamp is not.
                     assertPoints(commenterClient, course, commenterMe, -1 * assetCommentPoints, true, function() {
                       assertPoints(parentClient, course, parentMe, -1 * (getAssetCommentReplyPoints + getAssetCommentPoints), false, callback);
@@ -680,7 +680,7 @@ var assertDeleteReplyActivity = module.exports.assertDeleteReplyActivity = funct
                   // creator is different from the parent commenter
                   } else if (commenterMe.id !== creatorMe.id && commenterMe.id !== parentMe.id && parentMe.id !== creatorMe.id) {
                     // Impact score should decrement
-                    assert.strictEqual(updatedImpactScore, initialImpactScore - getAssetCommentImpact);
+                    assert.strictEqual(updatedImpactScore, initialImpactScore - assetCommentImpact);
                     // Commenter activity timestamp is incremented for the 'view' activity; creator activity timestamp is not.
                     assertPoints(commenterClient, course, commenterMe, -1 * assetCommentPoints, true, function() {
                       assertPoints(parentClient, course, parentMe, -1 * getAssetCommentReplyPoints, false, function() {
@@ -716,8 +716,8 @@ var assertLikeActivity = module.exports.assertLikeActivity = function(likerClien
     var dislikePoints = _.find(configuration, {'type': 'dislike'}).points;
     var getLikePoints = _.find(configuration, {'type': 'get_like'}).points;
     var getDislikePoints = _.find(configuration, {'type': 'get_dislike'}).points;
-    var getLikeImpact = _.find(configuration, {'type': 'get_like'}).impact;
-    var getViewImpact = _.find(configuration, {'type': 'get_view_asset'}).impact;
+    var likeImpact = _.find(configuration, {'type': 'like'}).impact;
+    var viewImpact = _.find(configuration, {'type': 'view_asset'}).impact;
 
     // Get the me object for the user liking or disliking the asset
     UsersTestUtil.assertGetMe(likerClient, course, null, function(likerMe) {
@@ -741,7 +741,7 @@ var assertLikeActivity = module.exports.assertLikeActivity = function(likerClien
                   // No point changes are expected
                   if (like === null) {
                     // Impact score increments for views but not likes
-                    assert.strictEqual(updatedImpactScore, initialImpactScore + (2 * getViewImpact));
+                    assert.strictEqual(updatedImpactScore, initialImpactScore + (2 * viewImpact));
                     // The liker client has an updated timestamp from the view activity, but no updated points
                     assertPoints(likerClient, course, likerMe, 0, true, function() {
                       // The creator client has no updated points or timestamp
@@ -750,7 +750,7 @@ var assertLikeActivity = module.exports.assertLikeActivity = function(likerClien
                   // Points for liking are expected to be rewarded to the user liking and the user receiving the like
                   } else if (like === true) {
                     // Impact score increments for views and likes
-                    assert.strictEqual(updatedImpactScore, initialImpactScore + (2 * getViewImpact) + getLikeImpact);
+                    assert.strictEqual(updatedImpactScore, initialImpactScore + (2 * viewImpact) + likeImpact);
                     assertPoints(likerClient, course, likerMe, likePoints, true, function() {
                       assertPoints(creatorClient, course, creatorMe, getLikePoints, false, callback);
                     });
@@ -765,7 +765,7 @@ var assertLikeActivity = module.exports.assertLikeActivity = function(likerClien
                   // Points for liking are expected to be removed from the user that liked and the user that received the like
                   if (like === null) {
                     // Impact score is incremented for views but the like is decremented
-                    assert.strictEqual(updatedImpactScore, initialImpactScore + (2 * getViewImpact) - getLikeImpact);
+                    assert.strictEqual(updatedImpactScore, initialImpactScore + (2 * viewImpact) - likeImpact);
                     // The liker client has an updated timestamp from the view activity, but no updated points
                     assertPoints(likerClient, course, likerMe, -likePoints, true, function() {
                       // The creator client has no updated points or timestamp
@@ -774,7 +774,7 @@ var assertLikeActivity = module.exports.assertLikeActivity = function(likerClien
                   // No point changes are expected
                   } else if (like === true) {
                     // Impact score increments for views but not likes
-                    assert.strictEqual(updatedImpactScore, initialImpactScore + (2 * getViewImpact));
+                    assert.strictEqual(updatedImpactScore, initialImpactScore + (2 * viewImpact));
                     assertPoints(likerClient, course, likerMe, 0, true, function() {
                       assertPoints(creatorClient, course, creatorMe, 0, false, callback);
                     });
@@ -831,7 +831,7 @@ var assertViewAssetActivity = module.exports.assertViewAssetActivity = function(
   assertGetActivityTypeConfiguration(viewerClient, course, function(configuration) {
     var viewPoints = _.find(configuration, {'type': 'view_asset'}).points;
     var getViewPoints = _.find(configuration, {'type': 'get_view_asset'}).points;
-    var getViewImpact = _.find(configuration, {'type': 'get_view_asset'}).impact;
+    var viewImpact = _.find(configuration, {'type': 'view_asset'}).impact;
 
     // Get the me object for the user viewing the asset
     UsersTestUtil.assertGetMe(viewerClient, course, null, function(viewerMe) {
@@ -860,7 +860,7 @@ var assertViewAssetActivity = module.exports.assertViewAssetActivity = function(
               // If viewer is not among asset creators
               } else {
                 // Asset recieves impact score
-                assert.strictEqual(updatedImpactScore, initialImpactScore + getViewImpact);
+                assert.strictEqual(updatedImpactScore, initialImpactScore + viewImpact);
                 // Viewer's points are changed (or not changed if viewPoints is 0) and last_activity timestamp is updated
                 assertPoints(viewerClient, course, viewerMe, viewPoints, true, function() {
                   // Creator's points are changed (or not changed if getViewPoints is 0) and last_activity timestamp is not updated
@@ -879,48 +879,44 @@ var assertViewAssetActivity = module.exports.assertViewAssetActivity = function(
  * Assert that a whiteboard can be remixed and activity points are earned
  *
  * @param  {RestClient}         remixerClient                   The REST client representing the user viewing the asset
- * @param  {RestClient}         creatorClient                   The REST client representing the user that created the asset
  * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
  * @param  {Number}             exportedWhiteboard              The exported whiteboard asset
  * @param  {Function}           callback                        Standard callback function
  * @throws {AssertionError}                                     Error thrown when an assertion failed
  */
-var assertRemixWhiteboardActivities = module.exports.assertRemixWhiteboardActivities = function(remixerClient, creatorClient, course, exportedWhiteboard, callback) {
+var assertRemixWhiteboardActivities = module.exports.assertRemixWhiteboardActivities = function(remixerClient, course, exportedWhiteboard, callback) {
   // Get the points and impact score earned when remixing a whitebaord
   assertGetActivityTypeConfiguration(remixerClient, course, function(configuration) {
     var remixPoints = _.find(configuration, {'type': 'remix_whiteboard'}).points;
     var getRemixPoints = _.find(configuration, {'type': 'get_remix_whiteboard'}).points;
-    var getRemixImpact = _.find(configuration, {'type': 'get_remix_whiteboard'}).impact;
+    var remixImpact = _.find(configuration, {'type': 'remix_whiteboard'}).impact;
 
     // Get the me object for the user remixing the asset
     UsersTestUtil.assertGetMe(remixerClient, course, null, function(remixerMe) {
-      // Get the me object for the asset creator
-      UsersTestUtil.assertGetMe(creatorClient, course, null, function(creatorMe) {
 
-        // Get the whiteboard asset's initial impact score from the database
-        AssetsTestUtil.getDbAsset(exportedWhiteboard.id, function(dbAsset) {
-          var initialImpactScore = dbAsset.impact_score;
+      // Get the whiteboard asset's initial impact score from the database
+      AssetsTestUtil.getDbAsset(exportedWhiteboard.id, function(dbAsset) {
+        var initialImpactScore = dbAsset.impact_score;
 
-          // Remix the exported whiteboard and get the updated impact score
-          AssetsTestUtil.assertRemixWhiteboard(remixerClient, course, exportedWhiteboard, function() {
-            AssetsTestUtil.getDbAsset(exportedWhiteboard.id, function(dbAsset) {
-              var updatedImpactScore = dbAsset.impact_score;
+        // Remix the exported whiteboard and get the updated impact score
+        AssetsTestUtil.assertRemixWhiteboard(remixerClient, course, exportedWhiteboard, function() {
+          AssetsTestUtil.getDbAsset(exportedWhiteboard.id, function(dbAsset) {
+            var updatedImpactScore = dbAsset.impact_score;
 
-              // If remixer is among asset creators
-              if (_.find(exportedWhiteboard.users, {'id': remixerMe.id})) {
-                // Asset recieves no impact score
-                assert.strictEqual(updatedImpactScore, initialImpactScore);
-                // Remixer gets points for performing the remix, but not for receiving the remix
-                assertPoints(remixerClient, course, remixerMe, remixPoints, true, callback);
+            // If remixer is among asset creators
+            if (_.find(exportedWhiteboard.users, {'id': remixerMe.id})) {
+              // Asset recieves no impact score
+              assert.strictEqual(updatedImpactScore, initialImpactScore);
+              // Remixer gets no points for performing the remix and no activity is created
+              assertPoints(remixerClient, course, remixerMe, 0, false, callback);
 
-              // If remixer is not among asset creators
-              } else {
-                // Asset recieves impact score
-                assert.strictEqual(updatedImpactScore, initialImpactScore + getRemixImpact);
-                // Remixer's points are changed (or not changed if remixPoints is 0) and last_activity timestamp is updated
-                assertPoints(remixerClient, course, remixerMe, remixPoints, true, callback);
-              }
-            });
+            // If remixer is not among asset creators
+            } else {
+              // The asset's impact score is incremented only once although there are multiple creators
+              assert.strictEqual(updatedImpactScore, initialImpactScore + remixImpact);
+              // Remixer's points are changed (or not changed if remixPoints is 0) and last_activity timestamp is updated
+              assertPoints(remixerClient, course, remixerMe, remixPoints, true, callback);
+            }
           });
         });
       });

--- a/node_modules/col-assets/lib/api.js
+++ b/node_modules/col-assets/lib/api.js
@@ -2011,6 +2011,12 @@ var createWhiteboardFromAsset = module.exports.createWhiteboardFromAsset = funct
 
       var metadata = {'whiteboard_id': whiteboard.id};
 
+      // If the user is remixing their own whiteboard, do not assign points or create activities.
+      var isAssetOwner = _.find(asset.users, {'id': ctx.user.id});
+      if (isAssetOwner) {
+        return callback(null, whiteboard);
+      }
+
       ActivitiesAPI.createActivity(ctx.course, ctx.user, 'remix_whiteboard', asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, metadata, null, function(err) {
         if (err) {
           log.error({'user': ctx.user, 'err': err}, 'Failed to create a remix_whiteboard activity');

--- a/node_modules/col-assets/tests/test-assets.js
+++ b/node_modules/col-assets/tests/test-assets.js
@@ -1503,8 +1503,8 @@ describe('Assets', function() {
      * Test that verifies that an exported whiteboard asset can be remixed
      */
     it('can be remixed', function(callback) {
-      AssetsTestUtil.setupExportedWhiteboard(function(client, course, user, exportedWhiteboard) {       
-        AssetsTestUtil.assertRemixWhiteboard(client, course, exportedWhiteboard, function() {
+      AssetsTestUtil.setupExportedWhiteboard(function(client1, client2, course, user1, user2, exportedWhiteboard) {       
+        AssetsTestUtil.assertRemixWhiteboard(client1, course, exportedWhiteboard, function() {
 
           return callback();
         });
@@ -1529,16 +1529,16 @@ describe('Assets', function() {
      * Test that verifies authorization when remixing an exported whiteboard
      */
     it('verifies authorization', function(callback) {
-      AssetsTestUtil.setupExportedWhiteboard(function(client, course, user, exportedWhiteboard) {       
+      AssetsTestUtil.setupExportedWhiteboard(function(client1, client2, course, user1, user2, exportedWhiteboard) {       
 
         // Verify that a user in a different course can't remix the whiteboard
-        TestsUtil.getAssetLibraryClient(null, null, null, function(client2, course2, user2) {
-          AssetsTestUtil.assertRemixWhiteboardFails(client2, course2, exportedWhiteboard, 404, function() {
+        TestsUtil.getAssetLibraryClient(null, null, null, function(foreignClient, foreignCourse, foreignUser) {
+          AssetsTestUtil.assertRemixWhiteboardFails(foreignClient, foreignCourse, exportedWhiteboard, 404, function() {
 
             // Verify that an administrator in a different course can't remix the whiteboard
             var instructor = TestsUtil.generateInstructor();
-            TestsUtil.getAssetLibraryClient(null, course2, instructor, function(instructorClient, course2, instructor) {
-              AssetsTestUtil.assertRemixWhiteboardFails(instructorClient, course2, exportedWhiteboard, 404, function() {
+            TestsUtil.getAssetLibraryClient(null, foreignCourse, instructor, function(instructorClient, foreignCourse, instructor) {
+              AssetsTestUtil.assertRemixWhiteboardFails(instructorClient, foreignCourse, exportedWhiteboard, 404, function() {
 
                 return callback();
               });

--- a/node_modules/col-assets/tests/util.js
+++ b/node_modules/col-assets/tests/util.js
@@ -1132,7 +1132,7 @@ var assertGetMigratedAsset = module.exports.assertGetMigratedAsset = function(cl
 };
 
 /**
- * Set up a new course and user with an exported whiteboard asset
+ * Set up a new course and two users with an exported whiteboard asset
  *
  * @param  {Function}           callback                        Standard callback function
  * @param  {RestClient}         client                          The REST client for the user
@@ -1141,16 +1141,23 @@ var assertGetMigratedAsset = module.exports.assertGetMigratedAsset = function(cl
  * @param  {Asset}              exportedAsset                   The exported whiteboard asset
  */
 var setupExportedWhiteboard = module.exports.setupExportedWhiteboard = function(callback) {
-  TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
+  TestsUtil.getAssetLibraryClient(null, null, null, function(client1, course, user1) {
+    TestsUtil.getAssetLibraryClient(null, course, null, function(client2, course, user2) {
 
-    // Create a whiteboard and add some elements
-    WhiteboardsTestsUtil.assertCreateWhiteboard(client, course, 'Export me', null, function(whiteboard) {
-      WhiteboardsTestsUtil.addElementsToWhiteboard(client, course, whiteboard, function() {
+      // Create a whiteboard with two members and add some elements
+      UsersTestsUtil.assertGetMe(client1, course, null, function(me1) {
+        UsersTestsUtil.assertGetMe(client2, course, null, function(me2) {
+          WhiteboardsTestsUtil.assertCreateWhiteboard(client1, course, 'Export me', [me1.id, me2.id], function(whiteboard) {
 
-        // Export whiteboard to asset
-        WhiteboardsTestsUtil.assertExportWhiteboardToAsset(client, course, whiteboard.id, null, null, function(exportedAsset) {
-          
-          return callback(client, course, user, exportedAsset);
+            WhiteboardsTestsUtil.addElementsToWhiteboard(client1, course, whiteboard, function() {
+
+              // Export whiteboard to asset
+              WhiteboardsTestsUtil.assertExportWhiteboardToAsset(client1, course, whiteboard.id, null, null, function(exportedAsset) {
+            
+                return callback(client1, client2, course, user1, user2, exportedAsset);
+              });
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
This is an attempt to solve the philosophical problem in https://jira.ets.berkeley.edu/jira/browse/COL-861 without having to change too much logic or modify the database. 

I think the solution is to associate "Impact," for purposes of assets, with "active" activities rather than "passive" activities (we need better terms for this distinction).

"Impact" visualizations for individual users will continue to derive from "passive" activities.