### PR TITLE
COL-929 Omit activities on deleted assets from activity feed

### DIFF
--- a/node_modules/col-activities/lib/api.js
+++ b/node_modules/col-activities/lib/api.js
@@ -253,10 +253,12 @@ var getActivitiesForUserId = module.exports.getActivitiesForUserId = function(ct
       'attributes': ['id', 'type', 'created_at'],
       'order': 'created_at ASC',
       'include': [
-        // Get any associated asset object.
+        // Get any associated asset object. We include deleted assets so that we can suppress
+        // the entire activity in processing below.
         {
           'model': DB.Asset,
-          'attributes': ['id', 'title', 'thumbnail_url']
+          'attributes': ['id', 'title', 'thumbnail_url', 'deleted_at'],
+          'paranoid': false
         },
         // Get any associated comment object.
         {
@@ -315,8 +317,13 @@ var getActivitiesForUserId = module.exports.getActivitiesForUserId = function(ct
       }
     };
 
-    // Collect user activity details
+    // Collect user activity details.
     _.each(user.activities, function(activity) {
+      // Omit activities associated with deleted assets.
+      if (activity.asset && activity.asset.deleted_at) {
+        return;
+      }
+
       var activityJSON = buildActivityJSON(activity, user);
       var activityGroup = null;
 

--- a/node_modules/col-activities/tests/test-activities.js
+++ b/node_modules/col-activities/tests/test-activities.js
@@ -24,7 +24,12 @@
  */
 
 var _ = require('lodash');
+var assert = require('assert');
 
+var ActivitiesAPI = require('col-activities');
+var AssetsTestUtil = require('col-assets/tests/util');
+var CollabosphereConstants = require('col-core/lib/constants');
+var DB = require('col-core/lib/db');
 var TestsUtil = require('col-tests');
 
 var ActivitiesTestUtil = require('./util');
@@ -76,12 +81,12 @@ describe('Activities', function() {
                 'asset_comment': 1
               },
               'actions.totals.user': 2,
-              'impacts.counts.user': {              
+              'impacts.counts.user': {
                 'get_asset_comment': 2
               },
               'impacts.totals.user': 2
             }, expectedCourseCounts));
-            
+
             ActivitiesTestUtil.assertGetActivitiesForUserId(users.simon.client, course, users.simon.me.id, function(activities) {
               // Simon left two comments
               ActivitiesTestUtil.assertUserActivities(activities, users.simon, _.merge({
@@ -99,7 +104,7 @@ describe('Activities', function() {
               ActivitiesTestUtil.assertGetActivitiesForUserId(users.paul.client, course, users.paul.me.id, function(activities) {
                 // Paul's asset got two comments
                 ActivitiesTestUtil.assertUserActivities(activities, users.paul, _.merge({
-                  'actions.creations': 1, 
+                  'actions.creations': 1,
                   'impacts.interactions': 2,
                   'actions.counts.user': {
                     'add_asset': 1
@@ -131,6 +136,58 @@ describe('Activities', function() {
                   return callback();
                 });
               });
+            });
+          });
+        });
+      });
+    });
+
+    it('excludes deleted assets', function(callback) {
+      // Create some assets and activities.
+      ActivitiesTestUtil.setupCourseWithActivity(function(dbCourse, course, users) {
+
+        // An instructor deletes an asset.
+        var instructor = TestsUtil.generateInstructor();
+        TestsUtil.getAssetLibraryClient(null, course, instructor, function(instructorClient, course, instructor) {
+          AssetsTestUtil.assertDeleteAsset(instructorClient, course, users.nico.asset.id, function() {
+
+            // Actions and impacts relating to the deleted asset should not show up in the activity feed or contribute to totals.
+            ActivitiesTestUtil.assertGetActivitiesForUserId(instructorClient, course, users.nico.me.id, function(activities) {
+              assert.strictEqual(activities.actions.creations.length, 0);
+              assert.strictEqual(activities.actions.totals.user, 1);
+              assert.ok(!activities.actions.counts.user.add_asset);
+
+              assert.strictEqual(activities.impacts.interactions.length, 0);
+              assert.strictEqual(activities.impacts.totals.user, 0);
+              assert.ok(!activities.impacts.counts.user.get_asset_comment);
+
+              return callback();
+            });
+          });
+        });
+      });
+    });
+
+    it('includes activities with no assets', function(callback) {
+      // Create some assets and asset-related activities.
+      ActivitiesTestUtil.setupCourseWithActivity(function(dbCourse, course, users) {
+        // Create an additional Canvas discussion activity.
+        DB.User.findOne({'where': {'canvas_user_id': users.annesophie.user.id}}).complete(function(err, dbUser) {
+          ActivitiesAPI.createActivity(dbCourse, dbUser, 'discussion_topic', 999, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.CANVAS_DISCUSSION, {}, null, function(err, activity) {
+            assert.ok(!err);
+
+            ActivitiesTestUtil.assertGetActivitiesForUserId(users.annesophie.client, course, users.annesophie.me.id, function(activities) {
+              // The discussion topic shows up in the activities feed despite having no asset.
+              assert.strictEqual(activities.actions.interactions.length, 2);
+              assert.strictEqual(activities.actions.interactions[1].type, 'discussion_topic');
+              assert.ok(!activities.actions.interactions[1].asset);
+
+              // The discussion topics also shows up in course and user totals.
+              assert.strictEqual(activities.actions.counts.user.discussion_topic, 1);
+              assert.strictEqual(activities.actions.counts.course.discussion_topic, 1);
+              assert.deepEqual(activities.actions.totals, {'user': 3, 'course': 11});
+
+              return callback();
             });
           });
         });
@@ -232,6 +289,6 @@ describe('Activities', function() {
           });
         });
       });
-    }); 
+    });
   });
 });


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-929

The trick: activities on deleted assets should be excluded, but activities with no asset should still show up. We first retrieve, then suppress.