### PR TITLE
COL-896 Suppress timeline 'View By: All' when >30 days activity

### DIFF
--- a/public/app/shared/activityTimeline.html
+++ b/public/app/shared/activityTimeline.html
@@ -15,10 +15,12 @@
     <button type="button" class="btn btn-link"
             data-ng-class="{'btn-link-disabled': currentZoomPreset === 'month'}"
             data-ng-disabled="currentZoomPreset === 'month'"
-            data-ng-click="zoomPreset('month')">Month</button> |
+            data-ng-click="zoomPreset('month')">Month</button>
+    <span data-ng-if="zoomAllEnabled">|</span>
     <button type="button" class="btn btn-link"
             data-ng-class="{'btn-link-disabled': currentZoomPreset === 'all'}"
             data-ng-disabled="currentZoomPreset === 'all'"
-            data-ng-click="zoomPreset('all')">All</button>
+            data-ng-click="zoomPreset('all')"
+            data-ng-if="zoomAllEnabled">All</button>
   </div>
 </div>

--- a/public/app/shared/activityTimelineDirective.js
+++ b/public/app/shared/activityTimelineDirective.js
@@ -69,8 +69,8 @@
           'whiteboard_add_asset': 'Added Asset to Whiteboard'
         };
 
-        // Default to showing at least one day of activity, even if no events go back that far.
-        var start = Date.now() - MILLISECONDS_PER_DAY;
+        // Default to showing at least one week of activity, even if no events go back that far.
+        var start = Date.now() - (7 * MILLISECONDS_PER_DAY);
         var end = Date.now();
 
         scope.$watch('activityTimeline', function() {
@@ -83,6 +83,9 @@
           });
 
           var totalDays = parseFloat(end - start) / MILLISECONDS_PER_DAY;
+
+          // Enable 'all' zoom option only if there's more than a month of activity.
+          scope.zoomAllEnabled = (totalDays > 30);
 
           // Determine precision of x-axis tick values and format appropriately.
           var tickFormat = function(date) {
@@ -276,7 +279,12 @@
               }
             });
 
-            scope.zoomPreset('all', false);
+            // Initial zoom level depends on how much activity there is to see.
+            if (totalDays <= 7) {
+              scope.zoomPreset('week', false);
+            } else {
+              scope.zoomPreset('all', false);
+            }
           };
 
           // Do not start drawing the timeline until timelineId has been interpolated in markup. This will ensure that


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-896

<img width="836" alt="screen shot 2017-06-07 at 10 28 54 am" src="https://user-images.githubusercontent.com/2413467/26892156-3f00d50e-4b6c-11e7-8eed-3bb119557813.png">

Don't show 'All' zoom option unless 'All' is greater than 'Month'.
Change minimum initial zoom from 1 day to 7 days, so that 'Week' starts out as the default selection.