### PR TITLE
COL-935, AssetsAPI gets pin and unpin; getAssets query gets filter and sort per pins

### DIFF
--- a/node_modules/col-assets/lib/api.js
+++ b/node_modules/col-assets/lib/api.js
@@ -148,6 +148,10 @@ var getAsset = module.exports.getAsset = function(ctx, id, opts, callback) {
           'model': DB.User,
           'attributes': UserConstants.BASIC_USER_FIELDS
         }]
+      },
+      {
+        'model': DB.Pin,
+        'as': 'pins'
       }
     ]
   };
@@ -275,8 +279,9 @@ var addUserToAsset = module.exports.addUserToAsset = function(asset, userId, cal
  * @param  {Number}         [filters.assignment]            The id of the assignment to which the assets should belong
  * @param  {Boolean}        [filters.hasComments]           If true then exclude zero comment_count; if false then zero comment_count only; if null do nothing
  * @param  {Boolean}        [filters.hasImpact]             If true then exclude zero impact; if false then zero impact only; if null do nothing
- * @param  {Boolean}        [filters.hasTrending]           If true then exclude zero trending score; if false then zero trending score only; if null do nothing
  * @param  {Boolean}        [filters.hasLikes]              If true then exclude zero likes; if false then zero likes only; if null do nothing
+ * @param  {Boolean}        [filters.hasPins]               If true then exclude assets with zero pins; if false then zero pins only; if null do nothing
+ * @param  {Boolean}        [filters.hasTrending]           If true then exclude zero trending score; if false then zero trending score only; if null do nothing
  * @param  {Boolean}        [filters.hasViews]              If true then exclude zero views; if false then zero views only; if null do nothing
  * @param  {Number}         [sort]                          A criterion to sort by. Defaults to 'recent' (id descending).
  * @param  {Number}         [limit]                         The maximum number of results to retrieve. Defaults to 10
@@ -311,8 +316,9 @@ var getAssets = module.exports.getAssets = function(ctx, filters, sort, limit, o
       'assignment': Joi.number().optional(),
       'hasComments': Joi.string().optional(),
       'hasImpact': Joi.string().optional(),
-      'hasTrending': Joi.string().optional(),
       'hasLikes': Joi.string().optional(),
+      'hasPins': Joi.string().optional(),
+      'hasTrending': Joi.string().optional(),
       'hasViews': Joi.string().optional()
     }),
     'sort': Joi.string().valid(['recent', 'likes', 'views', 'comments', 'impact', 'trending']).required(),
@@ -344,20 +350,22 @@ var getAssets = module.exports.getAssets = function(ctx, filters, sort, limit, o
     'offset': offset
   };
 
-  var sqlQuery = 'FROM assets a ' +
-                 'LEFT JOIN assets_categories ac ON a.id = ac.asset_id ' +
-                 'LEFT JOIN categories c ON c.id = ac.category_id ' +
-                 'LEFT JOIN asset_users au ON a.id = au.asset_id ' +
-                 'LEFT JOIN users u ON au.user_id = u.id ' +
-                 'LEFT JOIN activities act ON a.id = act.asset_id' +
-                 ' AND act.course_id = :course_id' +
-                 ' AND act.user_id = :user_id' +
-                 ' AND act.object_type = \'asset\'' +
-                 ' AND act.type IN(\'like\', \'dislike\') ' +
-                 'WHERE a.deleted_at IS NULL' +
-                 ' AND a.course_id = :course_id ' +
-                 ' AND a.visible = TRUE ' +
-                 ' AND (c.visible = TRUE OR c.visible IS NULL)';
+  var sqlQuery = `FROM assets a
+    LEFT JOIN assets_categories ac ON a.id = ac.asset_id
+    LEFT JOIN categories c ON c.id = ac.category_id
+    LEFT JOIN asset_users au ON a.id = au.asset_id
+    LEFT JOIN users u ON au.user_id = u.id
+    LEFT JOIN pinned_user_assets p ON a.id = p.asset_id
+    LEFT JOIN activities act ON a.id = act.asset_id
+     AND act.course_id = :course_id
+     AND act.user_id = :user_id
+     AND act.object_type = 'asset'
+     AND act.type IN('like', 'dislike')
+    WHERE a.deleted_at IS NULL
+     AND a.course_id = :course_id
+     AND a.visible = TRUE
+     AND (c.visible = TRUE OR c.visible IS NULL)
+  `;
 
   if (filters.keywords) {
     sqlQuery += ' AND (a.title ILIKE :keywords OR a.description ILIKE :keywords)';
@@ -395,14 +403,19 @@ var getAssets = module.exports.getAssets = function(ctx, filters, sort, limit, o
     sqlQuery += hasImpact ? ' AND a.impact_score > 0' : ' AND a.impact_score = 0';
   }
 
-  var hasTrending = CollabosphereUtil.getBooleanParam(filters.hasTrending, null);
-  if (hasTrending !== null) {
-    sqlQuery += hasTrending ? ' AND a.trending_score > 0' : ' AND a.trending_score = 0';
-  }
-
   var hasLikes = CollabosphereUtil.getBooleanParam(filters.hasLikes, null);
   if (hasLikes !== null) {
     sqlQuery += hasLikes ? ' AND a.likes > 0' : ' AND a.likes = 0';
+  }
+
+  var hasPins = CollabosphereUtil.getBooleanParam(filters.hasPins, null);
+  if (hasPins !== null) {
+    sqlQuery += hasPins ? ' AND p.asset_id IS NOT NULL' : ' AND p.asset_id IS NULL';
+  }
+
+  var hasTrending = CollabosphereUtil.getBooleanParam(filters.hasTrending, null);
+  if (hasTrending !== null) {
+    sqlQuery += hasTrending ? ' AND a.trending_score > 0' : ' AND a.trending_score = 0';
   }
 
   var hasViews = CollabosphereUtil.getBooleanParam(filters.hasViews, null);
@@ -411,7 +424,15 @@ var getAssets = module.exports.getAssets = function(ctx, filters, sort, limit, o
   }
 
   // Query that will be used to get the actual assets
-  var resultsSqlQuery = 'SELECT DISTINCT ON (a.id, a.likes, a.views, a.comment_count, a.impact_score, a.trending_score) a.*, act.type AS activity_type ' + sqlQuery;
+  var resultsSqlQuery = `SELECT
+    DISTINCT ON (a.id, a.likes, a.views, a.comment_count, a.impact_score, a.trending_score)
+    a.*,
+    act.type AS activity_type,
+    (select count(*) from pinned_user_assets p where p.asset_id = a.id)::int AS pin_count
+  `;
+  resultsSqlQuery += sqlQuery;
+
+
   if (sort === 'recent') {
     resultsSqlQuery += ' ORDER BY a.id DESC';
   } else if (sort === 'likes') {
@@ -425,6 +446,7 @@ var getAssets = module.exports.getAssets = function(ctx, filters, sort, limit, o
   } else if (sort === 'trending') {
     resultsSqlQuery += ' ORDER BY a.trending_score DESC, a.id DESC';
   }
+
   resultsSqlQuery += ' LIMIT :limit OFFSET :offset';
 
   // Query that will be used to get the total count
@@ -1892,6 +1914,107 @@ var like = module.exports.like = function(ctx, assetId, like, callback) {
           });
         });
       });
+    });
+  });
+};
+
+/* (UN)PINNING */
+
+/**
+ * (Un)pin an asset
+ *
+ * @param  {Context}        ctx                             Standard context containing the current user and the current course
+ * @param  {Number}         assetId                         The id of the asset that is pinned or unpinned
+ * @param  {Boolean}        pin                             `true` when the asset should be pinned, `false` when the asset should be unpinned
+ * @param  {Function}       callback                        Standard callback function
+ * @param  {Object}         callback.err                    An error that occurred, if any
+ * @param  {Asset}          callback.asset                  The asset that has been liked or disliked
+ */
+var pin = module.exports.pin = function(ctx, assetId, pin, callback) {
+  // Parameter validation
+  var validationSchema = Joi.object().keys({
+    'assetId': Joi.number().required(),
+    'pin': Joi.boolean().required()
+  });
+
+  var validationResult = Joi.validate({
+    'assetId': assetId,
+    'pin': pin
+  }, validationSchema);
+
+  if (validationResult.error) {
+    return callback({'code': 400, 'msg': validationResult.error.details[0].message});
+  }
+
+  // Get the asset that is being (un)pinned
+  getAsset(ctx, assetId, {'incrementViews': false}, function(err, asset) {
+    if (err) {
+      log.error({'user': ctx.user, 'asset': assetId, 'err': err}, 'Failed to retrieve asset');
+      return callback(err);
+    } else if (!asset) {
+      log.error({'user': ctx.user}, 'Asset not found');
+      return callback({'code': 404, 'msg': 'Asset not found'});
+    }
+
+    var wasPinned = !!_.find(asset.pins, function(p) { return p.user_id === ctx.user.id; });
+
+    if (wasPinned === pin) {
+      var msg = '\'pin\' must be the opposite of \'wasPinned\'';
+      log.error({'user': ctx.user.id, 'asset': asset.id, 'pin': pin}, msg);
+      return callback({'code': 400, 'msg': msg}, asset);
+    }
+
+    (pin ? addPinToAsset : unPinAsset)(asset.id, ctx.user.id, function(err) {
+      if (err) {
+        var msg = 'Failed to ' + (pin ? 'pin' : 'unpin') + ' asset';
+        log.error({'user': ctx.user.id, 'asset': asset.id, 'pin': pin}, msg);
+        return callback(err, msg);
+      }
+
+      return callback(null, asset);
+    });
+  });
+};
+
+var addPinToAsset = function(assetId, userId, callback) {
+  var pin = {
+    'asset_id': assetId,
+    'user_id': userId
+  };
+
+  DB.Pin.create(pin).complete(function(err, pin) {
+    if (err) {
+      log.error({'err': err, 'asset': assetId, 'user': userId}, 'Failed to create a new pin');
+      return callback({'code': 500, 'msg': err.message});
+    }
+
+    return callback(null, pin);
+  });
+};
+
+var unPinAsset = function(assetId, userId, callback) {
+  var options = {
+    'where': {
+      'asset_id': assetId,
+      'user_id': userId
+    }
+  };
+  DB.Pin.find(options).complete(function(err, pin) {
+    if (err) {
+      log.error({'err': err, 'asset': assetId, 'user': userId}, 'Failed to retrieve existing pin');
+      return callback({'code': 500, 'msg': err.message});
+    } else if (!pin) {
+      var msg = 'Asset has no pin owned by this user';
+      log.error({'asset': assetId, 'user': userId}, msg);
+      return callback({'code': 404, 'msg': msg});
+    }
+    pin.destroy().complete(function(err) {
+      if (err) {
+        log.error({'err': err, 'pin': pin}, 'Failed to delete pin');
+        return callback({'code': 500, 'msg': err.message});
+      }
+
+      return callback(null, pin);
     });
   });
 };

--- a/node_modules/col-assets/lib/rest.js
+++ b/node_modules/col-assets/lib/rest.js
@@ -69,8 +69,9 @@ Collabosphere.apiRouter.get('/assets', function(req, res) {
     'types': CollabosphereUtil.toArray(req.query.type),
     'hasComments': req.query.hasComments,
     'hasImpact': req.query.hasImpact,
-    'hasTrending': req.query.hasTrending,
     'hasLikes': req.query.hasLikes,
+    'hasPins': req.query.hasPins,
+    'hasTrending': req.query.hasTrending,
     'hasViews': req.query.hasViews
   };
   var sort = req.query.sort;
@@ -303,6 +304,33 @@ Collabosphere.apiRouter.post('/assets/:assetId/like', function(req, res) {
       event = 'Unlike asset';
     }
     AnalyticsAPI.track(req.ctx.user, event, AnalyticsAPI.getAssetProperties(asset));
+
+    return res.sendStatus(200);
+  });
+});
+
+
+/*!
+ * Pin an asset
+ */
+Collabosphere.apiRouter.post('/assets/:assetId/pin', function(req, res) {
+  AssetsAPI.pin(req.ctx, req.params.assetId, true, function(err, asset) {
+    if (err) {
+      return res.status(err.code).send(err.msg);
+    }
+
+    return res.sendStatus(200);
+  });
+});
+
+/*!
+ * Unpin an asset
+ */
+Collabosphere.apiRouter.post('/assets/:assetId/unpin', function(req, res) {
+  AssetsAPI.pin(req.ctx, req.params.assetId, false, function(err, asset) {
+    if (err) {
+      return res.status(err.code).send(err.msg);
+    }
 
     return res.sendStatus(200);
   });

--- a/node_modules/col-assets/tests/test-assets.js
+++ b/node_modules/col-assets/tests/test-assets.js
@@ -122,8 +122,9 @@ describe('Assets', function() {
    * @param  {Number}             [filters.type]            The type of assets. One of `CollabosphereConstants.ASSET.ASSET_TYPES`
    * @param  {Boolean}            [filters.hasComments]     If true then exclude zero comment_count; if false then zero comment_count only; if null do nothing
    * @param  {Boolean}            [filters.hasImpact]       If true then exclude zero impact; if false then zero impact only; if null do nothing
-   * @param  {Boolean}            [filters.hasTrending]     If true then exclude zero trending score; if false then zero trending score only; if null do nothing
    * @param  {Boolean}            [filters.hasLikes]        If true then exclude zero likes; if false then zero likes only; if null do nothing
+   * @param  {Boolean}            [filters.hasPins]         If true then exclude assets with zero pins; if false then zero pins only; if null do nothing
+   * @param  {Boolean}            [filters.hasTrending]     If true then exclude zero trending score; if false then zero trending score only; if null do nothing
    * @param  {Boolean}            [filters.hasViews]        If true then exclude zero views; if false then zero views only; if null do nothing
    * @param  {Asset[]}            expectedAssets            The expected assets
    * @param  {Function}           callback                  Standard callback function
@@ -679,72 +680,97 @@ describe('Assets', function() {
                                     AssetsTestUtil.assertGetAsset(client3, course, assets[2].id, null, 0, function(asset) {
                                       AssetsTestUtil.assertGetAsset(client4, course, assets[2].id, null, 0, function(asset) {
 
-                                        // Generate some comments
-                                        AssetsTestUtil.assertCreateComment(client2, course, assets[8].id, 'Comment', null, function(comment) {
-                                          AssetsTestUtil.assertCreateComment(client2, course, assets[9].id, 'Comment', null, function(comment) {
-                                            AssetsTestUtil.assertCreateComment(client2, course, assets[10].id, 'Comment', null, function(comment) {
-                                              AssetsTestUtil.assertCreateComment(client3, course, assets[9].id, 'Comment', null, function(comment) {
-                                                AssetsTestUtil.assertCreateComment(client3, course, assets[10].id, 'Comment', null, function(comment) {
-                                                  AssetsTestUtil.assertCreateComment(client3, course, assets[11].id, 'Comment', null, function(comment) {
+                                        // Pin some assets
+                                        AssetsTestUtil.assertPinAsset(client1, user1, course, assets[1].id, function(asset) {
+                                          AssetsTestUtil.assertPinAsset(client2, user2, course, assets[2].id, function(asset) {
+                                            AssetsTestUtil.assertPinAsset(client3, user3, course, assets[3].id, function(asset) {
 
-                                                    // Get all assets unpaged for purposes of comparison
-                                                    AssetsTestUtil.assertGetAssets(client1, course, null, 'recent', 12, null, 12, function(assets) {
-                                                      assets = assets.results;
 
-                                                      // Verify that sorting by 'recent' returns two pages of assets in reverse creation order
-                                                      AssetsTestUtil.assertGetAssets(client1, course, null, 'recent', null, null, 12, function(pagedAssets) {
-                                                        AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), 12);
+                                              // Generate some comments
+                                              AssetsTestUtil.assertCreateComment(client2, course, assets[8].id, 'Comment', null, function(comment) {
+                                                AssetsTestUtil.assertCreateComment(client2, course, assets[9].id, 'Comment', null, function(comment) {
+                                                  AssetsTestUtil.assertCreateComment(client2, course, assets[10].id, 'Comment', null, function(comment) {
+                                                    AssetsTestUtil.assertCreateComment(client3, course, assets[9].id, 'Comment', null, function(comment) {
+                                                      AssetsTestUtil.assertCreateComment(client3, course, assets[10].id, 'Comment', null, function(comment) {
+                                                        AssetsTestUtil.assertCreateComment(client3, course, assets[11].id, 'Comment', null, function(comment) {
 
-                                                        AssetsTestUtil.assertGetAssets(client1, course, null, 'recent', null, 10, 12, function(pagedAssets) {
-                                                          AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [10, 11]), 12);
+                                                          // Get all assets unpaged for purposes of comparison
+                                                          AssetsTestUtil.assertGetAssets(client1, course, null, 'recent', 12, null, 12, function(assets) {
+                                                            assets = assets.results;
 
-                                                          // Verify that sorting by 'likes' returns two pages of assets ordered by 1) like count, 2) creation time
-                                                          AssetsTestUtil.assertGetAssets(client1, course, null, 'likes', null, null, 12, function(pagedAssets) {
-                                                            AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [7, 8, 6, 9, 0, 1, 2, 3, 4, 5]), 12);
+                                                            // Verify that sorting by 'recent' returns two pages of assets in reverse creation order
+                                                            AssetsTestUtil.assertGetAssets(client1, course, null, 'recent', null, null, 12, function(pagedAssets) {
+                                                              AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), 12);
 
-                                                            AssetsTestUtil.assertGetAssets(client1, course, null, 'likes', null, 10, 12, function(pagedAssets) {
-                                                              AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [10, 11]), 12);
+                                                              AssetsTestUtil.assertGetAssets(client1, course, null, 'recent', null, 10, 12, function(pagedAssets) {
+                                                                AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [10, 11]), 12);
 
-                                                              // Verify that sorting by 'views' returns two pages of assets ordered by 1) view count, 2) creation time
-                                                              AssetsTestUtil.assertGetAssets(client1, course, null, 'views', null, null, 12, function(pagedAssets) {
-                                                                AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [7, 8, 2, 1, 6, 9, 0, 3, 4, 5]), 12);
+                                                                // Verify that sorting by 'likes' returns two pages of assets ordered by 1) like count, 2) creation time
+                                                                AssetsTestUtil.assertGetAssets(client1, course, null, 'likes', null, null, 12, function(pagedAssets) {
+                                                                  AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [7, 8, 6, 9, 0, 1, 2, 3, 4, 5]), 12);
 
-                                                                AssetsTestUtil.assertGetAssets(client1, course, null, 'views', null, 10, 12, function(pagedAssets) {
-                                                                  AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [10, 11]), 12);
+                                                                  AssetsTestUtil.assertGetAssets(client1, course, null, 'likes', null, 10, 12, function(pagedAssets) {
+                                                                    AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [10, 11]), 12);
 
-                                                                  // Verify that sorting by 'comments' returns two pages of assets ordered by 1) comment count, 2) creation time
-                                                                  AssetsTestUtil.assertGetAssets(client1, course, null, 'comments', null, null, 12, function(pagedAssets) {
-                                                                    AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [9, 10, 8, 11, 0, 1, 2, 3, 4, 5]), 12);
+                                                                    // Verify that sorting by 'views' returns two pages of assets ordered by 1) view count, 2) creation time
+                                                                    AssetsTestUtil.assertGetAssets(client1, course, null, 'views', null, null, 12, function(pagedAssets) {
+                                                                      AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [7, 8, 2, 1, 6, 9, 0, 3, 4, 5]), 12);
 
-                                                                    AssetsTestUtil.assertGetAssets(client1, course, null, 'comments', null, 10, 12, function(pagedAssets) {
-                                                                      AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [6, 7]), 12);
+                                                                      AssetsTestUtil.assertGetAssets(client1, course, null, 'views', null, 10, 12, function(pagedAssets) {
+                                                                        AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [10, 11]), 12);
 
-                                                                      // Verify that sorting by 'impact' returns two pages of assets ordered by:
-                                                                      // - 1) weighted total of comments (6 pts), likes (3 pts), views (2 pts);
-                                                                      // - 2) creation time
-                                                                      AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', null, null, 12, function(pagedAssets) {
-                                                                        AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [8, 9, 7, 10, 6, 2, 11, 1, 0, 3]), 12);
+                                                                        // Verify that sorting by 'comments' returns two pages of assets ordered by 1) comment count, 2) creation time
+                                                                        AssetsTestUtil.assertGetAssets(client1, course, null, 'comments', null, null, 12, function(pagedAssets) {
+                                                                          AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [9, 10, 8, 11, 0, 1, 2, 3, 4, 5]), 12);
 
-                                                                        AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', null, 10, 12, function(pagedAssets) {
-                                                                          AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [4, 5]), 12);
+                                                                          AssetsTestUtil.assertGetAssets(client1, course, null, 'comments', null, 10, 12, function(pagedAssets) {
+                                                                            AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [6, 7]), 12);
 
-                                                                          // Verify that before trending scores are calculated, a search for trending assets with hasTrending: true returns nothing
-                                                                          AssetsTestUtil.assertGetAssets(client1, course, {'hasTrending': true}, 'trending', null, null, 0, function(pagedAssets) {
-                                                                            assert.ok(_.isEmpty(pagedAssets.results));
+                                                                            // Verify that sorting by 'impact' returns two pages of assets ordered by:
+                                                                            // - 1) weighted total of comments (6 pts), likes (3 pts), views (2 pts);
+                                                                            // - 2) creation time
+                                                                            AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', null, null, 12, function(pagedAssets) {
+                                                                              AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [8, 9, 7, 10, 6, 2, 11, 1, 0, 3]), 12);
 
-                                                                            // Verify that after trending scores are calculated, a search for trending assets returns the same results as sorting by impact
-                                                                            ActivitiesAPI.recalculateTrendingScores(null, function() {
-                                                                              AssetsTestUtil.assertGetAssets(client1, course, null, 'trending', null, null, 12, function(pagedAssets) {
-                                                                                AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [8, 9, 7, 10, 6, 2, 11, 1, 0, 3]), 12, {'allowTimestampDiscrepancy': true});
+                                                                              AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', null, 10, 12, function(pagedAssets) {
+                                                                                AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [4, 5]), 12);
 
-                                                                                AssetsTestUtil.assertGetAssets(client1, course, null, 'trending', null, 10, 12, function(pagedAssets) {
-                                                                                  AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [4, 5]), 12, {'allowTimestampDiscrepancy': true});
+                                                                                // Verify that before trending scores are calculated, a search for trending assets with hasTrending: true returns nothing
+                                                                                AssetsTestUtil.assertGetAssets(client1, course, {'hasTrending': true}, 'trending', null, null, 0, function(pagedAssets) {
+                                                                                  assert.ok(_.isEmpty(pagedAssets.results));
 
-                                                                                  // Verify that a search for trending assets with hasTrending: true omits assets 3, 4, 5, which got no love
-                                                                                  AssetsTestUtil.assertGetAssets(client1, course, {'hasTrending': true}, 'trending', null, null, 9, function(pagedAssets) {
-                                                                                    AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [8, 9, 7, 10, 6, 2, 11, 1, 0]), 9, {'allowTimestampDiscrepancy': true});
+                                                                                  // Verify that after trending scores are calculated, a search for trending assets returns the same results as sorting by impact
+                                                                                  ActivitiesAPI.recalculateTrendingScores(null, function() {
+                                                                                    AssetsTestUtil.assertGetAssets(client1, course, null, 'trending', null, null, 12, function(pagedAssets) {
+                                                                                      AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [8, 9, 7, 10, 6, 2, 11, 1, 0, 3]), 12, {'allowTimestampDiscrepancy': true});
 
-                                                                                    return callback();
+                                                                                      AssetsTestUtil.assertGetAssets(client1, course, null, 'trending', null, 10, 12, function(pagedAssets) {
+                                                                                        AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [4, 5]), 12, {'allowTimestampDiscrepancy': true});
+
+                                                                                        // Verify that a search for trending assets with hasTrending: true omits assets 3, 4, 5, which got no love
+                                                                                        AssetsTestUtil.assertGetAssets(client1, course, {'hasTrending': true}, 'trending', null, null, 9, function(pagedAssets) {
+                                                                                          AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [8, 9, 7, 10, 6, 2, 11, 1, 0]), 9, {'allowTimestampDiscrepancy': true});
+
+                                                                                          // Verify that a search for assets with `hasPins: true` omits unpinned assets
+                                                                                          AssetsTestUtil.assertGetAssets(client1, course, {'hasPins': true}, 'recent', null, null, 3, function(pagedAssets) {
+                                                                                            AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [1, 2, 3]), 3, {'allowTimestampDiscrepancy': true});
+
+                                                                                            AssetsTestUtil.assertUnpinAsset(client2, user2, course, assets[2].id, function(asset) {
+                                                                                              AssetsTestUtil.assertGetAssets(client1, course, {'hasPins': true}, 'recent', null, null, 2, function(pagedAssets) {
+                                                                                                AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [1, 3]), 2, {'allowTimestampDiscrepancy': true});
+
+                                                                                                // Verify that a search for assets with `hasPins: false` omits pinned assets
+                                                                                                AssetsTestUtil.assertGetAssets(client1, course,  {'hasPins': false}, 'recent', null, null, 10, function(notPinnedAssets) {
+                                                                                                  AssetsTestUtil.assertAssets(notPinnedAssets, _.at(assets, [0, 2, 4, 5, 6, 7, 8, 9, 10, 11]), 10, {'allowTimestampDiscrepancy': true});
+
+                                                                                                   return callback();
+                                                                                                });
+                                                                                              });
+                                                                                            });
+                                                                                          });
+                                                                                        });
+                                                                                      });
+                                                                                    });
                                                                                   });
                                                                                 });
                                                                               });

--- a/node_modules/col-assets/tests/util.js
+++ b/node_modules/col-assets/tests/util.js
@@ -614,8 +614,9 @@ var assertGetAssetFails = module.exports.assertGetAssetFails = function(client, 
  * @param  {String[]}           [filters.types]                 The type of assets. One or more of `CollabosphereConstants.ASSET.ASSET_TYPES`
  * @param  {Boolean}            [filters.hasComments]           If true then exclude zero comment_count; if false then zero comment_count only; if null do nothing
  * @param  {Boolean}            [filters.hasImpact]             If true then exclude zero impact; if false then zero impact only; if null do nothing
- * @param  {Boolean}            [filters.hasTrending]           If true then exclude zero trending; if false then zero trending only; if null do nothing
  * @param  {Boolean}            [filters.hasLikes]              If true then exclude zero likes; if false then zero likes only; if null do nothing
+ * @param  {Boolean}            [filters.hasPins]               If true then exclude assets with zero pins; if false then zero pins only; if null do nothing
+ * @param  {Boolean}            [filters.hasTrending]           If true then exclude zero trending; if false then zero trending only; if null do nothing
  * @param  {Boolean}            [filters.hasViews]              If true then exclude zero views; if false then zero views only; if null do nothing
  * @param  {String}             [sort]                          An optional criterion to sort by. Defaults to id descending
  * @param  {Number}             [limit]                         The maximum number of results to retrieve. Defaults to 10
@@ -818,9 +819,12 @@ var assertDeleteAssetFails = module.exports.assertDeleteAssetFails = function(cl
  */
 var assertCreateComment = module.exports.assertCreateComment = function(client, course, assetId, body, parent, callback) {
   // Get the asset on which a comment is being made
-  client.assets.getAsset(course, assetId, false, function(err, originalAsset) {
+  client.assets.getAsset(course, assetId, false, function(err, asset) {
     assert.ok(!err);
-    assert.ok(originalAsset);
+    assert.ok(asset);
+
+    // Expected value after create
+    var previousCommentCount = asset.comment_count + 1;
 
     // Create the comment
     client.assets.createComment(course, assetId, body, parent, function(err, comment) {
@@ -837,9 +841,75 @@ var assertCreateComment = module.exports.assertCreateComment = function(client, 
       client.assets.getAsset(course, assetId, false, function(err, asset) {
         assert.ok(!err);
         assert.ok(asset);
-        assert.strictEqual(asset.comment_count, originalAsset.comment_count + 1);
+        assert.strictEqual(asset.comment_count, previousCommentCount);
 
         return callback(comment);
+      });
+    });
+  });
+};
+
+/**
+ * Assert that an asset can be pinned
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
+ * @param  {Number}             assetId                         The id of the asset which will be pinned
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertPinAsset = module.exports.assertPinAsset = function(client, user, course, assetId, callback) {
+  // Get the asset on which a comment is being made
+  client.assets.getAsset(course, assetId, false, function(err, asset) {
+    assert.ok(!err);
+    assert.ok(asset);
+
+    var previousPinCount = asset.pins.length;
+    // Create the comment
+    client.assets.pin(course, assetId, function(err) {
+      assert.ok(!err);
+
+      // Verify that the pin count has been increased
+      client.assets.getAsset(course, assetId, false, function(err, asset) {
+        assert.ok(!err);
+        assert.ok(asset);
+        assert.strictEqual(asset.pins.length, previousPinCount + 1);
+
+        return callback();
+      });
+    });
+  });
+};
+
+/**
+ * Assert that an asset can be unpinned
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
+ * @param  {Number}             assetId                         The id of the asset which will be unpinned
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertUnpinAsset = module.exports.assertUnpinAsset = function(client, user, course, assetId, callback) {
+  // Get the asset on which a comment is being made
+  client.assets.getAsset(course, assetId, false, function(err, asset) {
+    assert.ok(!err);
+    assert.ok(asset);
+
+    var previousPinCount = asset.pins.length;
+    assert.ok(previousPinCount);
+
+    // Create the comment
+    client.assets.unpin(course, assetId, function(err) {
+      assert.ok(!err);
+
+      // Verify that the pin count has been increased
+      client.assets.getAsset(course, assetId, false, function(err, asset) {
+        assert.ok(!err);
+        assert.ok(asset);
+        assert.strictEqual(asset.pins.length, previousPinCount - 1);
+
+        return callback();
       });
     });
   });

--- a/node_modules/col-rest/lib/rest/assets.js
+++ b/node_modules/col-rest/lib/rest/assets.js
@@ -58,8 +58,9 @@ module.exports = function(client) {
    * @param  {String[]}       [filters.types]                 The type of assets. One or more of `CollabosphereConstants.ASSET.ASSET_TYPES`
    * @param  {Boolean}        [filters.hasComments]           If true then exclude zero comment_count; if false then zero comment_count only; if null do nothing
    * @param  {Boolean}        [filters.hasImpact]             If true then exclude zero impact; if false then zero impact only; if null do nothing
-   * @param  {Boolean}        [filters.hasTrending]           If true then exclude zero trending score; if false then zero trending score only; if null do nothing
    * @param  {Boolean}        [filters.hasLikes]              If true then exclude zero likes; if false then zero likes only; if null do nothing
+   * @param  {Boolean}        [filters.hasPins]               If true then exclude assets with zero pins; if false then zero pins only; if null do nothing
+   * @param  {Boolean}        [filters.hasTrending]           If true then exclude zero trending score; if false then zero trending score only; if null do nothing
    * @param  {Boolean}        [filters.hasViews]              If true then exclude zero views; if false then zero views only; if null do nothing
    * @param  {String}         [sort]                          An optional criterion to sort by. Defaults to id descending
    * @param  {Number}         [limit]                         The maximum number of results to retrieve. Defaults to 10
@@ -81,8 +82,9 @@ module.exports = function(client) {
       'type': filters.types,
       'hasComments': filters.hasComments,
       'hasImpact': filters.hasImpact,
-      'hasTrending': filters.hasTrending,
       'hasLikes': filters.hasLikes,
+      'hasPins': filters.hasPins,
+      'hasTrending': filters.hasTrending,
       'hasViews': filters.hasViews,
       'sort': sort,
       'limit': limit,
@@ -334,6 +336,38 @@ module.exports = function(client) {
       'like': like
     };
     client.request(requestUrl, 'POST', data, null, callback);
+  };
+
+  /**
+   * Pin an asset
+   *
+   * @param  {Course}         course                          The Canvas course in which the user is interacting with the API
+   * @param  {Number}         assetId                         The id of the asset to be pinned
+   * @param  {Function}       callback                        Standard callback function
+   * @param  {Object}         callback.err                    An error that occurred, if any
+   * @param  {Object}         callback.body                   The JSON response from the REST API
+   * @param  {Response}       callback.response               The response object as returned by requestjs
+   * @see col-assets/lib/rest.js for more information
+   */
+  client.assets.pin = function(course, assetId, callback) {
+    var requestUrl = client.util.apiPrefix(course) + '/assets/' + client.util.encodeURIComponent(assetId) + '/pin';
+    client.request(requestUrl, 'POST', null, null, callback);
+  };
+
+  /**
+   * Unpin an asset
+   *
+   * @param  {Course}         course                          The Canvas course in which the user is interacting with the API
+   * @param  {Number}         assetId                         The id of the asset to be unpinned
+   * @param  {Function}       callback                        Standard callback function
+   * @param  {Object}         callback.err                    An error that occurred, if any
+   * @param  {Object}         callback.body                   The JSON response from the REST API
+   * @param  {Response}       callback.response               The response object as returned by requestjs
+   * @see col-assets/lib/rest.js for more information
+   */
+  client.assets.unpin = function(course, assetId, callback) {
+    var requestUrl = client.util.apiPrefix(course) + '/assets/' + client.util.encodeURIComponent(assetId) + '/unpin';
+    client.request(requestUrl, 'POST', null, null, callback);
   };
 
   /**

--- a/public/app/assetlibrary/assetLibraryFactory.js
+++ b/public/app/assetlibrary/assetLibraryFactory.js
@@ -103,6 +103,9 @@
       if (searchOptions.hasLikes !== undefined) {
         url += '&hasLikes=' + searchOptions.hasLikes;
       }
+      if (searchOptions.hasPins !== undefined) {
+        url += '&hasPins=' + searchOptions.hasPins;
+      }
       if (searchOptions.hasTrending !== undefined) {
         url += '&hasTrending=' + searchOptions.hasTrending;
       }
@@ -258,6 +261,17 @@
     };
 
     /**
+     * Pin or unpin an asset
+     *
+     * @param  {Number}               id                              The id of the asset that is pinned or unpinned
+     * @param  {Boolean}              value                           `true` when the asset should be pinned, `false` when the asset should be unpinned
+     * @return {Promise}                                              $http promise
+     */
+    var pin = function(id, value) {
+      return $http.post(utilService.getApiUrl('/assets/' + id + (value ? '/pin' : '/unpin')));
+    };
+
+    /**
      * Create a new whiteboard from an exported whiteboard asset
      *
      * @param  {Number}               id                            The id of the whiteboard asset
@@ -269,19 +283,20 @@
     };
 
     return {
-      'getAsset': getAsset,
-      'getActivitiesForAsset': getActivitiesForAsset,
-      'getAssets': getAssets,
+      'createComment': createComment,
       'createFile': createFile,
       'createLink': createLink,
-      'editAsset': editAsset,
+      'createWhiteboardFromAsset': createWhiteboardFromAsset,
       'deleteAsset': deleteAsset,
-      'migrateAssets': migrateAssets,
-      'createComment': createComment,
-      'editComment': editComment,
       'deleteComment': deleteComment,
+      'editAsset': editAsset,
+      'editComment': editComment,
+      'getActivitiesForAsset': getActivitiesForAsset,
+      'getAsset': getAsset,
+      'getAssets': getAssets,
       'like': like,
-      'createWhiteboardFromAsset': createWhiteboardFromAsset
+      'migrateAssets': migrateAssets,
+      'pin': pin
     };
 
   });


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-935

Does not include scoring yet. The `getAssets` query has unorthodox sort-by-pin_count implementation – using strictly SQL would cause a big refactor and risk (i.e., GROUP BY per SELECT criteria).
