### PR TITLE
COL-977, deal with event 'assetPinEventByMe' regardless of sortBy

### DIFF
--- a/public/app/dashboard/profileController.js
+++ b/public/app/dashboard/profileController.js
@@ -281,7 +281,7 @@
      * Listen for pinning/unpinning events by 'me'
      */
     $scope.$on('assetPinEventByMe', function(ev, updatedAsset) {
-      if ($scope.isMyProfile && $scope.user.assets.sortBy === 'pins') {
+      if ($scope.isMyProfile) {
         var reloadUserAssets = false;
         _.each([$scope.user.assets.results, $scope.community.assets.results], function(assets) {
           _.each(assets, function(asset, index) {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-977

The "400 error" described in Jira was due to pin=true attempt on an already-pinned asset. If user pins asset on his/her profile we must _always_ refresh.
