### PR TITLE
COL-986 Fix alignment on activity breakdown labels

### DIFF
--- a/public/app/dashboard/profile.css
+++ b/public/app/dashboard/profile.css
@@ -95,6 +95,7 @@
   flex: 0 0 150px;
   justify-content: flex-end;
   padding-right: 8px;
+  text-align: right;
 }
 
 .profile-activity-breakdown-popover-details {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-986

Fun fact! If the text all fits on one line, fancy flexbox `justify-content: flex-end;` controls alignment. If the text wraps, boring old `text-align: right;` must be used.