### PR TITLE
COL-1004, core.getVersion includes properties of buildspec-report.json

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,7 +19,7 @@ phases:
   post_build:
     commands:
       - for i in $(ls node_modules | grep -v ^col-); do rm -Rf node_modules/$i; done
-      - ./scripts/generate-buildspec-report.sh
+      - chmod 554 scripts/generate-buildspec-report.sh && ./scripts/generate-buildspec-report.sh
 
 artifacts:
   files:

--- a/node_modules/col-core/lib/api.js
+++ b/node_modules/col-core/lib/api.js
@@ -426,5 +426,12 @@ var getVersion = module.exports.getVersion = function(callback) {
   var version = {
     'version': appPackage.version
   };
+
+  var buildReport = '../../../config/buildspec-report.json';
+  if (fs.existsSync(path.join(__dirname, buildReport))) {
+    // Add info on Git branch and more
+    _.extend(version, require(buildReport));
+  };
+
   return callback(version);
 };


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1004

CodeBuild complained with: `generate-buildspec-report.sh: Permission denied` I hope to fix that with `buildspec.yml` change.

Back-end includes the info, if file exists.