### PR TITLE
COL-949 Badges: back end

### DIFF
--- a/node_modules/col-activities/tests/test-points.js
+++ b/node_modules/col-activities/tests/test-points.js
@@ -522,7 +522,7 @@ describe('Activity Points', function() {
      */
     it('updates the points', function(callback) {
       // Create an exported whiteboard and two users
-      AssetsTestUtil.setupExportedWhiteboard(function(creatorClient1, creatorClient2, course, creatorUser1, creatorClient2, exportedWhiteboard) {   
+      AssetsTestUtil.setupExportedWhiteboard(null, null, null, null, null, function(creatorClient1, creatorClient2, course, creatorUser1, creatorClient2, exportedWhiteboard) {
         TestsUtil.getAssetLibraryClient(null, course, null, function(remixerClient, course, remixerUser) {
 
           // Define activity points for whiteboard remixes

--- a/node_modules/col-assets/lib/api.js
+++ b/node_modules/col-assets/lib/api.js
@@ -65,18 +65,32 @@ var getAssetProfile = module.exports.getAssetProfile = function(ctx, id, increme
       return callback(err);
     }
 
-    asset = asset.toJSON();
-    asset.whiteboard_elements = _.map(asset.whiteboard_elements, 'element');
-    asset.exported_whiteboards = _.map(asset.exported_whiteboards, function(whiteboard) {
-      return _.pick(whiteboard, ['id', 'title']);
+    // Check for badge eligibility before JSONification suppresses the impact score.
+    getBadgeCutoffForCourse(ctx.course, function(err, cutoffScore) {
+      if (err) {
+        log.error({'err': err, 'course': ctx.course}, 'Could not get badge cutoff score for course');
+        return callback({'code': 500, 'msg': err.message});
+      }
+
+      // Award a badge if the asset is associated with no instructors and its impact score equals or exceeds
+      // the cutoff score.
+      if (cutoffScore && asset.impact_score >= cutoffScore && !_.find(asset.users, 'is_admin')) {
+        asset.badged = true;
+      }
+
+      asset = asset.toJSON();
+      asset.whiteboard_elements = _.map(asset.whiteboard_elements, 'element');
+      asset.exported_whiteboards = _.map(asset.exported_whiteboards, function(whiteboard) {
+        return _.pick(whiteboard, ['id', 'title']);
+      });
+
+      asset.can_delete = canDeleteAsset(ctx.user, asset);
+
+      // Do not return usage in active whiteboards (which are private) as part of the asset profile
+      delete asset.whiteboard_usages;
+
+      return callback(null, asset);
     });
-
-    asset.can_delete = canDeleteAsset(ctx.user, asset);
-
-    // Do not return usage in active whiteboards (which are private) as part of the asset profile
-    delete asset.whiteboard_usages;
-
-    return callback(null, asset);
   });
 };
 
@@ -471,69 +485,88 @@ var getAssets = module.exports.getAssets = function(ctx, filters, sort, limit, o
       // Extract the total count from the result
       var count = countResult[0][0].count;
 
-      // Construct the data to return
-      var data = {
-        'offset': offset,
-        'total': count,
-        'results': _.map(assets, function(asset) {
-          return asset.toJSON();
-        })
-      };
-
-      var assetIds = _.map(assets, 'id');
-
-      // Get all the users that are associated to each of the assets. We do this in a separate query so
-      // each assets always has all collaborators associated to it, even when we're filtering the assets
-      // by a specific user
-      var userOptions = {
-        'attributes': UserConstants.BASIC_USER_FIELDS,
-        'include': [{
-          'model': DB.Asset,
-          'attributes': ['id'],
-          'as': 'assets',
-          'where': {
-            'id': assetIds
-          }
-        }]
-      };
-      DB.User.findAll(userOptions).complete(function(err, users) {
+      // Get cutoff score for purposes of awarding badges.
+      getBadgeCutoffForCourse(ctx.course, function(err, cutoffScore) {
         if (err) {
-          log.error({'err': err, 'course': ctx.course}, 'Failed to get the users for the assets in the current course');
+          log.error({'err': err, 'course': ctx.course}, 'Could not get badge cutoff score for course');
           return callback({'code': 500, 'msg': err.message});
         }
 
-        _.each(data.results, function(result) {
-          result.users = _.filter(users, function(user) {
-            return _.find(user.assets, {'id': result.id});
-          });
-        });
-
-        _.each(data.results, function(result) {
-          result.users = _.map(result.users, function(user) {
-            user = user.toJSON();
-            delete user.assets;
-            return user;
-          });
-        });
-
-        var options = {
-          'where': {
-            'asset_id': assetIds
-          }
+        // Construct the data to return
+        var data = {
+          'offset': offset,
+          'total': count,
+          'results': _.map(assets, function(asset) {
+            // Award any badges before JSONification suppresses the impact scores. Note that because we don't
+            // yet have the associated users, instructor-associated assets get their badges suppressed below.
+            if (cutoffScore && asset.impact_score >= cutoffScore) {
+              asset.badged = true;
+            }
+            return asset.toJSON();
+          })
         };
-        DB.Pin.findAll(options).complete(function(err, pins) {
+
+        var assetIds = _.map(assets, 'id');
+
+        // Get all the users that are associated to each of the assets. We do this in a separate query so
+        // each assets always has all collaborators associated to it, even when we're filtering the assets
+        // by a specific user
+        var userOptions = {
+          'attributes': UserConstants.BASIC_USER_FIELDS,
+          'include': [{
+            'model': DB.Asset,
+            'attributes': ['id'],
+            'as': 'assets',
+            'where': {
+              'id': assetIds
+            }
+          }]
+        };
+        DB.User.findAll(userOptions).complete(function(err, users) {
           if (err) {
-            log.error({'err': err, 'course': ctx.course}, 'Failed to get asset pins in current course');
+            log.error({'err': err, 'course': ctx.course}, 'Failed to get the users for the assets in the current course');
             return callback({'code': 500, 'msg': err.message});
           }
 
           _.each(data.results, function(asset) {
-            asset.pins = _.filter(pins, function(pin) {
-              return pin.asset_id === asset.id;
+            asset.users = _.filter(users, function(user) {
+              return _.find(user.assets, {'id': asset.id});
             });
           });
 
-          return callback(null, data);
+          _.each(data.results, function(asset) {
+            asset.users = _.map(asset.users, function(user) {
+              user = user.toJSON();
+              delete user.assets;
+
+              // Suppress any badges for instructor assets.
+              if (user.is_admin) {
+                delete asset.badged;
+              }
+
+              return user;
+            });
+          });
+
+          var options = {
+            'where': {
+              'asset_id': assetIds
+            }
+          };
+          DB.Pin.findAll(options).complete(function(err, pins) {
+            if (err) {
+              log.error({'err': err, 'course': ctx.course}, 'Failed to get asset pins in current course');
+              return callback({'code': 500, 'msg': err.message});
+            }
+
+            _.each(data.results, function(asset) {
+              asset.pins = _.filter(pins, function(pin) {
+                return pin.asset_id === asset.id;
+              });
+            });
+
+            return callback(null, data);
+          });
         });
       });
     });
@@ -1130,6 +1163,66 @@ var canDeleteAsset = function(user, asset) {
 var isDeletedOrHidden = module.exports.isDeletedOrHidden = function(asset) {
   return !asset.visible || !!asset.deleted_at || !(_.isEmpty(asset.categories) || _.find(asset.categories, 'visible'));
 };
+
+
+/* BADGES */
+
+/**
+ * Return the impact score which assets in a given course must equal or exceed to receive a badge. If badges
+ * are not enabled in the course, return null.
+ *
+ * @param   {Course}        course                     The course for which to query the badge cutoff score
+ * @param   {Function}      [callback]                 Standard callback function
+ * @param   {Object}        [callback.err]             An error object, if any
+ * @param   {Number}        [callback.cutoffScore]     The badge cutoff score, or null if badges are not enabled
+ * @api private
+ */
+var getBadgeCutoffForCourse = module.exports.getBadgeCutoffForCourse = function(course, callback) {
+  // If the Impact Studio is not enabled, no more are badges.
+  if (!course.dashboard_url) {
+    return callback();
+  }
+
+  // Query for badge-eligible assets, meaning assets that are visible and not associated with an
+  // instructor. (The easiest way to verify the second criterion is in raw SQL: left join assets to users
+  // in instructor roles, then group by asset id and filter out rows where user id is present.) Count
+  // results and calculate a 90th-percentile impact score, which assets must equal or exceed to receive a badge.
+  var params = {
+    'course_id': course.id,
+    'admin_roles': _.union(CollabosphereConstants.ADMIN_ROLES, CollabosphereConstants.TEACHER_ROLES)
+  }
+
+  var badgeEligibleAssetsQuery = `SELECT COUNT(*)::int, PERCENTILE_DISC(.90) WITHIN GROUP (ORDER BY asset_impact_score)
+    FROM (SELECT a.id, a.impact_score as asset_impact_score
+      FROM assets a
+      JOIN asset_users au ON
+        a.id = au.asset_id
+        AND a.course_id = :course_id
+        AND a.visible = true
+        AND a.deleted_at IS NULL
+      LEFT JOIN users u ON
+        u.id = au.user_id
+        AND u.canvas_course_role IN (:admin_roles)
+      GROUP BY a.id
+      HAVING MAX(u.id) IS NULL) badge_eligible_assets`;
+
+  DB.getSequelize().query(badgeEligibleAssetsQuery, {'replacements': params}).complete(function(err, results) {
+    if (err) {
+      log.error({'err': err, 'course': params.course_id}, 'Error retrieving badge-eligible assets for course');
+    }
+
+    var count = results[0][0].count;
+    var cutoffScore = results[0][0].percentile_disc;
+
+    // We hand out no badges if there are fewer than ten badge-eligible assets in the course.
+    if (count < 10) {
+      return callback();
+    }
+
+    return callback(null, cutoffScore);
+  });
+};
+
 
 /* PREVIEWS */
 

--- a/node_modules/col-assets/tests/test-assets.js
+++ b/node_modules/col-assets/tests/test-assets.js
@@ -28,6 +28,7 @@ var assert = require('assert');
 var randomstring = require('randomstring');
 
 var AssetsTestUtil = require('./util');
+var LtiTestsUtil = require('col-lti/tests/util');
 var TestsUtil = require('col-tests');
 var UsersTestUtil = require('col-users/tests/util');
 var WhiteboardsTestUtil = require('col-whiteboards/tests/util');
@@ -592,7 +593,7 @@ describe('Assets', function() {
      * Test that verifies that an exported whiteboard asset can be remixed
      */
     it('can be remixed', function(callback) {
-      AssetsTestUtil.setupExportedWhiteboard(function(client1, client2, course, user1, user2, exportedWhiteboard) {
+      AssetsTestUtil.setupExportedWhiteboard(null, null, null, null, null, function(client1, client2, course, user1, user2, exportedWhiteboard) {
         AssetsTestUtil.assertRemixWhiteboard(client1, course, exportedWhiteboard, function() {
 
           return callback();
@@ -618,7 +619,7 @@ describe('Assets', function() {
      * Test that verifies authorization when remixing an exported whiteboard
      */
     it('verifies authorization', function(callback) {
-      AssetsTestUtil.setupExportedWhiteboard(function(client1, client2, course, user1, user2, exportedWhiteboard) {
+      AssetsTestUtil.setupExportedWhiteboard(null, null, null, null, null, function(client1, client2, course, user1, user2, exportedWhiteboard) {
 
         // Verify that a user in a different course can't remix the whiteboard
         TestsUtil.getAssetLibraryClient(null, null, null, function(foreignClient, foreignCourse, foreignUser) {
@@ -630,6 +631,97 @@ describe('Assets', function() {
               AssetsTestUtil.assertRemixWhiteboardFails(instructorClient, foreignCourse, exportedWhiteboard, 404, function() {
 
                 return callback();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('Badges', function() {
+
+    /**
+     * Test that verifies badges on impactful assets
+     */
+    it('awards badges to impactful assets', function(callback) {
+      // Create impactful assets and retrieve them in impactful order.
+      AssetsTestUtil.setupImpactfulAssets(function(assets, client1, client2, client3, client4, course, user1, user2, user3, user4) {
+        AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', 12, null, 12, function(assets) {
+
+          // No one gets a badge if the Impact Studio is not enabled.
+          AssetsTestUtil.assertBadges(assets, []);
+
+          // Launch the Impact Studio and refresh the assets.
+          LtiTestsUtil.assertDashboardCartridgeSucceeds(client4, course, user4, function() {
+            AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', 12, null, 12, function(assets) {
+              // The two most impactful assets should have badges.
+              AssetsTestUtil.assertBadges(assets, [0, 1]);
+
+              // Individual asset views should also return the expected badge information.
+              AssetsTestUtil.assertGetAsset(client1, course, assets.results[0].id, null, null, function(asset) {
+                assert.ok(asset.badged);
+                AssetsTestUtil.assertGetAsset(client1, course, assets.results[2].id, null, null, function(asset) {
+                  assert.ok(!asset.badged);
+
+                  // An instructor and student co-create a highly impactful exported whiteboard.
+                  var instructor = TestsUtil.generateInstructor();
+                  TestsUtil.getAssetLibraryClient(null, course, instructor, function(instructorClient, course, instructor) {
+                    AssetsTestUtil.setupExportedWhiteboard(client1, instructorClient, course, user1, instructor, function(client1, instructorClient, course, user1, instructor, exportedWhiteboard) {
+                      AssetsTestUtil.assertRemixWhiteboard(client2, course, exportedWhiteboard, function() {
+                        AssetsTestUtil.assertRemixWhiteboard(client3, course, exportedWhiteboard, function() {
+                          AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', 13, null, 13, function(assets) {
+
+                            // The much-remixed whiteboard is at the top of the charts, but is not eligible for a badge, so the two
+                            // previously badged assets retain their badges.
+                            assert.strictEqual(assets.results[0].type, 'whiteboard');
+                            AssetsTestUtil.assertBadges(assets, [1, 2]);
+
+                            // An individual asset view on the instructor asset should also suppress the badge.
+                            AssetsTestUtil.assertGetAsset(client1, course, assets.results[0].id, null, null, function(asset) {
+                              assert.ok(!asset.badged);
+
+                              // Two students co-create an even more impactful exported whiteboard.
+                              AssetsTestUtil.setupExportedWhiteboard(client1, client2, course, user1, user2, function(client1, client2, course, user1, user2, exportedWhiteboard) {
+                                AssetsTestUtil.assertRemixWhiteboard(client3, course, exportedWhiteboard, function() {
+                                  AssetsTestUtil.assertRemixWhiteboard(client4, course, exportedWhiteboard, function() {
+                                    AssetsTestUtil.assertRemixWhiteboard(instructorClient, course, exportedWhiteboard, function() {
+
+                                      // The student whiteboard is now at the top of the charts and has a badge. The more impactful of the previously badged
+                                      // assets retains its badge; the less impactful has lost its badge.
+                                      AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', 14, null, 14, function(assets) {
+                                        assert.strictEqual(assets.results[0].type, 'whiteboard');
+                                        AssetsTestUtil.assertBadges(assets, [0, 2]);
+
+                                        // With extreme prejudice, the instructor deletes a bunch of less impactful assets.
+                                        AssetsTestUtil.assertDeleteAsset(client1, course, assets.results[10].id, function() {
+                                          AssetsTestUtil.assertDeleteAsset(client1, course, assets.results[11].id, function() {
+                                            AssetsTestUtil.assertDeleteAsset(client1, course, assets.results[12].id, function() {
+                                              AssetsTestUtil.assertDeleteAsset(client1, course, assets.results[13].id, function() {
+
+                                                // We now have ten assets in the course, but because one of the assets is instructor-associated, only nine assets are
+                                                // badge-eligible. Everyone's fun is spoiled and no one gets a badge.
+                                                AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', 10, null, 10, function(assets) {
+                                                  AssetsTestUtil.assertBadges(assets, []);
+
+                                                  return callback();
+                                                });
+                                              });
+                                            });
+                                          });
+                                        });
+                                      });
+                                    });
+                                  });
+                                });
+                              });
+                            });
+                          });
+                        });
+                      });
+                    });
+                  });
+                });
               });
             });
           });

--- a/node_modules/col-assets/tests/test-search.js
+++ b/node_modules/col-assets/tests/test-search.js
@@ -244,143 +244,73 @@ describe('Search', function() {
      * Test that verifies that the assets in a course can be sorted
      */
     it('can be sorted', function(callback) {
-      // Generate some users
-      TestsUtil.getAssetLibraryClient(null, null, null, function(client1, course, user1) {
-        TestsUtil.getAssetLibraryClient(null, course, null, function(client2, course, user2) {
-          TestsUtil.getAssetLibraryClient(null, course, null, function(client3, course, user3) {
-            TestsUtil.getAssetLibraryClient(null, course, null, function(client4, course, user4) {
+      AssetsTestUtil.setupImpactfulAssets(function(assets, client1, client2, client3, client4, course, user1, user2, user3, user4) {
+        // Verify that sorting by 'recent' returns two pages of assets in reverse creation order
+        AssetsTestUtil.assertGetAssets(client1, course, null, 'recent', null, null, 12, function(pagedAssets) {
+          AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), 12);
 
-              // User 1 creates many test assets
-              TestsUtil.generateTestAssets(client1, course, 12, function(assets) {
-                // Start with default 'most recent' ordering
-                assets = _.sortBy(assets, 'id').reverse();
+          AssetsTestUtil.assertGetAssets(client1, course, null, 'recent', null, 10, 12, function(pagedAssets) {
+            AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [10, 11]), 12);
 
-                // Generate some likes and views (each assertLike adds two views as a side effect)
-                AssetsTestUtil.assertLike(client2, course, assets[6].id, true, function() {
-                  AssetsTestUtil.assertLike(client2, course, assets[7].id, true, function() {
-                    AssetsTestUtil.assertLike(client2, course, assets[8].id, true, function() {
-                      AssetsTestUtil.assertLike(client3, course, assets[7].id, true, function() {
-                        AssetsTestUtil.assertLike(client3, course, assets[8].id, true, function() {
-                          AssetsTestUtil.assertLike(client3, course, assets[9].id, true, function() {
+            // Verify that sorting by 'likes' returns two pages of assets ordered by 1) like count, 2) creation time
+            AssetsTestUtil.assertGetAssets(client1, course, null, 'likes', null, null, 12, function(pagedAssets) {
+              AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [7, 8, 6, 9, 0, 1, 2, 3, 4, 5]), 12);
 
-                            // Generate some additional views
-                            AssetsTestUtil.assertGetAsset(client2, course, assets[0].id, null, 0, function(asset) {
-                              AssetsTestUtil.assertGetAsset(client2, course, assets[1].id, null, 0, function(asset) {
-                                AssetsTestUtil.assertGetAsset(client2, course, assets[2].id, null, 0, function(asset) {
-                                  AssetsTestUtil.assertGetAsset(client3, course, assets[1].id, null, 0, function(asset) {
-                                    AssetsTestUtil.assertGetAsset(client3, course, assets[2].id, null, 0, function(asset) {
-                                      AssetsTestUtil.assertGetAsset(client4, course, assets[2].id, null, 0, function(asset) {
+              AssetsTestUtil.assertGetAssets(client1, course, null, 'likes', null, 10, 12, function(pagedAssets) {
+                AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [10, 11]), 12);
 
-                                        // Pin some assets
-                                        AssetsTestUtil.assertPinAsset(client1, user1, course, assets[1].id, function(asset) {
-                                          AssetsTestUtil.assertPinAsset(client2, user2, course, assets[2].id, function(asset) {
-                                            AssetsTestUtil.assertPinAsset(client3, user3, course, assets[3].id, function(asset) {
+                // Verify that sorting by 'views' returns two pages of assets ordered by 1) view count, 2) creation time
+                AssetsTestUtil.assertGetAssets(client1, course, null, 'views', null, null, 12, function(pagedAssets) {
+                  AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [7, 8, 2, 1, 6, 9, 0, 3, 4, 5]), 12);
 
+                  AssetsTestUtil.assertGetAssets(client1, course, null, 'views', null, 10, 12, function(pagedAssets) {
+                    AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [10, 11]), 12);
 
-                                              // Generate some comments
-                                              AssetsTestUtil.assertCreateComment(client2, course, assets[8].id, 'Comment', null, function(comment) {
-                                                AssetsTestUtil.assertCreateComment(client2, course, assets[9].id, 'Comment', null, function(comment) {
-                                                  AssetsTestUtil.assertCreateComment(client2, course, assets[10].id, 'Comment', null, function(comment) {
-                                                    AssetsTestUtil.assertCreateComment(client3, course, assets[9].id, 'Comment', null, function(comment) {
-                                                      AssetsTestUtil.assertCreateComment(client3, course, assets[10].id, 'Comment', null, function(comment) {
-                                                        AssetsTestUtil.assertCreateComment(client3, course, assets[11].id, 'Comment', null, function(comment) {
+                    // Verify that sorting by 'comments' returns two pages of assets ordered by 1) comment count, 2) creation time
+                    AssetsTestUtil.assertGetAssets(client1, course, null, 'comments', null, null, 12, function(pagedAssets) {
+                      AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [9, 10, 8, 11, 0, 1, 2, 3, 4, 5]), 12);
 
-                                                          // Get all assets unpaged for purposes of comparison
-                                                          AssetsTestUtil.assertGetAssets(client1, course, null, 'recent', 12, null, 12, function(assets) {
-                                                            assets = assets.results;
+                      AssetsTestUtil.assertGetAssets(client1, course, null, 'comments', null, 10, 12, function(pagedAssets) {
+                        AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [6, 7]), 12);
 
-                                                            // Verify that sorting by 'recent' returns two pages of assets in reverse creation order
-                                                            AssetsTestUtil.assertGetAssets(client1, course, null, 'recent', null, null, 12, function(pagedAssets) {
-                                                              AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), 12);
+                        // Verify that sorting by 'impact' returns two pages of assets ordered by:
+                        // - 1) weighted total of comments (6 pts), likes (3 pts), views (2 pts);
+                        // - 2) creation time
+                        AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', null, null, 12, function(pagedAssets) {
+                          AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [8, 9, 7, 10, 6, 2, 11, 1, 0, 3]), 12);
 
-                                                              AssetsTestUtil.assertGetAssets(client1, course, null, 'recent', null, 10, 12, function(pagedAssets) {
-                                                                AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [10, 11]), 12);
+                          AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', null, 10, 12, function(pagedAssets) {
+                            AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [4, 5]), 12);
 
-                                                                // Verify that sorting by 'likes' returns two pages of assets ordered by 1) like count, 2) creation time
-                                                                AssetsTestUtil.assertGetAssets(client1, course, null, 'likes', null, null, 12, function(pagedAssets) {
-                                                                  AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [7, 8, 6, 9, 0, 1, 2, 3, 4, 5]), 12);
+                            // Verify that before trending scores are calculated, a search for trending assets with hasTrending: true returns nothing
+                            AssetsTestUtil.assertGetAssets(client1, course, {'hasTrending': true}, 'trending', null, null, 0, function(pagedAssets) {
+                              assert.ok(_.isEmpty(pagedAssets.results));
 
-                                                                  AssetsTestUtil.assertGetAssets(client1, course, null, 'likes', null, 10, 12, function(pagedAssets) {
-                                                                    AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [10, 11]), 12);
+                              // Verify that after trending scores are calculated, a search for trending assets returns the same results as sorting by impact
+                              ActivitiesAPI.recalculateTrendingScores(null, function() {
+                                AssetsTestUtil.assertGetAssets(client1, course, null, 'trending', null, null, 12, function(pagedAssets) {
+                                  AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [8, 9, 7, 10, 6, 2, 11, 1, 0, 3]), 12, {'allowTimestampDiscrepancy': true});
 
-                                                                    // Verify that sorting by 'views' returns two pages of assets ordered by 1) view count, 2) creation time
-                                                                    AssetsTestUtil.assertGetAssets(client1, course, null, 'views', null, null, 12, function(pagedAssets) {
-                                                                      AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [7, 8, 2, 1, 6, 9, 0, 3, 4, 5]), 12);
+                                  AssetsTestUtil.assertGetAssets(client1, course, null, 'trending', null, 10, 12, function(pagedAssets) {
+                                    AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [4, 5]), 12, {'allowTimestampDiscrepancy': true});
 
-                                                                      AssetsTestUtil.assertGetAssets(client1, course, null, 'views', null, 10, 12, function(pagedAssets) {
-                                                                        AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [10, 11]), 12);
+                                    // Verify that a search for trending assets with hasTrending: true omits assets 3, 4, 5, which got no love
+                                    AssetsTestUtil.assertGetAssets(client1, course, {'hasTrending': true}, 'trending', null, null, 9, function(pagedAssets) {
+                                      AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [8, 9, 7, 10, 6, 2, 11, 1, 0]), 9, {'allowTimestampDiscrepancy': true});
 
-                                                                        // Verify that sorting by 'comments' returns two pages of assets ordered by 1) comment count, 2) creation time
-                                                                        AssetsTestUtil.assertGetAssets(client1, course, null, 'comments', null, null, 12, function(pagedAssets) {
-                                                                          AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [9, 10, 8, 11, 0, 1, 2, 3, 4, 5]), 12);
+                                      // Verify that a search for assets with `hasPins: true` omits unpinned assets
+                                      AssetsTestUtil.assertGetAssets(client1, course, {'hasPins': true}, 'recent', null, null, 3, function(pagedAssets) {
+                                        AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [1, 2, 3]), 3, {'allowTimestampDiscrepancy': true});
 
-                                                                          AssetsTestUtil.assertGetAssets(client1, course, null, 'comments', null, 10, 12, function(pagedAssets) {
-                                                                            AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [6, 7]), 12);
+                                        AssetsTestUtil.assertUnpinAsset(client2, user2, course, assets[2].id, function(asset) {
+                                          AssetsTestUtil.assertGetAssets(client1, course, {'hasPins': true}, 'recent', null, null, 2, function(pagedAssets) {
+                                            AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [1, 3]), 2, {'allowTimestampDiscrepancy': true});
 
-                                                                            // Verify that sorting by 'impact' returns two pages of assets ordered by:
-                                                                            // - 1) weighted total of comments (6 pts), likes (3 pts), views (2 pts);
-                                                                            // - 2) creation time
-                                                                            AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', null, null, 12, function(pagedAssets) {
-                                                                              AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [8, 9, 7, 10, 6, 2, 11, 1, 0, 3]), 12);
+                                            // Verify that a search for assets with `hasPins: false` omits pinned assets
+                                            AssetsTestUtil.assertGetAssets(client1, course,  {'hasPins': false}, 'recent', null, null, 10, function(notPinnedAssets) {
+                                              AssetsTestUtil.assertAssets(notPinnedAssets, _.at(assets, [0, 2, 4, 5, 6, 7, 8, 9, 10, 11]), 10, {'allowTimestampDiscrepancy': true});
 
-                                                                              AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', null, 10, 12, function(pagedAssets) {
-                                                                                AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [4, 5]), 12);
-
-                                                                                // Verify that before trending scores are calculated, a search for trending assets with hasTrending: true returns nothing
-                                                                                AssetsTestUtil.assertGetAssets(client1, course, {'hasTrending': true}, 'trending', null, null, 0, function(pagedAssets) {
-                                                                                  assert.ok(_.isEmpty(pagedAssets.results));
-
-                                                                                  // Verify that after trending scores are calculated, a search for trending assets returns the same results as sorting by impact
-                                                                                  ActivitiesAPI.recalculateTrendingScores(null, function() {
-                                                                                    AssetsTestUtil.assertGetAssets(client1, course, null, 'trending', null, null, 12, function(pagedAssets) {
-                                                                                      AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [8, 9, 7, 10, 6, 2, 11, 1, 0, 3]), 12, {'allowTimestampDiscrepancy': true});
-
-                                                                                      AssetsTestUtil.assertGetAssets(client1, course, null, 'trending', null, 10, 12, function(pagedAssets) {
-                                                                                        AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [4, 5]), 12, {'allowTimestampDiscrepancy': true});
-
-                                                                                        // Verify that a search for trending assets with hasTrending: true omits assets 3, 4, 5, which got no love
-                                                                                        AssetsTestUtil.assertGetAssets(client1, course, {'hasTrending': true}, 'trending', null, null, 9, function(pagedAssets) {
-                                                                                          AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [8, 9, 7, 10, 6, 2, 11, 1, 0]), 9, {'allowTimestampDiscrepancy': true});
-
-                                                                                          // Verify that a search for assets with `hasPins: true` omits unpinned assets
-                                                                                          AssetsTestUtil.assertGetAssets(client1, course, {'hasPins': true}, 'recent', null, null, 3, function(pagedAssets) {
-                                                                                            AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [1, 2, 3]), 3, {'allowTimestampDiscrepancy': true});
-
-                                                                                            AssetsTestUtil.assertUnpinAsset(client2, user2, course, assets[2].id, function(asset) {
-                                                                                              AssetsTestUtil.assertGetAssets(client1, course, {'hasPins': true}, 'recent', null, null, 2, function(pagedAssets) {
-                                                                                                AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [1, 3]), 2, {'allowTimestampDiscrepancy': true});
-
-                                                                                                // Verify that a search for assets with `hasPins: false` omits pinned assets
-                                                                                                AssetsTestUtil.assertGetAssets(client1, course,  {'hasPins': false}, 'recent', null, null, 10, function(notPinnedAssets) {
-                                                                                                  AssetsTestUtil.assertAssets(notPinnedAssets, _.at(assets, [0, 2, 4, 5, 6, 7, 8, 9, 10, 11]), 10, {'allowTimestampDiscrepancy': true});
-
-                                                                                                   return callback();
-                                                                                                });
-                                                                                              });
-                                                                                            });
-                                                                                          });
-                                                                                        });
-                                                                                      });
-                                                                                    });
-                                                                                  });
-                                                                                });
-                                                                              });
-                                                                            });
-                                                                          });
-                                                                        });
-                                                                      });
-                                                                    });
-                                                                  });
-                                                                });
-                                                              });
-                                                            });
-                                                          });
-                                                        });
-                                                      });
-                                                    });
-                                                  });
-                                                });
-                                              });
+                                              return callback();
                                             });
                                           });
                                         });

--- a/node_modules/col-assets/tests/util.js
+++ b/node_modules/col-assets/tests/util.js
@@ -1226,17 +1226,121 @@ var assertGetMigratedAsset = module.exports.assertGetMigratedAsset = function(cl
 };
 
 /**
- * Set up a new course and two users with an exported whiteboard asset
- *
+ * Create a bunch of impactful assets
  * @param  {Function}           callback                        Standard callback function
- * @param  {RestClient}         client                          The REST client for the user
- * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
- * @param  {User}               user                            The user making the request
- * @param  {Asset}              exportedAsset                   The exported whiteboard asset
+ * @throws {AssertionError}
  */
-var setupExportedWhiteboard = module.exports.setupExportedWhiteboard = function(callback) {
+var setupImpactfulAssets = module.exports.setupImpactfulAssets = function(callback) {
+  // Generate some users
   TestsUtil.getAssetLibraryClient(null, null, null, function(client1, course, user1) {
     TestsUtil.getAssetLibraryClient(null, course, null, function(client2, course, user2) {
+      TestsUtil.getAssetLibraryClient(null, course, null, function(client3, course, user3) {
+        TestsUtil.getAssetLibraryClient(null, course, null, function(client4, course, user4) {
+
+          // User 1 creates many test assets
+          TestsUtil.generateTestAssets(client1, course, 12, function(assets) {
+            // Start with default 'most recent' ordering
+            assets = _.sortBy(assets, 'id').reverse();
+
+            // Generate some likes and views (each assertLike adds two views as a side effect)
+            assertLike(client2, course, assets[6].id, true, function() {
+              assertLike(client2, course, assets[7].id, true, function() {
+                assertLike(client2, course, assets[8].id, true, function() {
+                  assertLike(client3, course, assets[7].id, true, function() {
+                    assertLike(client3, course, assets[8].id, true, function() {
+                      assertLike(client3, course, assets[9].id, true, function() {
+
+                        // Generate some additional views
+                        assertGetAsset(client2, course, assets[0].id, null, 0, function(asset) {
+                          assertGetAsset(client2, course, assets[1].id, null, 0, function(asset) {
+                            assertGetAsset(client2, course, assets[2].id, null, 0, function(asset) {
+                              assertGetAsset(client3, course, assets[1].id, null, 0, function(asset) {
+                                assertGetAsset(client3, course, assets[2].id, null, 0, function(asset) {
+                                  assertGetAsset(client4, course, assets[2].id, null, 0, function(asset) {
+
+                                    // Pin some assets
+                                    assertPinAsset(client1, user1, course, assets[1].id, function(asset) {
+                                      assertPinAsset(client2, user2, course, assets[2].id, function(asset) {
+                                        assertPinAsset(client3, user3, course, assets[3].id, function(asset) {
+
+                                          // Generate some comments
+                                          assertCreateComment(client2, course, assets[8].id, 'Comment', null, function(comment) {
+                                            assertCreateComment(client2, course, assets[9].id, 'Comment', null, function(comment) {
+                                              assertCreateComment(client2, course, assets[10].id, 'Comment', null, function(comment) {
+                                                assertCreateComment(client3, course, assets[9].id, 'Comment', null, function(comment) {
+                                                  assertCreateComment(client3, course, assets[10].id, 'Comment', null, function(comment) {
+                                                    assertCreateComment(client3, course, assets[11].id, 'Comment', null, function(comment) {
+
+                                                      // Get all assets unpaged
+                                                      assertGetAssets(client1, course, null, 'recent', 12, null, 12, function(assets) {
+
+                                                        // Return assets and client/course/user objects
+                                                        return callback(assets.results, client1, client2, client3, client4, course, user1, user2, user3, user4);
+                                                      });
+                                                    });
+                                                  });
+                                                });
+                                              });
+                                            });
+                                          });
+                                        });
+                                      });
+                                    });
+                                  });
+                                });
+                              });
+                            });
+                          });
+                        });
+                      });
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+};
+
+/**
+ * Assert that only specified assets in a given series have badges
+ *
+ * @param  {Asset[]}           assets                       Assets to check for badges
+ * @param  {Number[]}          expectBadgesAtIndexes        Indexes of assets that should be badged (empty array if no badges expected)
+ * @throws {AssertionError}
+ */
+var assertBadges = module.exports.assertBadges = function(assets, expectBadgesAtIndexes) {
+  _.forEach(assets.results, function(asset, index) {
+    if (_.includes(expectBadgesAtIndexes, index)) {
+      assert.ok(asset.badged);
+    } else {
+      assert.ok(!asset.badged);
+    }
+  });
+};
+
+/**
+ * Set up a new course and two users with an exported whiteboard asset
+ *
+ * @param  {RestClient}         [client1]                       The REST client for the first user, if specified
+ * @param  {RestClient}         [client2]                       The REST client for the second user, if specified
+ * @param  {Course}             [course]                        The Canvas course in which the users are interacting with the API, if specified
+ * @param  {User}               [user1]                         The first user, if specified
+ * @param  {User}               [user2]                         The second user, if specified
+ * @param  {Function}           callback                        Standard callback function
+ * @param  {RestClient}         callback.client1                The REST client for the first user
+ * @param  {RestClient}         callback.client2                The REST client for the second user
+ * @param  {Course}             callback.course                 The Canvas course in which the users are interacting with the API
+ * @param  {User}               callback.user1                  The first user
+ * @param  {User}               callback.user2                  The second user
+ * @param  {Asset}              callback.exportedAsset          The exported whiteboard asset
+ */
+var setupExportedWhiteboard = module.exports.setupExportedWhiteboard = function(client1, client2, course, user1, user2, callback) {
+  TestsUtil.getAssetLibraryClient(client1, course, user1, function(client1, course, user1) {
+    TestsUtil.getAssetLibraryClient(client2, course, user2, function(client2, course, user2) {
 
       // Create a whiteboard with two members and add some elements
       UsersTestsUtil.assertGetMe(client1, course, null, function(me1) {

--- a/node_modules/col-core/lib/db.js
+++ b/node_modules/col-core/lib/db.js
@@ -499,6 +499,10 @@ var setUpModel = function(sequelize) {
       'allowNull': false,
       'defaultValue': 0
     },
+    'badged': {
+      'type': Sequelize.VIRTUAL,
+      'allowNull': true
+    },
     'visible': {
       'type': Sequelize.BOOLEAN,
       'defaultValue': true,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-949

All this to get a boolean in the asset feed. `?w=1` review recommended as ever.

Due to the required omission of instructor assets, the query for a 90th-percentile cutoff score is somewhat expensive. If there's a noticeable impact in production we may need to store and recalculate the cutoff per course.