### PR TITLE
COL-744, asset-library-search gets new filter: by Section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - "6.9.1"
 
 addons:
-  postgresql: "9.4"
+  postgresql: "9.5"
   apt:
     sources:
       - ubuntu-toolchain-r-test

--- a/node_modules/col-assets/lib/api.js
+++ b/node_modules/col-assets/lib/api.js
@@ -270,6 +270,7 @@ var addUserToAsset = module.exports.addUserToAsset = function(asset, userId, cal
  * @param  {String}         [filters.keywords]              A string to filter the assets by
  * @param  {Number}         [filters.category]              The id of the category to filter the assets by
  * @param  {Number}         [filters.user]                  The id of the user who created the assets
+ * @param  {String}         [filters.section]               The name of section (i.e., subset of users) to filter assets by
  * @param  {String[]}       [filters.types]                 The type of assets. One or more of `CollabosphereConstants.ASSET.ASSET_TYPES`
  * @param  {Number}         [filters.assignment]            The id of the assignment to which the assets should belong
  * @param  {Number}         [sort]                          A criterion to sort by. Defaults to 'recent' (id descending).
@@ -300,6 +301,7 @@ var getAssets = module.exports.getAssets = function(ctx, filters, sort, limit, o
       'keywords': Joi.string().optional(),
       'category': Joi.number().optional(),
       'user': Joi.number().optional(),
+      'section': Joi.string().optional(),
       'types': Joi.array().items(Joi.string().valid(CollabosphereConstants.ASSET.ASSET_TYPES)).optional(),
       'assignment': Joi.number().optional()
     }),
@@ -327,6 +329,7 @@ var getAssets = module.exports.getAssets = function(ctx, filters, sort, limit, o
     'assignment': filters.assignment,
     'category': filters.category,
     'user': filters.user,
+    'section': filters.section,
     'limit': limit,
     'offset': offset
   };
@@ -335,6 +338,7 @@ var getAssets = module.exports.getAssets = function(ctx, filters, sort, limit, o
                  'LEFT JOIN assets_categories ac ON a.id = ac.asset_id ' +
                  'LEFT JOIN categories c ON c.id = ac.category_id ' +
                  'LEFT JOIN asset_users au ON a.id = au.asset_id ' +
+                 'LEFT JOIN users u ON au.user_id = u.id ' +
                  'LEFT JOIN activities act ON a.id = act.asset_id' +
                  ' AND act.course_id = :course_id' +
                  ' AND act.user_id = :user_id' +
@@ -365,6 +369,10 @@ var getAssets = module.exports.getAssets = function(ctx, filters, sort, limit, o
 
   if (filters.user) {
     sqlQuery += ' AND au.user_id = :user';
+  }
+
+  if (filters.section) {
+    sqlQuery += ' AND (array_position(u.canvas_course_sections, :section) > 0)';
   }
 
   // Query that will be used to get the actual assets

--- a/node_modules/col-assets/lib/rest.js
+++ b/node_modules/col-assets/lib/rest.js
@@ -64,6 +64,7 @@ Collabosphere.apiRouter.get('/assets', function(req, res) {
   var filters = {
     'keywords': req.query.keywords,
     'user': req.query.user,
+    'section': req.query.section,
     'category': req.query.category,
     'types': CollabosphereUtil.toArray(req.query.type)
   };
@@ -74,12 +75,13 @@ Collabosphere.apiRouter.get('/assets', function(req, res) {
     }
 
     // Track the asset search
-    if (filters.keywords || filters.user || filters.category || filters.types.length) {
+    if (filters.keywords || filters.user || filters.section || filters.category || filters.types.length) {
       AnalyticsAPI.track(req.ctx.user, 'Search assets', {
         'offset': assets.offset,
         'total': assets.total,
         'asset_search_keywords': filters.keywords,
         'asset_search_user': filters.user,
+        'asset_search_section': filters.section,
         'asset_search_category': filters.category,
         'asset_search_types': filters.types
       });
@@ -161,7 +163,7 @@ Collabosphere.apiRouter.post('/assets/migrate', function(req, res) {
     // Send a success response.
     res.status(200).send();
 
-    // Perform the migration in the background, executing a no-op callback when complete. 
+    // Perform the migration in the background, executing a no-op callback when complete.
     MigrateAssetsAPI.migrate(req.ctx, toCtx, adminCtx, opts, _.noop);
   });
 });

--- a/node_modules/col-assets/tests/test-assets.js
+++ b/node_modules/col-assets/tests/test-assets.js
@@ -30,6 +30,7 @@ var randomstring = require('randomstring');
 
 var CategoriesTestUtil = require('col-categories/tests/util');
 var CollabosphereConstants = require('col-core/lib/constants');
+var DB = require('col-core/lib/db');
 var TestsUtil = require('col-tests');
 var UsersAPI = require('col-users');
 var UsersTestUtil = require('col-users/tests/util');
@@ -38,6 +39,64 @@ var WhiteboardsTestUtil = require('col-whiteboards/tests/util');
 var AssetsTestUtil = require('./util');
 
 describe('Assets', function() {
+
+  /**
+   * Get course by Canvas course id
+   *
+   * @param  {Number}           canvasCourseId          The id of the course in Canvas
+   * @param  {Function}         callback                Invoked when the course has been retrieved
+   * @param  {Course}           callback.course         The retrieved course object
+   * @throws {AssertionError}                           Error thrown when an assertion failed
+   */
+  var getCourse = function(canvasCourseId, callback) {
+    var options = {
+      'where': {
+        'canvas_course_id': canvasCourseId
+      },
+      'include': [{
+        'model': DB.Canvas,
+        'as': 'canvas'
+      }]
+    };
+    DB.Course.findOne(options).complete(function(err, course) {
+      assert.ok(!err);
+      assert.ok(course);
+
+      return callback(course);
+    });
+  };
+
+  /**
+   * Get user from database via Canvas user data
+   *
+   * @param  {User}             canvasUser              The user of the course
+   * @param  {Course}           course                  The course in Canvas
+   * @param  {String[]}         sections                The sections of the course in which user is enrolled
+   * @param  {Function}         callback                Invoked when the user has been retrieved
+   * @param  {User}             callback.user           The retrieved user object
+   * @throws {AssertionError}                           Error thrown when an assertion failed
+   */
+  var findUser = function(canvasUser, course, sections, callback) {
+    var options = {
+      'where': {
+        'canvas_user_id': canvasUser.id
+      }
+    };
+    DB.User.findOne(options).complete(function(err, user) {
+      assert.ok(!err);
+
+      var profile = {
+        'canvas_course_role': canvasUser.roles,
+        'canvas_full_name': canvasUser.fullName,
+        'canvas_course_sections': sections
+      };
+      UsersAPI.getOrCreateUser(canvasUser.id, course, profile, function(err, user) {
+        assert.ok(!err);
+
+        callback(user);
+      });
+    });
+  };
 
   /**
    * Get a file stream
@@ -58,6 +117,7 @@ describe('Assets', function() {
    * @param  {String}             [filters.keywords]        A string to filter the assets by
    * @param  {Number}             [filters.category]        The id of the category to filter the assets by
    * @param  {Number}             [filters.user]            The id of the user who created the assets
+   * @param  {String}             [filters.section]         The name of the section in which owners of the assets are enrolled
    * @param  {Number}             [filters.type]            The type of assets. One of `CollabosphereConstants.ASSET.ASSET_TYPES`
    * @param  {Asset[]}            expectedAssets            The expected assets
    * @param  {Function}           callback                  Standard callback function
@@ -589,7 +649,7 @@ describe('Assets', function() {
         TestsUtil.getAssetLibraryClient(null, course, null, function(client2, course, user2) {
           TestsUtil.getAssetLibraryClient(null, course, null, function(client3, course, user3) {
             TestsUtil.getAssetLibraryClient(null, course, null, function(client4, course, user4) {
-            
+
               // User 1 creates many test assets
               TestsUtil.generateTestAssets(client1, course, 12, function(assets) {
                 // Start with default 'most recent' ordering
@@ -741,9 +801,32 @@ describe('Assets', function() {
     };
 
     /**
+     * Enroll user in section(s)
+     *
+     * @param  {CanvasCourse}   course                  The course in which sections belong
+     * @param  {User}           canvasUser              The user in Canvas
+     * @param  {String[]}       sections                Sections of course
+     * @param  {Function}       callback                Standard callback function
+     * @param  {Category}       callback.user           Updated user
+     * @api private
+     */
+    var setUpSectionStudent = function(course, canvasUser, sections, callback) {
+      TestsUtil.getAssetLibraryClient(null, course, canvasUser, function(client, course, canvasUser) {
+        var canvasCourseId = course.id;
+
+        getCourse(canvasCourseId, function(course) {
+          findUser(canvasUser, course, sections, function(user) {
+            callback(user);
+          });
+        });
+      });
+    };
+
+    /**
      * Create a few assets in a course
      *
      * @param  {CanvasCourse}   course                      The course in which the categories should be created
+     * @param  {User}           user                        The user in Canvas. Defaults to a new user in the `ucberkeley` Canvas instance
      * @param  {Category}       category1                   The first category
      * @param  {Category}       category2                   The second category
      * @param  {Function}       callback                    Standard callback function
@@ -754,43 +837,41 @@ describe('Assets', function() {
      * @throws {AssertionError}                             Error thrown when an assertion failed
      * @api private
      */
-    var setupAssets = function(course, category1, category2, callback) {
-      TestsUtil.getAssetLibraryClient(null, course, null, function(client, course, user) {
-        UsersTestUtil.assertGetMe(client, course, null, function(me) {
-          // Create a few assets with lots of metadata
-          var opts = {
-            'categories': [category1.id],
-            'description': 'University of California, Berkeley homepage, #ucberk',
+    var setupAssets = function(course, user, category1, category2, callback) {
+      TestsUtil.getAssetLibraryClient(null, course, user, function(client, course, user) {
+        // Create a few assets with lots of metadata
+        var opts = {
+          'categories': [category1.id],
+          'description': 'University of California, Berkeley homepage, #ucberk',
+          'source': 'http://www.universityofcalifornia.edu/uc-system'
+        };
+        AssetsTestUtil.assertCreateLink(client, course, 'UC Berkeley', 'http://www.berkeley.edu/', opts, function(berkeleyAsset) {
+          CategoriesTestUtil.assertCategory(berkeleyAsset.categories[0], {'expectedCategory': category1});
+
+          opts = {
+            'categories': [category2.id],
+            'description': 'University of California, Davis homepage, #ucdav',
             'source': 'http://www.universityofcalifornia.edu/uc-system'
           };
-          AssetsTestUtil.assertCreateLink(client, course, 'UC Berkeley', 'http://www.berkeley.edu/', opts, function(berkeleyAsset) {
-            CategoriesTestUtil.assertCategory(berkeleyAsset.categories[0], {'expectedCategory': category1});
+          AssetsTestUtil.assertCreateLink(client, course, 'UC Davis', 'http://www.ucdavis.edu/', opts, function(davisAsset) {
+            CategoriesTestUtil.assertCategory(davisAsset.categories[0], {'expectedCategory': category2});
 
             opts = {
-              'categories': [category2.id],
-              'description': 'University of California, Davis homepage, #ucdav',
+              'categories': [category1.id, category2.id],
+              'description': 'University of California, Los Angeles homepage, #ucla',
               'source': 'http://www.universityofcalifornia.edu/uc-system'
             };
-            AssetsTestUtil.assertCreateLink(client, course, 'UC Davis', 'http://www.ucdavis.edu/', opts, function(davisAsset) {
-              CategoriesTestUtil.assertCategory(davisAsset.categories[0], {'expectedCategory': category2});
+            AssetsTestUtil.assertCreateLink(client, course, 'UC Los Angeles', 'http://www.ucla.edu/', opts, function(laAsset) {
+              CategoriesTestUtil.assertCategory(laAsset.categories[0], {'expectedCategory': category1});
+              CategoriesTestUtil.assertCategory(laAsset.categories[1], {'expectedCategory': category2});
 
-              opts = {
-                'categories': [category1.id, category2.id],
-                'description': 'University of California, Los Angeles homepage, #ucla',
+              var opts = {
+                'description': 'University of California, Berkeley logo, #ucberk',
                 'source': 'http://www.universityofcalifornia.edu/uc-system'
               };
-              AssetsTestUtil.assertCreateLink(client, course, 'UC Los Angeles', 'http://www.ucla.edu/', opts, function(laAsset) {
-                CategoriesTestUtil.assertCategory(laAsset.categories[0], {'expectedCategory': category1});
-                CategoriesTestUtil.assertCategory(laAsset.categories[1], {'expectedCategory': category2});
+              AssetsTestUtil.assertCreateFile(client, course, 'UC Berkeley', getFileStream('logo-ucberkeley.png'), opts, function(logoAsset) {
 
-                var opts = {
-                  'description': 'University of California, Berkeley logo, #ucberk',
-                  'source': 'http://www.universityofcalifornia.edu/uc-system'
-                };
-                AssetsTestUtil.assertCreateFile(client, course, 'UC Berkeley', getFileStream('logo-ucberkeley.png'), opts, function(logoAsset) {
-
-                  return callback(client, me, berkeleyAsset, davisAsset, laAsset, logoAsset);
-                });
+                return callback(client, user, berkeleyAsset, davisAsset, laAsset, logoAsset);
               });
             });
           });
@@ -802,53 +883,74 @@ describe('Assets', function() {
      * Test that verifies that assets can be searched through
      */
     it('can be searched through', function(callback) {
-      var course = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
-      setupCategories(course, function(category1, category2) {
-        setupAssets(course, category1, category2, function(client, user1, berkeleyAsset1, davisAsset1, laAsset1, logoAsset1) {
-          setupAssets(course, category1, category2, function(client, user2, berkeleyAsset2, davisAsset2, laAsset2, logoAsset2) {
+      var canvasCourse = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var canvasUser1 = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+      var canvasUser2 = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
 
-            // All assets should be returned when no filters are specified
-            var allAssets = [berkeleyAsset1, davisAsset1, laAsset1, logoAsset1, berkeleyAsset2, davisAsset2, laAsset2, logoAsset2];
-            verifySearch(client, course, null, allAssets, function() {
+      setupCategories(canvasCourse, function(category1, category2) {
+        setUpSectionStudent(canvasCourse, canvasUser1, ['Section 001'], function(user1) {
+          assert.ok(user1.canvas_course_sections);
 
-              // Simple searches
-              verifySearch(client, course, {'keywords': 'Los'}, [laAsset1, laAsset2], function() {
-                verifySearch(client, course, {'keywords': 'Los Angeles'}, [laAsset1, laAsset2], function() {
-                  verifySearch(client, course, {'keywords': 'This totally does not match anything'}, [], function() {
-                    verifySearch(client, course, {'keywords': 'university Angeles'}, [laAsset1, laAsset2], function() {
-                      verifySearch(client, course, {'keywords': 'Uni ang'}, [laAsset1, laAsset2], function() {
-                        verifySearch(client, course, {'keywords': 'erkel'}, [berkeleyAsset1, berkeleyAsset2, logoAsset1, logoAsset2], function() {
-                          verifySearch(client, course, {'category': category1.id}, [berkeleyAsset1, berkeleyAsset2, laAsset1, laAsset2], function() {
-                            verifySearch(client, course, {'types': ['file']}, [logoAsset1, logoAsset2], function() {
-                              verifySearch(client, course, {'types': ['file', 'link']}, [logoAsset1, logoAsset2, berkeleyAsset1, berkeleyAsset2, davisAsset1, davisAsset2, laAsset1, laAsset2], function() {
-                                verifySearch(client, course, {'user': user1.id}, [berkeleyAsset1, davisAsset1, laAsset1, logoAsset1], function() {
+          setupAssets(canvasCourse, canvasUser1, category1, category2, function(client, canvasUser1, berkeleyAsset1, davisAsset1, laAsset1, logoAsset1) {
+            setUpSectionStudent(canvasCourse, canvasUser2, ['Section 002'], function(user2) {
+              assert.ok(user2.canvas_course_sections);
 
-                                  // Permutations of 2 options
-                                  verifySearch(client, course, {'keywords': 'Los Angeles', 'category': category1.id}, [laAsset1, laAsset2], function() {
-                                    verifySearch(client, course, {'keywords': 'Los Angeles', 'types': ['file']}, [], function() {
-                                      verifySearch(client, course, {'keywords': 'Los Angeles', 'user': user2.id}, [laAsset2], function() {
-                                        verifySearch(client, course, {'category': category1.id, 'types': ['file']}, [], function() {
-                                          verifySearch(client, course, {'category': category1.id, 'user': user1.id}, [berkeleyAsset1, laAsset1], function() {
-                                            verifySearch(client, course, {'types': ['file'], 'user': user1.id}, [logoAsset1], function() {
-                                              verifySearch(client, course, {'types': ['file', 'link'], 'user': user1.id}, [logoAsset1, berkeleyAsset1, davisAsset1, laAsset1], function() {
+              setupAssets(canvasCourse, canvasUser2, category1, category2, function(client, canvasUser2, berkeleyAsset2, davisAsset2, laAsset2, logoAsset2) {
 
-                                                // Permutations of 3 options
-                                                verifySearch(client, course, {'keywords': 'Los Angeles', 'category': category1.id, 'types': ['file']}, [], function() {
-                                                  verifySearch(client, course, {'keywords': 'Los Angeles', 'category': category1.id, 'user': user1.id}, [laAsset1], function() {
-                                                    verifySearch(client, course, {'keywords': 'Los Angeles', 'types': ['file'], 'user': user2.id}, [], function() {
-                                                      verifySearch(client, course, {'category': category1.id, 'types': ['link'], 'user': user2.id}, [berkeleyAsset2, laAsset2], function() {
-                                                        verifySearch(client, course, {'category': category1.id, 'types': ['link', 'file'], 'user': user2.id}, [berkeleyAsset2, laAsset2], function() {
+                // All assets should be returned when no filters are specified
+                var allAssets = [berkeleyAsset1, davisAsset1, laAsset1, logoAsset1, berkeleyAsset2, davisAsset2, laAsset2, logoAsset2];
+                verifySearch(client, canvasCourse, null, allAssets, function() {
 
-                                                          // Create a like and comment, and get updated asset data
-                                                          AssetsTestUtil.assertLike(client, course, laAsset1.id, true, function() {
-                                                            AssetsTestUtil.assertCreateComment(client, course, berkeleyAsset1.id, 'Comment', null, function() {
-                                                              AssetsTestUtil.assertGetAsset(client, course, laAsset1.id, null, null, function(laAsset1) {
-                                                                AssetsTestUtil.assertGetAsset(client, course, berkeleyAsset1.id, null, null, function(berkeleyAsset1) {
-                                                                  // Verify that sorting works in conjunction with search filters
-                                                                  verifySort(client, course, {'category': category1.id, 'user': user1.id}, 'likes', [laAsset1, berkeleyAsset1], function() {
-                                                                    verifySort(client, course, {'category': category1.id, 'user': user1.id}, 'comments', [berkeleyAsset1, laAsset1], function() {
-                                                                
-                                                                      return callback();
+                  // Simple searches
+                  verifySearch(client, canvasCourse, {'keywords': 'Los'}, [laAsset1, laAsset2], function() {
+                    verifySearch(client, canvasCourse, {'keywords': 'Los Angeles'}, [laAsset1, laAsset2], function() {
+                      verifySearch(client, canvasCourse, {'keywords': 'This totally does not match anything'}, [], function() {
+                        verifySearch(client, canvasCourse, {'keywords': 'university Angeles'}, [laAsset1, laAsset2], function() {
+                          verifySearch(client, canvasCourse, {'keywords': 'Uni ang'}, [laAsset1, laAsset2], function() {
+                            verifySearch(client, canvasCourse, {'keywords': 'erkel'}, [berkeleyAsset1, berkeleyAsset2, logoAsset1, logoAsset2], function() {
+                              verifySearch(client, canvasCourse, {'category': category1.id}, [berkeleyAsset1, berkeleyAsset2, laAsset1, laAsset2], function() {
+                                verifySearch(client, canvasCourse, {'types': ['file']}, [logoAsset1, logoAsset2], function() {
+                                  verifySearch(client, canvasCourse, {'types': ['file', 'link']}, [logoAsset1, logoAsset2, berkeleyAsset1, berkeleyAsset2, davisAsset1, davisAsset2, laAsset1, laAsset2], function() {
+                                    verifySearch(client, canvasCourse, {'user': user1.id}, [berkeleyAsset1, davisAsset1, laAsset1, logoAsset1], function() {
+                                      verifySearch(client, canvasCourse, {'section': user1.canvas_course_sections[0]}, [berkeleyAsset1, davisAsset1, laAsset1, logoAsset1], function() {
+
+                                        // Permutations of 2 options
+                                        verifySearch(client, canvasCourse, {'keywords': 'Los Angeles', 'category': category1.id}, [laAsset1, laAsset2], function() {
+                                          verifySearch(client, canvasCourse, {'keywords': 'Los Angeles', 'types': ['file']}, [], function() {
+                                            verifySearch(client, canvasCourse, {'keywords': 'Los Angeles', 'user': user2.id}, [laAsset2], function() {
+                                              verifySearch(client, canvasCourse, {'category': category1.id, 'types': ['file']}, [], function() {
+                                                verifySearch(client, canvasCourse, {'category': category1.id, 'user': user1.id}, [berkeleyAsset1, laAsset1], function() {
+                                                  verifySearch(client, canvasCourse, {'types': ['file'], 'user': user1.id}, [logoAsset1], function() {
+                                                    verifySearch(client, canvasCourse, {'types': ['file', 'link'], 'user': user1.id}, [logoAsset1, berkeleyAsset1, davisAsset1, laAsset1], function() {
+                                                      verifySearch(client, canvasCourse, {'section': user1.canvas_course_sections[0], 'types': ['file']}, [logoAsset1], function() {
+
+                                                        // Permutations of 3 options
+                                                        verifySearch(client, canvasCourse, {'keywords': 'Los Angeles', 'category': category1.id, 'types': ['file']}, [], function() {
+                                                          verifySearch(client, canvasCourse, {'keywords': 'Los Angeles', 'category': category1.id, 'user': user1.id}, [laAsset1], function() {
+                                                            verifySearch(client, canvasCourse, {'keywords': 'Los Angeles', 'types': ['file'], 'user': user2.id}, [], function() {
+                                                              verifySearch(client, canvasCourse, {'category': category1.id, 'types': ['link'], 'user': user2.id}, [berkeleyAsset2, laAsset2], function() {
+                                                                verifySearch(client, canvasCourse, {'category': category1.id, 'types': ['link', 'file'], 'user': user2.id}, [berkeleyAsset2, laAsset2], function() {
+                                                                  verifySearch(client, canvasCourse, {'category': category1.id, 'section': user2.canvas_course_sections[0], 'types': ['link']}, [berkeleyAsset2, laAsset2], function() {
+
+                                                                    // Permutations of 4 options
+                                                                    verifySearch(client, canvasCourse, {'category': category1.id, 'section': user1.canvas_course_sections[0], 'user': user2.id, 'types': ['link']}, [], function() {
+
+                                                                      // Create a like and comment, and get updated asset data
+                                                                      AssetsTestUtil.assertLike(client, canvasCourse, laAsset1.id, true, function() {
+                                                                        AssetsTestUtil.assertCreateComment(client, canvasCourse, berkeleyAsset1.id, 'Comment', null, function() {
+                                                                          AssetsTestUtil.assertGetAsset(client, canvasCourse, laAsset1.id, null, null, function(laAsset1) {
+                                                                            AssetsTestUtil.assertGetAsset(client, canvasCourse, berkeleyAsset1.id, null, null, function(berkeleyAsset1) {
+                                                                              // Verify that sorting works in conjunction with search filters
+                                                                              verifySort(client, canvasCourse, {'category': category1.id, 'user': user1.id}, 'likes', [laAsset1, berkeleyAsset1], function() {
+                                                                                verifySort(client, canvasCourse, {'category': category1.id, 'user': user1.id}, 'comments', [berkeleyAsset1, laAsset1], function() {
+
+                                                                                  return callback();
+                                                                                });
+                                                                              });
+                                                                            });
+                                                                          });
+                                                                        });
+                                                                      });
                                                                     });
                                                                   });
                                                                 });
@@ -890,20 +992,24 @@ describe('Assets', function() {
     it('can search through many assets', function(callback) {
       // Create a couple of assets that we will eventually search for
       var course = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var canvasUser = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+
       setupCategories(course, function(category1, category2) {
-        setupAssets(course, category1, category2, function(client, user1, berkeleyAsset1, davisAsset1, laAsset1, logoAsset1) {
+        setUpSectionStudent(course, canvasUser, ['Section 001'], function(user1) {
+          setupAssets(course, canvasUser, category1, category2, function(client, canvasUser, berkeleyAsset1, davisAsset1, laAsset1, logoAsset1) {
 
-          // Now create a bunch of irrelevant assets
-          setupCategories(course, function(category3, category4) {
-            setupAssets(course, category3, category4, function(client, user3, berkeleyAsset3, davisAsset3, laAsset3, logoAsset3) {
-              setupAssets(course, category3, category4, function(client, user4, berkeleyAsset4, davisAsset4, laAsset4, logoAsset4) {
-                setupAssets(course, category3, category4, function(client, user5, berkeleyAsset5, davisAsset5, laAsset5, logoAsset5) {
+            // Now create a bunch of irrelevant assets
+            setupCategories(course, function(category3, category4) {
+              setupAssets(course, null, category3, category4, function(client, user2, berkeleyAsset3, davisAsset3, laAsset3, logoAsset3) {
+                setupAssets(course, null, category3, category4, function(client, user3, berkeleyAsset4, davisAsset4, laAsset4, logoAsset4) {
+                  setupAssets(course, null, category3, category4, function(client, user4, berkeleyAsset5, davisAsset5, laAsset5, logoAsset5) {
 
-                  // Search for the first assets
-                  verifySearch(client, course, {'keywords': 'Los Angeles', 'category': category1.id}, [laAsset1], function() {
-                    verifySearch(client, course, {'user': user1.id}, [berkeleyAsset1, davisAsset1, laAsset1, logoAsset1], function() {
-                      verifySearch(client, course, {'user': user1.id, 'types': 'link'}, [berkeleyAsset1, davisAsset1, laAsset1], function() {
-                        return callback();
+                    // Search for the first assets
+                    verifySearch(client, course, {'keywords': 'Los Angeles', 'category': category1.id}, [laAsset1], function() {
+                      verifySearch(client, course, {'user': user1.id}, [berkeleyAsset1, davisAsset1, laAsset1, logoAsset1], function() {
+                        verifySearch(client, course, {'user': user1.id, 'types': 'link'}, [berkeleyAsset1, davisAsset1, laAsset1], function() {
+                          return callback();
+                        });
                       });
                     });
                   });
@@ -921,13 +1027,15 @@ describe('Assets', function() {
     it('can search for hashtags', function(callback) {
       // Create a couple of assets that we will search for
       var course = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
-      setupCategories(course, function(category1, category2) {
-        setupAssets(course, category1, category2, function(client, user, berkeleyAsset, davisAsset, laAsset, logoAsset) {
+      TestsUtil.getAssetLibraryClient(null, course, null, function(client, course, user) {
+        setupCategories(course, function(category1, category2) {
+          setupAssets(course, user, category1, category2, function(client, user, berkeleyAsset, davisAsset, laAsset, logoAsset) {
 
-          // Verify that including the pound sign doesn't influence the hashtag search results
-          verifySearch(client, course, {'keywords': 'ucla'}, [laAsset], function() {
-            verifySearch(client, course, {'keywords': '#ucla'}, [laAsset], function() {
-              return callback();
+            // Verify that including the pound sign doesn't influence the hashtag search results
+            verifySearch(client, course, {'keywords': 'ucla'}, [laAsset], function() {
+              verifySearch(client, course, {'keywords': '#ucla'}, [laAsset], function() {
+                return callback();
+              });
             });
           });
         });
@@ -1503,7 +1611,7 @@ describe('Assets', function() {
      * Test that verifies that an exported whiteboard asset can be remixed
      */
     it('can be remixed', function(callback) {
-      AssetsTestUtil.setupExportedWhiteboard(function(client1, client2, course, user1, user2, exportedWhiteboard) {       
+      AssetsTestUtil.setupExportedWhiteboard(function(client1, client2, course, user1, user2, exportedWhiteboard) {
         AssetsTestUtil.assertRemixWhiteboard(client1, course, exportedWhiteboard, function() {
 
           return callback();
@@ -1529,7 +1637,7 @@ describe('Assets', function() {
      * Test that verifies authorization when remixing an exported whiteboard
      */
     it('verifies authorization', function(callback) {
-      AssetsTestUtil.setupExportedWhiteboard(function(client1, client2, course, user1, user2, exportedWhiteboard) {       
+      AssetsTestUtil.setupExportedWhiteboard(function(client1, client2, course, user1, user2, exportedWhiteboard) {
 
         // Verify that a user in a different course can't remix the whiteboard
         TestsUtil.getAssetLibraryClient(null, null, null, function(foreignClient, foreignCourse, foreignUser) {

--- a/node_modules/col-assets/tests/util.js
+++ b/node_modules/col-assets/tests/util.js
@@ -594,6 +594,7 @@ var assertGetAssetFails = module.exports.assertGetAssetFails = function(client, 
  * @param  {String}             [filters.keywords]              A string to filter the assets by
  * @param  {Number}             [filters.category]              The id of the category to filter the assets by
  * @param  {Number}             [filters.user]                  The id of the user who created the assets
+ * @param  {String}             [filters.section]               Section of the course
  * @param  {String[]}           [filters.types]                 The type of assets. One or more of `CollabosphereConstants.ASSET.ASSET_TYPES`
  * @param  {String}             [sort]                          An optional criterion to sort by. Defaults to id descending
  * @param  {Number}             [limit]                         The maximum number of results to retrieve. Defaults to 10
@@ -1153,7 +1154,7 @@ var setupExportedWhiteboard = module.exports.setupExportedWhiteboard = function(
 
               // Export whiteboard to asset
               WhiteboardsTestsUtil.assertExportWhiteboardToAsset(client1, course, whiteboard.id, null, null, function(exportedAsset) {
-            
+
                 return callback(client1, client2, course, user1, user2, exportedAsset);
               });
             });
@@ -1176,7 +1177,7 @@ var setupExportedWhiteboard = module.exports.setupExportedWhiteboard = function(
 var assertRemixWhiteboard = module.exports.assertRemixWhiteboard = function(client, course, asset, callback) {
   client.assets.remixWhiteboard(course, asset.id, function(err, whiteboard) {
     assert.ok(!err);
-    
+
     WhiteboardsTestsUtil.assertWhiteboard(whiteboard, {'expectFullWhiteboard': true});
     assert.strictEqual(whiteboard.title, asset.title);
 
@@ -1188,7 +1189,7 @@ var assertRemixWhiteboard = module.exports.assertRemixWhiteboard = function(clie
 
     // Assert that the requesting user is the only whiteboard member
     UsersTestsUtil.assertGetMe(client, course, null, function(me) {
-      assert.strictEqual(whiteboard.members.length, 1);      
+      assert.strictEqual(whiteboard.members.length, 1);
       assert.strictEqual(whiteboard.members[0].id, me.id);
 
       return callback();

--- a/node_modules/col-rest/lib/rest/assets.js
+++ b/node_modules/col-rest/lib/rest/assets.js
@@ -72,6 +72,7 @@ module.exports = function(client) {
       'keywords': filters.keywords,
       'category': filters.category,
       'user': filters.user,
+      'section': filters.section,
       'type': filters.types,
       'sort': sort,
       'limit': limit,

--- a/node_modules/col-tests/lib/util.js
+++ b/node_modules/col-tests/lib/util.js
@@ -177,8 +177,8 @@ var generateCourse = module.exports.generateCourse = function(canvas, id, label,
  * @param  {String}           [userImage]             The url that points to a profile picture for the user
  * @return {User}                                     An object that contains the information about the user
  */
-var generateCanvasAdmin = module.exports.generateCanvasAdmin = function(canvas, id, sections, givenName, familyName, loginId, userImage) {
-  return generateUser(canvas, id, 'urn:lti:instrole:ims/lis/Administrator', sections, givenName, familyName, loginId, userImage);
+var generateCanvasAdmin = module.exports.generateCanvasAdmin = function(canvas, id, givenName, familyName, loginId, userImage) {
+  return generateUser(canvas, id, 'urn:lti:instrole:ims/lis/Administrator', givenName, familyName, loginId, userImage);
 };
 
 /**
@@ -193,8 +193,8 @@ var generateCanvasAdmin = module.exports.generateCanvasAdmin = function(canvas, 
  * @param  {String}           [userImage]             The url that points to a profile picture for the user
  * @return {User}                                     An object that contains the information about the user
  */
-var generateInstructor = module.exports.generateInstructor = function(canvas, id, sections, givenName, familyName, loginId, userImage) {
-  return generateUser(canvas, id, 'urn:lti:role:ims/lis/Instructor', sections, givenName, familyName, loginId, userImage);
+var generateInstructor = module.exports.generateInstructor = function(canvas, id, givenName, familyName, loginId, userImage) {
+  return generateUser(canvas, id, 'urn:lti:role:ims/lis/Instructor', givenName, familyName, loginId, userImage);
 };
 
 /**
@@ -204,14 +204,13 @@ var generateInstructor = module.exports.generateInstructor = function(canvas, id
  * @param  {Canvas}           [canvas]                The canvas instance in which the user lives
  * @param  {Number}           [id]                    The id of the user in Canvas
  * @param  {String}           [roles]                 The role of the user in the course, defaults to `Student`
- * @param  {Array}            [sections]              The course sections in which user is enrolled
  * @param  {String}           [givenName]             The given name of the user
  * @param  {String}           [familyName]            The family name of the user
  * @param  {String}           [loginId]               The login id for the user
  * @param  {String}           [userImage]             The url that points to a profile picture for the user
  * @return {User}                                     An object that contains the information about the user
  */
-var generateUser = module.exports.generateUser = function(canvas, id, roles, sections, givenName, familyName, loginId, userImage) {
+var generateUser = module.exports.generateUser = function(canvas, id, roles, givenName, familyName, loginId, userImage) {
   givenName = givenName || randomstring.generate(10);
   familyName = familyName || randomstring.generate(15);
   return {
@@ -221,7 +220,6 @@ var generateUser = module.exports.generateUser = function(canvas, id, roles, sec
     'familyName': familyName,
     'fullName': givenName + ' ' + familyName,
     'roles': roles || 'Student',
-    'sections': sections || ['Section 001'],
     'ext_roles': roles || 'Student',
     'loginId': loginId || (_.random(1000000) + '@berkeley.edu'),
     'guid': _.random(100000),

--- a/public/app/app.states.js
+++ b/public/app/app.states.js
@@ -60,7 +60,7 @@
         'controller': 'AssetLibraryManageAssetsController'
       })
       .state('assetlibrarylist', {
-        'url': '/assetlibrary?category&user&keywords&type&sort',
+        'url': '/assetlibrary?category&user&section&keywords&type&sort',
         'templateUrl': '/app/assetlibrary/list/list.html',
         'controller': 'AssetLibraryListController'
       })

--- a/public/app/assetlibrary/assetLibraryFactory.js
+++ b/public/app/assetlibrary/assetLibraryFactory.js
@@ -63,6 +63,7 @@
      * @param  {String}               [searchOptions.keywords]        A string to filter the assets by
      * @param  {Number}               [searchOptions.category]        The id of the category to filter the assets by
      * @param  {Number}               [searchOptions.user]            The id of the user who created the assets
+     * @param  {String}               [searchOptions.section]         The name of section (i.e., subset of users) to filter assets by
      * @param  {String}               [searchOptions.type]            The type of assets
      * @return {Promise<Object>}                                      $http promise returning the total number of assets for the current course and the assets in the current page
      */
@@ -80,6 +81,9 @@
       }
       if (searchOptions.user) {
         url += '&user=' + searchOptions.user;
+      }
+      if (searchOptions.section) {
+        url += '&section=' + encodeURIComponent(searchOptions.section);
       }
       if (searchOptions.type) {
         url += '&type=' + searchOptions.type;

--- a/public/app/assetlibrary/assetLibraryService.js
+++ b/public/app/assetlibrary/assetLibraryService.js
@@ -69,6 +69,7 @@
             'asset_search_keywords': data.keywords,
             'asset_search_category': data.category,
             'asset_search_user': data.user,
+            'asset_search_section': data.section,
             'asset_search_types': data.type,
             'referer': document.referrer
           });
@@ -77,6 +78,7 @@
             'keywords': (data.keywords ? data.keywords : ''),
             'category': (data.category ? data.category : ''),
             'user': (data.user ? data.user : ''),
+            'section': (data.section ? data.section : ''),
             'type': (data.type ? data.type : ''),
             'sort': (data.sort ? data.sort : '')
           };

--- a/public/app/assetlibrary/list/assetLibraryListController.js
+++ b/public/app/assetlibrary/list/assetLibraryListController.js
@@ -52,6 +52,7 @@
       'keywords': $state.params.keywords || '',
       'category': parseInt($state.params.category, 10) || '',
       'user': parseInt($state.params.user, 10) || '',
+      'section': $state.params.section || '',
       'type': $state.params.type || '',
       'sort': $state.params.sort || ''
     };
@@ -60,10 +61,8 @@
     // initial value gets derived from the state parameters that are passed into this controller.
     // The value will be bound to the search directive which will update it when a user switches
     // between simple and advanced search mode
-    $scope.isAdvancedSearch = false;
-    if ($scope.searchOptions.category || $scope.searchOptions.user || $scope.searchOptions.type || $scope.searchOptions.sort) {
-      $scope.isAdvancedSearch = true;
-    }
+    var search = $scope.searchOptions;
+    $scope.isAdvancedSearch = search.category || search.user || search.section || search.type || search.sort;
 
     /**
      * If a search is being performed, initialize variables
@@ -71,11 +70,10 @@
      * @return {void}
      */
     var initializeSearchContext = function() {
-      $scope.isSearch = false;
+      var opts = $scope.searchOptions;
+      $scope.isSearch = opts.keywords || opts.category || opts.user || opts.section || opts.type || opts.sort;
+
       $scope.resultsMessage = null;
-      if ($scope.searchOptions.keywords || $scope.searchOptions.category || $scope.searchOptions.user || $scope.searchOptions.type || $scope.searchOptions.sort) {
-        $scope.isSearch = true;
-      }
     };
 
     initializeSearchContext();

--- a/public/app/assetlibrary/list/list.html
+++ b/public/app/assetlibrary/list/list.html
@@ -8,6 +8,7 @@
       data-search-options-keywords="searchOptions.keywords"
       data-search-options-category="searchOptions.category"
       data-search-options-user="searchOptions.user"
+      data-search-options-section="searchOptions.section"
       data-search-options-type="searchOptions.type"
       data-search-options-sort="searchOptions.sort"
       class="assetlibrary-list-search-container col-xs-{{ isAdvancedSearch ? 12 : 8 }}"></search>

--- a/public/app/assetlibrary/search/assetLibrarySearchDirective.js
+++ b/public/app/assetlibrary/search/assetLibrarySearchDirective.js
@@ -40,17 +40,21 @@
         'keywords': '=searchOptionsKeywords',
         'category': '=searchOptionsCategory',
         'user': '=searchOptionsUser',
+        'section': '=searchOptionsSection',
         'type': '=searchOptionsType',
         'sort': '=searchOptionsSort'
       },
       'templateUrl': '/app/assetlibrary/search/search.html',
       'controller': function($scope, assetLibraryCategoriesFactory, userFactory) {
 
-        // Variable that keeps track of the categories in the current course
+        // Categories of the current course
         $scope.categories = null;
 
-        // Variable that keeps track of the users in the current course
+        // Users of the current course
         $scope.users = null;
+
+        // Sections of the current course
+        $scope.sections = null;
 
         /**
          * Emit an event indicating that we want to search through the assets
@@ -59,24 +63,21 @@
          */
         var search = $scope.search = function() {
           if ($scope.isAdvancedSearch) {
-            var categoryObject = null;
-            var userObject = null;
-            if ($scope.category) {
-              categoryObject = _.find($scope.categories, {'id': $scope.category});
-            }
-            if ($scope.user) {
-              userObject = _.find($scope.users, {'id': $scope.user});
-            }
+            var categoryObject = $scope.category ? _.find($scope.categories, {'id': $scope.category}) : null;
+            var userObject = $scope.user ? _.find($scope.users, {'id': $scope.user}) : null;
+
             var searchOptions = {
               'keywords': $scope.keywords,
               'category': $scope.category,
               'user': $scope.user,
+              'section': $scope.section,
               'type': $scope.type,
               'sort': $scope.sort,
               'categoryObject': categoryObject,
               'userObject': userObject
             };
             $scope.$emit('assetLibrarySearchSearch', searchOptions);
+
           } else {
             $scope.$emit('assetLibrarySearchSearch', {'keywords': $scope.keywords});
           }
@@ -113,6 +114,18 @@
           if (!$scope.users) {
             userFactory.getAllUsers().success(function(users) {
               $scope.users = users;
+
+              // User can have zero or more sections
+              var sections = _(users)
+                .map('canvas_course_sections')
+                .flatten()
+                .uniq()
+                .compact()
+                .sort()
+                .value();
+
+              // Section filter requires two or more sections
+              $scope.sections = sections.length > 1 ? sections : null;
             });
           }
 

--- a/public/app/assetlibrary/search/search.html
+++ b/public/app/assetlibrary/search/search.html
@@ -34,25 +34,50 @@
       </div>
 
       <!-- FILTER BY -->
-      <div class="form-group">
-        <label for="assetlibrary-search-category" class="col-sm-1 control-label">Filter by</label>
-        <div class="col-sm-4">
-          <select id="assetlibrary-search-category" class="form-control" data-ng-model="category" data-value="{{category}}" data-ng-options="category.id as category.title for category in categories">
-            <option value="" selected>Category</option>
-          </select>
+      <div class="search-filters">
+        <div class="form-group">
+          <label for="assetlibrary-search-category" class="col-sm-1 control-label">Filter by</label>
+          <div class="col-sm-4">
+            <select id="assetlibrary-search-category" class="form-control"
+              data-ng-model="category"
+              data-value="{{category}}"
+              data-ng-options="category.id as category.title for category in categories">
+
+              <option value="" selected>Category</option>
+            </select>
+          </div>
+          <div class="col-sm-3">
+            <select id="assetlibrary-search-type" class="form-control"
+              data-ng-model="type"
+              data-value="{{type}}">
+
+              <option value="" selected>Asset type</option>
+              <option value="file">File</option>
+              <option value="link">Link</option>
+              <option value="whiteboard">Whiteboard</option>
+            </select>
+          </div>
         </div>
-        <div class="col-sm-4">
-          <select id="assetlibrary-search-user" class="form-control" data-ng-model="user" data-value="{{user}}" data-ng-options="user.id as user.canvas_full_name for user in users">
-            <option value="" selected>Uploader</option>
-          </select>
-        </div>
-        <div class="col-sm-3">
-          <select id="assetlibrary-search-type" class="form-control" data-ng-model="type" data-value="{{type}}">
-            <option value="" selected>Asset type</option>
-            <option value="file">File</option>
-            <option value="link">Link</option>
-            <option value="whiteboard">Whiteboard</option>
-          </select>
+        <div class="form-group">
+          <div class="col-sm-1"></div>
+          <div class="col-sm-4">
+            <select id="assetlibrary-search-user" class="form-control"
+              data-ng-model="user"
+              data-value="{{user}}"
+              data-ng-options="user.id as user.canvas_full_name for user in users">
+
+              <option value="" selected>Uploader</option>
+            </select>
+          </div>
+          <div class="col-sm-4" data-ng-if="sections.length">
+            <select id="assetlibrary-search-section" class="form-control"
+              data-ng-model="section"
+              data-value="{{section}}"
+              data-ng-options="section as section for section in sections">
+
+              <option value="" selected>Section</option>
+            </select>
+          </div>
         </div>
       </div>
 

--- a/public/app/shared/utilService.js
+++ b/public/app/shared/utilService.js
@@ -391,6 +391,10 @@
         filters.push('selected user');
       }
 
+      if (searchOptions.section) {
+        filters.push('section ' + searchOptions.section);
+      }
+
       if (filters.length) {
         message += ' for ' + filters.join(' and ');
       }

--- a/public/app/whiteboards/reuse/whiteboardsReuseController.js
+++ b/public/app/whiteboards/reuse/whiteboardsReuseController.js
@@ -87,9 +87,12 @@
       // until the current request has completed
       $scope.list.ready = false;
       $scope.isSearch = false;
-      assetLibraryFactory.getAssets($scope.list.page, $scope.searchOptions).success(function(assets) {
+
+      var opts = $scope.searchOptions;
+
+      assetLibraryFactory.getAssets($scope.list.page, opts).success(function(assets) {
         // Indicate whether a search was performed
-        if ($scope.searchOptions.keywords || $scope.searchOptions.category || $scope.searchOptions.user || $scope.searchOptions.type) {
+        if (opts.keywords || opts.category || opts.user || opts.section || opts.type) {
           $scope.isSearch = true;
         }
 

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -73,6 +73,10 @@ a {
   margin-bottom: 20px;
 }
 
+.form-horizontal .search-filters .form-group:not(:last-child) {
+  margin-bottom: 0 !important;
+}
+
 .form-group:not(.has-error) div[data-ng-messages] {
   display: none;
 }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-744

List of distinct section names can be extracted from the list `users` already available in angular directive. SQL behind search now has `array_position(u.canvas_course_sections, :section)`

![image](https://cloud.githubusercontent.com/assets/7606442/25876485/63cc6b7e-34d2-11e7-9fd9-eb7df14dbaf8.png)

Initial PR #390 was closed due to no test coverage. 