### PR TITLE
COL-924, tool-href support in hashtagFilter; toolHref logic to shared utilService

### DIFF
--- a/public/app/app.bootstrap.js
+++ b/public/app/app.bootstrap.js
@@ -61,7 +61,7 @@
     }.bind({}))[0];
 
     // '_id' represents an asset, user or view requested via link action.
-    var m = queryArgs.match(/.*[\?&]_id=([%0-9a-zA-Z]+).*/);
+    var m = queryArgs.match(/.*[\?&]_id=([%0-9a-zA-Z\-\.]+).*/);
     parameters.requestedId = (m && m.length > 0) ? decodeURIComponent(m[1]) : null;
 
     // '_referring_tool' is the SuiteC tool in which user initiated the action.

--- a/public/app/assetlibrary/backtoreferrer.html
+++ b/public/app/assetlibrary/backtoreferrer.html
@@ -5,7 +5,6 @@
     tool-href
     data-tool="dashboard"
     data-referring-tool="assetlibrary"
-    data-course="me.course"
     data-id="referringTool.referringId"
     data-ng-if="referringTool.name === 'dashboard'"><i class="fa fa-angle-left"></i> Back to Impact Studio</a>
 </div>

--- a/public/app/assetlibrary/item/item.html
+++ b/public/app/assetlibrary/item/item.html
@@ -5,7 +5,6 @@
     tool-href
     data-tool="dashboard"
     data-referring-tool="assetlibrary"
-    data-course="me.course"
     data-id="referringTool.referringId"
     data-ng-if="referringTool.name === 'dashboard'"><i class="fa fa-angle-left"></i> Back to Impact Studio</a>
 
@@ -128,7 +127,6 @@
                   <a tool-href
                     data-tool="dashboard"
                     data-referring-tool="assetlibrary"
-                    data-course="me.course"
                     data-id="user.id"
                     data-ng-if="me.course.dashboard_url">
                     <i class="fa fa-graduation-cap" data-ng-if="user.is_admin"></i> {{user.canvas_full_name}}
@@ -223,7 +221,6 @@
             <a tool-href
               data-tool="dashboard"
               data-referring-tool="assetlibrary"
-              data-course="me.course"
               data-id="me.id"
               data-ng-if="me.course.dashboard_url">
               <i class="fa fa-graduation-cap" data-ng-if="me.is_admin"></i> {{me.canvas_full_name}}
@@ -258,7 +255,6 @@
           <a tool-href
             data-tool="dashboard"
             data-referring-tool="assetlibrary"
-            data-course="me.course"
             data-id="comment.user.id"
             data-ng-if="me.course.dashboard_url">
             <i class="fa fa-graduation-cap" data-ng-if="comment.user.is_admin"></i> {{comment.user.canvas_full_name}}

--- a/public/app/assetlibrary/list/assetLibraryListController.js
+++ b/public/app/assetlibrary/list/assetLibraryListController.js
@@ -27,10 +27,14 @@
 
   'use strict';
 
-  angular.module('collabosphere').controller('AssetLibraryListController', function(assetLibraryFactory, assetLibraryService, me, utilService, $rootScope, $scope, $state) {
+  angular.module('collabosphere').controller('AssetLibraryListController', function(assetLibraryFactory, assetLibraryService, me, referringTool, utilService, $rootScope, $scope, $state) {
 
     // Make the me object available to the scope
     $scope.me = me;
+
+    // If the referringTool object is present then the request originated in
+    // a SuiteC tool other than the Asset Library
+    $scope.referringTool = referringTool;
 
     // Variable that keeps track of the URL state
     $scope.state = $state;

--- a/public/app/assetlibrary/list/list.css
+++ b/public/app/assetlibrary/list/list.css
@@ -25,6 +25,7 @@
 
 .assetlibrary-list-top {
   margin-bottom: 12px;
+  margin-top: 5px;
 }
 
 /* NO RESULTS */

--- a/public/app/assetlibrary/list/list.html
+++ b/public/app/assetlibrary/list/list.html
@@ -1,4 +1,11 @@
 <div data-ng-show="state.current.name === 'assetlibrarylist'">
+  <a class="col-back"
+    tool-href
+    data-tool="dashboard"
+    data-referring-tool="assetlibrary"
+    data-id="referringTool.referringId"
+    data-ng-if="referringTool.name === 'dashboard'"><i class="fa fa-angle-left"></i> Back to Impact Studio</a>
+
   <div data-ng-if="me.is_admin && (!me.course.active || me.course.reactivated)" data-ng-include="'/app/shared/syncdisabled.html'"></div>
 
   <div class="row assetlibrary-list-top">

--- a/public/app/dashboard/profile.html
+++ b/public/app/dashboard/profile.html
@@ -31,7 +31,7 @@
         <span data-ng-if="user.last_activity">{{user.last_activity | formatDate}}</span>
         <span data-ng-if="!user.last_activity">Never</span>
       </div>
-      <div class="profile-user-description" data-ng-if="user.personal_bio" data-ng-bind-html="user.personal_bio | linky:'_blank' | hashtags"></div>
+      <div class="profile-user-description" data-ng-if="user.personal_bio" data-ng-bind-html="user.personal_bio | linky:'_blank' | toolHrefHashtag:'dashboard':user.id"></div>
     </div>
     <div class="profile-summary-column-with-border" data-ng-if="showEngagementIndexBox">
       <div class="profile-summary-column-square">
@@ -39,8 +39,7 @@
           <h2>
             <a tool-href
               data-tool="engagementindex"
-              data-referring-tool="dashboard"
-              data-course="me.course">
+              data-referring-tool="dashboard">
               Engagement Index
             </a>
           </h2>
@@ -55,8 +54,7 @@
             Sharing off.
             <a tool-href
               data-tool="engagementindex"
-              data-referring-tool="dashboard"
-              data-course="me.course">Turn on?</a>
+              data-referring-tool="dashboard">Turn on?</a>
           </div>
         </div>
       </div>
@@ -156,7 +154,6 @@
           data-tool="assetlibrary"
           data-referring-tool="dashboard"
           data-referring-id="user.id"
-          data-course="me.course"
           data-id="user.assets.advancedSearchId"
           data-ng-bind="user.assets.total"></a>)
       </span>
@@ -180,7 +177,6 @@
                     data-tool="assetlibrary"
                     data-referring-tool="dashboard"
                     data-referring-id="user.id"
-                    data-course="me.course"
                     data-id="routerStateUploadAsset">
                     <i class="fa fa-laptop"></i>
                     <div class="assetlibrary-list-item-add-action">Upload</div>
@@ -190,7 +186,6 @@
                     data-tool="assetlibrary"
                     data-referring-tool="dashboard"
                     data-referring-id="user.id"
-                    data-course="me.course"
                     data-id="routerStateAddLink">
                     <i class="fa fa-link"></i>
                     <div class="assetlibrary-list-item-add-action">Add Link</div>
@@ -204,7 +199,6 @@
                 data-tool="assetlibrary"
                 data-referring-tool="dashboard"
                 data-referring-id="user.id"
-                data-course="me.course"
                 data-id="routerStateBookmarkletInfo">
                 Add assets more easily
                 <i class="fa fa-bookmark pull-left"></i>
@@ -218,7 +212,6 @@
             data-tool="assetlibrary"
             data-referring-tool="dashboard"
             data-referring-id="user.id"
-            data-course="me.course"
             data-id="asset.id">
 
             <div class="col-list-item-container">
@@ -259,7 +252,6 @@
             data-tool="assetlibrary"
             data-referring-tool="dashboard"
             data-referring-id="user.id"
-            data-course="me.course"
             data-id="community.assets.advancedSearchId"
             data-ng-bind="community.assets.total"></a>)
         </span>
@@ -278,7 +270,6 @@
             data-tool="assetlibrary"
             data-referring-tool="dashboard"
             data-referring-id="user.id"
-            data-course="me.course"
             data-id="asset.id">
 
             <div class="col-list-item-container">

--- a/public/app/dashboard/profileController.js
+++ b/public/app/dashboard/profileController.js
@@ -125,16 +125,6 @@
     };
 
     /**
-     * Get encoded instructions to pre-populate Asset Library's advanced search.
-     *
-     * @param  {Object}         searchOptions             Properties associated with dropdowns of Advanced Search
-     * @return {String}                                   Search options, stringified
-     */
-    var getAdvancedSearchId = function(searchOptions) {
-      return 'assetlibrarylist:' + JSON.stringify(searchOptions);
-    };
-
-    /**
      * Get custom type of asset list (e.g., 'Most Impactful') per user.
      *
      * @param  {String}         sortType              Name of field to sort by
@@ -159,7 +149,7 @@
           $scope.user.totalAssetsInCourse = $scope.user.assets.results.length;
         }
         $scope.user.assets.sortBy = sortType;
-        $scope.user.assets.advancedSearchId = getAdvancedSearchId({
+        $scope.user.assets.advancedSearchId = utilService.getAdvancedSearchId({
           sort: isShowAllFilter ? '' : sortType,
           user: $scope.user.id
         });
@@ -191,7 +181,7 @@
           $scope.community.totalAssetsInCourse = $scope.community.assets.results.length;
         }
         $scope.community.assets.sortBy = sortType;
-        $scope.community.assets.advancedSearchId = getAdvancedSearchId({
+        $scope.community.assets.advancedSearchId = utilService.getAdvancedSearchId({
           sort: isShowAllFilter ? '' : sortType
         });
         $scope.community.assets.isLoading = false;

--- a/public/app/engagementindex/leaderboard/list.html
+++ b/public/app/engagementindex/leaderboard/list.html
@@ -54,7 +54,6 @@
             <a tool-href
               data-tool="dashboard"
               data-referring-tool="engagementindex"
-              data-course="me.course"
               data-id="user.id"
               data-ng-if="me.course.dashboard_url">
               <span data-ng-bind="user.canvas_full_name"></span>

--- a/public/app/shared/activityTimelineEventDetails.html
+++ b/public/app/shared/activityTimelineEventDetails.html
@@ -1,6 +1,6 @@
 <div class="event-details-container">
   <div data-ng-if="pageContext.tool === 'dashboard'">
-    <img class="event-details-thumbnail" 
+    <img class="event-details-thumbnail"
          data-ng-src="{{activity.asset.thumbnail_url}}"
          alt="{{activity.asset.title}}"
          title="{{activity.asset.title}}"/>
@@ -20,7 +20,6 @@
     <h3 class="event-details-title" data-ng-if="pageContext.tool === 'dashboard'">
       <a tool-href
          data-tool="assetlibrary"
-         data-course="pageContext.course"
          data-id="activity.asset.id"
          data-referring-tool="pageContext.tool"
          data-referring-id="pageContext.id"
@@ -28,17 +27,16 @@
     </h3>
 
     <p class="event-details-description">
-      <span data-ng-if="pageContext.tool === 'dashboard'"> 
+      <span data-ng-if="pageContext.tool === 'dashboard'">
         <i class="fa fa-comment" data-ng-if="display.comment"></i>
         <i class="fa fa-thumbs-up" data-ng-if="display.like"></i>
         <i class="fa fa-eye" data-ng-if="display.view"></i>
         <strong data-ng-bind="display.description"></strong>
       </span>
 
-      <span data-ng-if="pageContext.tool === 'assetlibrary'"> 
+      <span data-ng-if="pageContext.tool === 'assetlibrary'">
         <a tool-href
            data-tool="dashboard"
-           data-course="pageContext.course"
            data-id="activity.user.id"
            data-referring-tool="pageContext.tool"
            data-referring-id="pageContext.id"
@@ -62,7 +60,6 @@
                 data-ng-bind-template="&ldquo;{{display.snippet}}&hellip;&rdquo;"></span>
           <a tool-href
              data-tool="assetlibrary"
-             data-course="pageContext.course"
              data-id="activity.asset.id"
              data-referring-tool="pageContext.tool"
              data-referring-id="pageContext.id"
@@ -75,7 +72,6 @@
       <span data-ng-if="pageContext.tool === 'dashboard'">
         <a tool-href
            data-tool="dashboard"
-           data-course="pageContext.course"
            data-id="activity.user.id"
            data-referring-tool="pageContext.tool"
            data-referring-id="pageContext.id"

--- a/public/app/shared/hashtagsFilter.js
+++ b/public/app/shared/hashtagsFilter.js
@@ -37,7 +37,11 @@
      * @return {String}               The text in which the hashtags have been replaced with links
      */
     return function(input) {
-      return input.replace(/#(\w*[a-zA-Z_\-\.]+\w*)/gim, '<a href="/assetlibrary?keywords=$1">#$1</a>');
+      return input.replace(/#(\w*[a-zA-Z_\-\.]+\w*)/gim, function(match, hashtag) {
+        // Remove trailing punctuation, as it might have been picked up by regex above
+        var trimmed = hashtag.replace(/[\.\-]+$/g, '');
+        return '<a href="/assetlibrary?keywords=' + trimmed + '">#' + hashtag + '</a>';
+      });
     };
   });
 

--- a/public/app/shared/toolHrefHashtagFilter.js
+++ b/public/app/shared/toolHrefHashtagFilter.js
@@ -27,34 +27,25 @@
 
   'use strict';
 
-  /**
-   * Constructs URLs for linking from one SuiteC LTI tool to another.
-   */
-  angular.module('collabosphere').directive('toolHref', function(utilService) {
-    return {
-      // Directive matches on attribute name.
-      // @see https://docs.angularjs.org/guide/directive#template-expanding-directive
-      restrict: 'A',
+  angular.module('collabosphere').filter('toolHrefHashtag', function(utilService) {
 
-      // @see https://docs.angularjs.org/guide/directive#isolating-the-scope-of-a-directive
-      scope: {
-        tool: '=',
-        id: '=',
-        referringTool: '=',
-        referringId: '='
-      },
-
-      'link': function(scope, elem, attrs) {
-        scope.$watch('id', function() {
-          // 'id' and 'referring-tool' attributes may specify either a variable name (the evaluated value
-          // of which appears under 'scope'), or a string literal (which appears under 'attrs').
-          var id = scope.id || attrs.id;
-          var referringTool = scope.referringTool || attrs.referringTool;
-
-          elem.attr('href', utilService.getToolHref(attrs.tool, id, referringTool, scope.referringId));
-          elem.attr('target', '_parent');
-        });
-      }
+    /**
+     * Replace each hashtag with a link to the asset library that will search through the asset library
+     * for that keyword.
+     *
+     * @param  {String}     input             Text containing hashtags. Hashtags will be replaced with proper hrefs.
+     * @param  {String}     referringTool     SuiteC tool in which user initiated the action
+     * @param  {String}     referringId       State of the referring tool, at time of exit
+     * @return {String}                       The processed text, in which hashtags were replaced with links
+     */
+    return function(input, referringTool, referringId) {
+      return input.replace(/#(\w*[a-zA-Z_\-\.]+\w*)/gim, function(match, hashtag) {
+        // Remove trailing punctuation, as it might have been picked up by regex above
+        var trimmed = hashtag.replace(/[\.\-]+$/g, '');
+        var id = utilService.getAdvancedSearchId({'keywords': trimmed});
+        var url = utilService.getToolHref('assetlibrary', id, referringTool, referringId);
+        return '<a href="' + url + '" target="_parent">#' + hashtag + '</a>';
+      });
     };
   });
 

--- a/public/app/shared/utilService.js
+++ b/public/app/shared/utilService.js
@@ -27,7 +27,7 @@
 
   'use strict';
 
-  angular.module('collabosphere').service('utilService', function(analyticsService, $cookies, $location, $q, $timeout) {
+  angular.module('collabosphere').service('utilService', function(analyticsService, me, $cookies, $location, $q, $timeout) {
 
     // Cache the API domain and Course ID that were passed in through
     // the iFrame launch URL. These variables need to be used to construct
@@ -48,6 +48,16 @@
         'toolUrl': toolUrl
       };
       return launchParams;
+    };
+
+    /**
+     * Get encoded instructions to pre-populate Asset Library's advanced search.
+     *
+     * @param  {Object}         searchOptions             Properties associated with dropdowns of Advanced Search
+     * @return {String}                                   Search options, stringified
+     */
+    var getAdvancedSearchId = function(searchOptions) {
+      return 'assetlibrarylist:' + JSON.stringify(searchOptions);
     };
 
     /**
@@ -88,6 +98,44 @@
      */
     var getToolUrl = function() {
       return toolUrl;
+    };
+
+    /**
+     * Get URL to link from one SuiteC LTI tool to another
+     *
+     * @param  {String}       tool            Name of SuiteC LTI tool targeted in URL
+     * @param  {String}       id              Represents an asset, user or view requested via link action
+     * @param  {String}       referringTool   SuiteC tool in which user initiated the action
+     * @param  {String}       referringId     State of the referring tool, at time of exit
+     * @return {String}                       URL used to reload page, not simply the iFrame
+     */
+    var getToolHref = function(tool, id, referringTool, referringId) {
+      // 'id' may refer to router-state, asset id, user id or similar.
+      var queryArgs = id ? '?_id=' + encodeURIComponent(id) : '';
+      if (referringTool) {
+        queryArgs = queryArgs ? queryArgs + '&' : '?';
+        queryArgs += '_referring_tool=' + referringTool;
+        if (referringId) {
+          queryArgs += '&_referring_id=' + encodeURIComponent(referringId);
+        }
+      }
+      switch (tool) {
+        case 'assetlibrary': {
+          return me.course.assetlibrary_url + queryArgs;
+        }
+        case 'dashboard': {
+          return me.course.dashboard_url + queryArgs;
+        }
+        case 'engagementindex': {
+          return me.course.engagementindex_url + queryArgs;
+        }
+        case 'whiteboards': {
+          return me.course.whiteboards_url + queryArgs;
+        }
+        default: {
+          return null;
+        }
+      }
     };
 
     /**
@@ -418,11 +466,13 @@
       'addAssetInclusionFilter': addAssetInclusionFilter,
       'appendOrdinalSuffix': appendOrdinalSuffix,
       'buildSearchResultsMessage': buildSearchResultsMessage,
+      'getAdvancedSearchId': getAdvancedSearchId,
       'getApiUrl': getApiUrl,
       'getColorConstants': getColorConstants,
       'getLaunchParams': getLaunchParams,
       'getParentUrlData': getParentUrlData,
       'getScrollInformation': getScrollInformation,
+      'getToolHref': getToolHref,
       'getToolUrl': getToolUrl,
       'resizeIFrame': resizeIFrame,
       'scrollTo': scrollTo,

--- a/public/index.html
+++ b/public/index.html
@@ -94,6 +94,7 @@
   <script src="/app/shared/sanitizeFilter.js"></script>
   <script src="/app/shared/syncDisabledController.js"></script>
   <script src="/app/shared/toolHrefDirective.js"></script>
+  <script src="/app/shared/toolHrefHashtagFilter.js"></script>
   <script src="/app/shared/uniqueFilter.js"></script>
   <script src="/app/shared/userFactory.js"></script>
   <script src="/app/shared/utilService.js"></script>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-924

Notes:
* Delicate refactor of toolHref logic such that the new `toolHrefHashtagFilter` can build proper links in, for example, personal descriptions.
* Because dots and dashes are allowed in hashtags, we must tweak the regex which extracts `_id` from toolHref URL.
* Hashtag followed by period (e.g., "Ready for the #world.") leads to search on keyword='world.' but user prolly wanted keyword='world'   Both hashtag-related filters are fixed. 

Bonus: `data-course` is not needed in the markup of directive.