### PR TITLE
COL-916, hasPins support in Adv Search; wiring for whiteboardsReuseController > reuse existing asset

### DIFF
--- a/node_modules/col-assets/lib/api.js
+++ b/node_modules/col-assets/lib/api.js
@@ -335,7 +335,7 @@ var getAssets = module.exports.getAssets = function(ctx, filters, sort, limit, o
       'hasTrending': Joi.string().optional(),
       'hasViews': Joi.string().optional()
     }),
-    'sort': Joi.string().valid(['recent', 'likes', 'views', 'comments', 'impact', 'trending']).required(),
+    'sort': Joi.string().valid(['comments', 'impact', 'likes', 'pins', 'recent', 'trending', 'views']).required(),
     'limit': Joi.number().required(),
     'offset': Joi.number().required()
   });
@@ -364,110 +364,126 @@ var getAssets = module.exports.getAssets = function(ctx, filters, sort, limit, o
     'offset': offset
   };
 
-  var sqlQuery = `FROM assets a
-    LEFT JOIN assets_categories ac ON a.id = ac.asset_id
-    LEFT JOIN categories c ON c.id = ac.category_id
-    LEFT JOIN asset_users au ON a.id = au.asset_id
-    LEFT JOIN users u ON au.user_id = u.id
-    LEFT JOIN pinned_user_assets p ON a.id = p.asset_id
-    LEFT JOIN activities act ON a.id = act.asset_id
-     AND act.course_id = :course_id
-     AND act.user_id = :user_id
-     AND act.object_type = 'asset'
-     AND act.type IN('like', 'dislike')
-    WHERE a.deleted_at IS NULL
+  var fromClause = ` FROM assets a
+      LEFT JOIN assets_categories ac ON a.id = ac.asset_id
+      LEFT JOIN categories c ON c.id = ac.category_id
+      LEFT JOIN asset_users au ON a.id = au.asset_id
+      LEFT JOIN users u ON au.user_id = u.id
+      LEFT JOIN activities act ON a.id = act.asset_id
+       AND act.course_id = :course_id
+       AND act.user_id = :user_id
+       AND act.object_type = 'asset'
+       AND act.type IN('like', 'dislike')
+  `;
+
+  var whereClause = ` WHERE
+     a.deleted_at IS NULL
      AND a.course_id = :course_id
      AND a.visible = TRUE
      AND (c.visible = TRUE OR c.visible IS NULL)
   `;
 
   if (filters.keywords) {
-    sqlQuery += ' AND (a.title ILIKE :keywords OR a.description ILIKE :keywords)';
+    whereClause += ' AND (a.title ILIKE :keywords OR a.description ILIKE :keywords)';
     // Replace spaces with wildcards so basic multi-term matching can happen
     params['keywords'] = '%' + filters.keywords.trim().replace(/ /g, '%') + '%'
   }
 
   if (!_.isEmpty(filters.types)) {
-    sqlQuery += ' AND a.type IN(:types)';
+    whereClause += ' AND a.type IN(:types)';
   }
 
   if (filters.assignment) {
-    sqlQuery += ' AND a.canvas_assignment_id = :assignment';
+    whereClause += ' AND a.canvas_assignment_id = :assignment';
   }
 
   if (filters.category) {
-    sqlQuery += ' AND c.id = :category';
+    whereClause += ' AND c.id = :category';
   }
 
-  if (filters.user) {
-    sqlQuery += ' AND au.user_id = :user';
+  var hasPins = CollabosphereUtil.getBooleanParam(filters.hasPins, null);
+  if (hasPins != null) {
+    // Who is the target user? For example, "filter by user" in Adv Search or "My Pinned" on profile page.
+    var userId = filters.user || ctx.user.id;
+    var existsOrNot = hasPins ? ' AND EXISTS' : ' AND NOT EXISTS';
+    whereClause += existsOrNot + ' (SELECT 1 FROM pinned_user_assets WHERE asset_id = a.id AND user_id = ' + userId + ' LIMIT 1)';
+  }
+
+  // If hasPins is present then we do NOT want to limit results with the condition below.
+  // Instead, we use `filters.user` against `pinned_user_assets` with condition above.
+  if (hasPins === null && filters.user) {
+    whereClause += ' AND au.user_id = :user';
   }
 
   if (filters.section) {
-    sqlQuery += ' AND (array_position(u.canvas_course_sections, :section) > 0)';
+    whereClause += ' AND (array_position(u.canvas_course_sections, :section) > 0)';
   }
 
   var hasComments = CollabosphereUtil.getBooleanParam(filters.hasComments, null);
   if (hasComments !== null) {
-    sqlQuery += hasComments ? ' AND a.comment_count > 0' : ' AND a.comment_count = 0';
+    whereClause += hasComments ? ' AND a.comment_count > 0' : ' AND a.comment_count = 0';
   }
 
   var hasImpact = CollabosphereUtil.getBooleanParam(filters.hasImpact, null);
   if (hasImpact !== null) {
-    sqlQuery += hasImpact ? ' AND a.impact_score > 0' : ' AND a.impact_score = 0';
+    whereClause += hasImpact ? ' AND a.impact_score > 0' : ' AND a.impact_score = 0';
   }
 
   var hasLikes = CollabosphereUtil.getBooleanParam(filters.hasLikes, null);
   if (hasLikes !== null) {
-    sqlQuery += hasLikes ? ' AND a.likes > 0' : ' AND a.likes = 0';
-  }
-
-  var hasPins = CollabosphereUtil.getBooleanParam(filters.hasPins, null);
-  if (hasPins !== null) {
-    sqlQuery += hasPins ? ' AND p.asset_id IS NOT NULL' : ' AND p.asset_id IS NULL';
-    if (hasPins && filters.user) {
-      sqlQuery += ' AND p.user_id = :user';
-    }
+    whereClause += hasLikes ? ' AND a.likes > 0' : ' AND a.likes = 0';
   }
 
   var hasTrending = CollabosphereUtil.getBooleanParam(filters.hasTrending, null);
   if (hasTrending !== null) {
-    sqlQuery += hasTrending ? ' AND a.trending_score > 0' : ' AND a.trending_score = 0';
+    whereClause += hasTrending ? ' AND a.trending_score > 0' : ' AND a.trending_score = 0';
   }
 
   var hasViews = CollabosphereUtil.getBooleanParam(filters.hasViews, null);
   if (hasViews !== null) {
-    sqlQuery += hasViews ? ' AND a.views > 0' : ' AND a.views = 0';
+    whereClause += hasViews ? ' AND a.views > 0' : ' AND a.views = 0';
   }
 
   // Query that will be used to get the actual assets
-  var resultsSqlQuery = `SELECT
-    DISTINCT ON (a.id, a.likes, a.views, a.comment_count, a.impact_score, a.trending_score)
-    a.*,
-    act.type AS activity_type
-  `;
-  resultsSqlQuery += sqlQuery;
+  var selectClause = 'SELECT';
 
-  if (sort === 'recent') {
-    resultsSqlQuery += ' ORDER BY a.id DESC';
-  } else if (sort === 'likes') {
-    resultsSqlQuery += ' ORDER BY a.likes DESC, a.id DESC';
-  } else if (sort === 'views') {
-    resultsSqlQuery += ' ORDER BY a.views DESC, a.id DESC';
-  } else if (sort === 'comments') {
-    resultsSqlQuery += ' ORDER BY a.comment_count DESC, a.id DESC';
-  } else if (sort === 'impact') {
-    resultsSqlQuery += ' ORDER BY a.impact_score DESC, a.id DESC';
-  } else if (sort === 'trending') {
-    resultsSqlQuery += ' ORDER BY a.trending_score DESC, a.id DESC';
+  if (sort === 'pins') {
+    // 'order by pinned_by_me' is an available searchOption and default order of Whiteboards > Add asset
+    selectClause += `
+      DISTINCT ON (a.id, a.likes, a.views, a.comment_count, a.impact_score, a.trending_score, pinned_by_me)
+      a.*,
+      act.type AS activity_type,
+      EXISTS (SELECT 1 FROM pinned_user_assets WHERE asset_id = a.id AND user_id = :user_id LIMIT 1) as pinned_by_me
+    `;
+  } else {
+    selectClause += `
+      DISTINCT ON (a.id, a.likes, a.views, a.comment_count, a.impact_score, a.trending_score)
+      a.*,
+      act.type AS activity_type
+    `;
   }
 
-  resultsSqlQuery += ' LIMIT :limit OFFSET :offset';
+  var query = selectClause + ' ' + fromClause + ' ' + whereClause;
 
-  // Query that will be used to get the total count
-  var countSqlQuery = 'SELECT COUNT(DISTINCT(a.id))::int AS count ' + sqlQuery;
+  if (sort === 'recent') {
+    query += ' ORDER BY a.id DESC';
+  } else if (sort === 'likes') {
+    query += ' ORDER BY a.likes DESC, a.id DESC';
+  } else if (sort === 'views') {
+    query += ' ORDER BY a.views DESC, a.id DESC';
+  } else if (sort === 'comments') {
+    query += ' ORDER BY a.comment_count DESC, a.id DESC';
+  } else if (sort === 'impact') {
+    query += ' ORDER BY a.impact_score DESC, a.id DESC';
+  } else if (sort === 'trending') {
+    query += ' ORDER BY a.trending_score DESC, a.id DESC';
+  } else if (sort === 'pins') {
+    query += ' ORDER BY pinned_by_me DESC, a.id DESC';
+  }
 
-  DB.getSequelize().query(resultsSqlQuery, {
+  query += ' LIMIT :limit OFFSET :offset';
+
+  DB.getSequelize().query(query, {
     'model': DB.Asset,
     'replacements': params
   }).complete(function(err, assets) {
@@ -476,7 +492,10 @@ var getAssets = module.exports.getAssets = function(ctx, filters, sort, limit, o
       return callback({'code': 500, 'msg': err.message});
     }
 
-    DB.getSequelize().query(countSqlQuery, {'replacements': params}).complete(function(err, countResult) {
+    // Query that will be used to get the total count
+    var countQuery = 'SELECT COUNT(DISTINCT(a.id))::int AS count ' + fromClause + ' ' + whereClause;
+
+    DB.getSequelize().query(countQuery, {'replacements': params}).complete(function(err, countResult) {
       if (err) {
         log.error({'err': err, 'course': ctx.course}, 'Failed to get the count of assets in the current course');
         return callback({'code': 500, 'msg': err.message});

--- a/node_modules/col-assets/tests/test-search.js
+++ b/node_modules/col-assets/tests/test-search.js
@@ -241,6 +241,40 @@ describe('Search', function() {
     });
 
     /**
+     * Verify that assets can be filtered by pinned status
+     */
+    it('can filter by pinned assets', function(callback) {
+      AssetsTestUtil.setupPinnedAssets(function(client1, client2, course, user1, user2, assets1, assets2, pinnedBy1, pinnedBy2) {
+
+        // We expect all assets pinned by user1
+        verifySearch(client1, course, {'hasPins': true}, pinnedBy1, function() {
+
+          // We expect all assets, pinned by user1 first
+          AssetsTestUtil.assertGetAssets(client1, course, null, 'pins', null, null, assets1.length + assets2.length, function(assets) {
+            var expectedFirst = _.sortBy(pinnedBy1, 'id').reverse();
+            _.each(expectedFirst, function(expected, i) {
+              assert.equal(expected.id, assets.results[i].id);
+            });
+
+            // Get course id and user2 id from db (needed by search filter)
+            getCourse(course.id, function(dbCourse) {
+
+              DB.User.findOne({'where': {'canvas_user_id': user2.id}}).complete(function(err, dbUser2) {
+                assert.ok(!err);
+
+                // user1 wants to see what user2 has pinned
+                verifySearch(client1, course, {'user': dbUser2.id, 'hasPins': true}, pinnedBy2, function() {
+
+                  return callback();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    /**
      * Test that verifies that the assets in a course can be sorted
      */
     it('can be sorted', function(callback) {
@@ -299,16 +333,16 @@ describe('Search', function() {
                                       AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [8, 9, 7, 10, 6, 2, 11, 1, 0]), 9, {'allowTimestampDiscrepancy': true});
 
                                       // Verify that a search for assets with `hasPins: true` omits unpinned assets
-                                      AssetsTestUtil.assertGetAssets(client1, course, {'hasPins': true}, 'recent', null, null, 3, function(pagedAssets) {
-                                        AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [1, 2, 3]), 3, {'allowTimestampDiscrepancy': true});
+                                      AssetsTestUtil.assertGetAssets(client1, course, {'hasPins': true}, 'recent', null, null, 1, function(pagedAssets) {
+                                        AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [1]), 1, {'allowTimestampDiscrepancy': true});
 
-                                        AssetsTestUtil.assertUnpinAsset(client2, user2, course, assets[2].id, function(asset) {
-                                          AssetsTestUtil.assertGetAssets(client1, course, {'hasPins': true}, 'recent', null, null, 2, function(pagedAssets) {
-                                            AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, [1, 3]), 2, {'allowTimestampDiscrepancy': true});
+                                        AssetsTestUtil.assertUnpinAsset(client2, course, assets[2].id, function(asset) {
+                                          AssetsTestUtil.assertGetAssets(client2, course, {'hasPins': true}, 'recent', null, null, 0, function(pagedAssets) {
+                                            AssetsTestUtil.assertAssets(pagedAssets, _.at(assets, []), 0, {'allowTimestampDiscrepancy': true});
 
                                             // Verify that a search for assets with `hasPins: false` omits pinned assets
-                                            AssetsTestUtil.assertGetAssets(client1, course,  {'hasPins': false}, 'recent', null, null, 10, function(notPinnedAssets) {
-                                              AssetsTestUtil.assertAssets(notPinnedAssets, _.at(assets, [0, 2, 4, 5, 6, 7, 8, 9, 10, 11]), 10, {'allowTimestampDiscrepancy': true});
+                                            AssetsTestUtil.assertGetAssets(client1, course,  {'hasPins': false}, 'recent', null, null, 11, function(notPinnedAssets) {
+                                              AssetsTestUtil.assertAssets(notPinnedAssets, _.at(notPinnedAssets, [0, 2, 4, 5, 6, 7, 8, 9, 10, 11]), 11, {'allowTimestampDiscrepancy': true});
 
                                               return callback();
                                             });

--- a/node_modules/col-assets/tests/util.js
+++ b/node_modules/col-assets/tests/util.js
@@ -859,7 +859,7 @@ var assertCreateComment = module.exports.assertCreateComment = function(client, 
  * @param  {Function}           callback                        Standard callback function
  * @throws {AssertionError}                                     Error thrown when an assertion failed
  */
-var assertPinAsset = module.exports.assertPinAsset = function(client, user, course, assetId, callback) {
+var assertPinAsset = function(client, course, assetId, callback) {
   // Get the asset on which a comment is being made
   client.assets.getAsset(course, assetId, false, function(err, asset) {
     assert.ok(!err);
@@ -892,7 +892,7 @@ var assertPinAsset = module.exports.assertPinAsset = function(client, user, cour
  * @param  {Function}           callback                        Standard callback function
  * @throws {AssertionError}                                     Error thrown when an assertion failed
  */
-var assertUnpinAsset = module.exports.assertUnpinAsset = function(client, user, course, assetId, callback) {
+var assertUnpinAsset = module.exports.assertUnpinAsset = function(client, course, assetId, callback) {
   // Get the asset on which a comment is being made
   client.assets.getAsset(course, assetId, false, function(err, asset) {
     assert.ok(!err);
@@ -1226,6 +1226,46 @@ var assertGetMigratedAsset = module.exports.assertGetMigratedAsset = function(cl
 };
 
 /**
+ * Pin some assets
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}
+ */
+var setupPinnedAssets = module.exports.setupPinnedAssets = function(callback) {
+  TestsUtil.getAssetLibraryClient(null, null, null, function(client1, course, user1) {
+    TestsUtil.getAssetLibraryClient(null, course, null, function(client2, course, user2) {
+
+      // Three assets per user
+      TestsUtil.generateTestAssets(client1, course, 3, function(assets1) {
+        TestsUtil.generateTestAssets(client2, course, 3, function(assets2) {
+
+          // user1 will pin these assets
+          var pinnedBy1 = [assets1[1], assets1[2], assets2[0]];
+
+          assertPinAsset(client1, course, pinnedBy1[0].id, function(asset) {
+            assertPinAsset(client1, course, pinnedBy1[1].id, function(asset) {
+              assertPinAsset(client1, course, pinnedBy1[2].id, function(asset) {
+
+                // user2 will pin these assets
+                var pinnedBy2 = [assets1[0], assets2[1], assets2[2]];
+
+                assertPinAsset(client2, course, pinnedBy2[0].id, function(asset) {
+                  assertPinAsset(client2, course, pinnedBy2[1].id, function(asset) {
+                    assertPinAsset(client2, course, pinnedBy2[2].id, function(asset) {
+
+                      return callback(client1, client2, course, user1, user2, assets1, assets2, pinnedBy1, pinnedBy2);
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+};
+
+/**
  * Create a bunch of impactful assets
  * @param  {Function}           callback                        Standard callback function
  * @throws {AssertionError}
@@ -1259,9 +1299,9 @@ var setupImpactfulAssets = module.exports.setupImpactfulAssets = function(callba
                                   assertGetAsset(client4, course, assets[2].id, null, 0, function(asset) {
 
                                     // Pin some assets
-                                    assertPinAsset(client1, user1, course, assets[1].id, function(asset) {
-                                      assertPinAsset(client2, user2, course, assets[2].id, function(asset) {
-                                        assertPinAsset(client3, user3, course, assets[3].id, function(asset) {
+                                    assertPinAsset(client1, course, assets[1].id, function(asset) {
+                                      assertPinAsset(client2, course, assets[2].id, function(asset) {
+                                        assertPinAsset(client3, course, assets[3].id, function(asset) {
 
                                           // Generate some comments
                                           assertCreateComment(client2, course, assets[8].id, 'Comment', null, function(comment) {

--- a/public/app/assetlibrary/assetLibraryFactory.js
+++ b/public/app/assetlibrary/assetLibraryFactory.js
@@ -71,9 +71,6 @@
       page = page || 0;
       searchOptions = searchOptions || {};
 
-      // Certain types of sort will narrow the search
-      utilService.narrowSearchPerSort(searchOptions);
-
       var url = '/assets';
       url += '?offset=' + (page * 10);
       if (searchOptions.keywords) {

--- a/public/app/assetlibrary/list/assetLibraryListController.js
+++ b/public/app/assetlibrary/list/assetLibraryListController.js
@@ -100,6 +100,9 @@
 
       var isFirstResultSet = ($scope.list.page === 0);
 
+      // Narrow the search, if appropriate
+      utilService.narrowSearchPerSort($scope.searchOptions);
+
       assetLibraryFactory.getAssets($scope.list.page, $scope.searchOptions).success(function(assets) {
         utilService.setPinnedByMe(assets.results);
 

--- a/public/app/assetlibrary/search/search.html
+++ b/public/app/assetlibrary/search/search.html
@@ -90,6 +90,7 @@
             <option value="likes">Most likes</option>
             <option value="views">Most views</option>
             <option value="comments">Most comments</option>
+            <option value="pins">Pinned</option>
             <option value="impact" data-ng-if="me.course.dashboard_url">Most impactful</option>
             <option value="trending" data-ng-if="me.course.dashboard_url">Trending</option>
           </select>

--- a/public/app/dashboard/profileController.js
+++ b/public/app/dashboard/profileController.js
@@ -155,6 +155,9 @@
         'limit': $scope.maxPerSwimlane
       };
 
+      // Narrow the search, if appropriate
+      utilService.narrowSearchPerSort(searchOptions);
+
       assetLibraryFactory.getAssets(0, searchOptions).success(function(assets) {
         angular.extend($scope.user.assets, assets);
         utilService.setPinnedByMe($scope.user.assets.results);
@@ -187,6 +190,9 @@
         'sort': sortType,
         'limit': $scope.maxPerSwimlane
       };
+
+      // Narrow the search, if appropriate
+      utilService.narrowSearchPerSort(searchOptions);
 
       assetLibraryFactory.getAssets(0, searchOptions).success(function(assets) {
         angular.extend($scope.community.assets, assets);

--- a/public/app/shared/utilService.js
+++ b/public/app/shared/utilService.js
@@ -460,10 +460,6 @@
       var sort = searchOptions && searchOptions.sort;
       if (sort && sort !== 'recent') {
         searchOptions['has' + _.startCase(sort)] = true;
-        if (sort === 'pins') {
-          // Sort-by-pinned gives pinned assets sorted by date.
-          searchOptions.sort = 'recent';
-        }
       }
     };
 

--- a/public/app/whiteboards/reuse/whiteboardsReuseController.js
+++ b/public/app/whiteboards/reuse/whiteboardsReuseController.js
@@ -86,16 +86,19 @@
       // Indicate the no further REST API requests should be made
       // until the current request has completed
       $scope.list.ready = false;
-      $scope.isSearch = false;
 
+      // Indicate whether a search was performed
       var opts = $scope.searchOptions;
+      $scope.isSearch = opts.keywords || opts.category || opts.user || opts.section || opts.type;
+
+      // Default view has 'pins' assets listed first.
+      if (!$scope.isSearch) {
+        opts = {
+          'sort': 'pins'
+        };
+      }
 
       assetLibraryFactory.getAssets($scope.list.page, opts).success(function(assets) {
-        // Indicate whether a search was performed
-        if (opts.keywords || opts.category || opts.user || opts.section || opts.type) {
-          $scope.isSearch = true;
-        }
-
         // Add the new assets
         $scope.assets = $scope.assets.concat(assets.results);
 
@@ -108,6 +111,18 @@
       });
       // Ensure that the next page is requested the next time
       $scope.list.page++;
+    };
+
+    /**
+     * Get the assets for the current course through an infinite scroll
+     *
+     * @param  {Asset[]}          assets           All assets from AssetsAPI, including pinned_by_me
+     * @return {Asset[]}                           Filtered set of assets (pinned_by_me are excluded). If user performs search then list is unfiltered.
+     */
+    var notPinnedByMe = $scope.notPinnedByMe = function(assets) {
+      return $scope.isSearch ? assets : _.filter(assets, function(asset) {
+        return !asset.pinned_by_me;
+      });
     };
 
     /**


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-916
https://jira.ets.berkeley.edu/jira/browse/COL-919

Use case: Go to profile page, click 'My Assets > Pinned' and get ALL assets you've pinned. List will include assets uploaded/created by other users. If 'Pinned' list has 5+ assets, and you click to see more, then you'll go to Asset Library list with pre-selected filters: user: John Doe, sort by: Pinned

This PR also supports the `ORDER BY myPinned` needed by UX: https://jira.ets.berkeley.edu/jira/browse/COL-808

The next PR will include `whiteboards/reuse.html` as described in  https://jira.ets.berkeley.edu/jira/browse/COL-919