### PR TITLE
COL-923 Grab, grab, grab went the cursor

### DIFF
--- a/public/app/shared/activityTimeline.css
+++ b/public/app/shared/activityTimeline.css
@@ -28,7 +28,10 @@
 }
 
 .chart-wrapper {
-  cursor: pointer;
+  cursor: pointer; /* fallback if grab cursor is unsupported */
+  cursor: -moz-grab;
+  cursor: -webkit-grab;
+  cursor: grab;
 }
 
 .event-details {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-923

Browser permitting, the mouse cursor on activity timelines should not POINT with ONE finger but GRAB with MANY fingers.