### PR TITLE
COL-1004, test CodeBuild env var: CODEBUILD_RESOLVED_SOURCE_VERSION

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,11 +15,11 @@ phases:
       - ./node_modules/.bin/gulp eslint
   build:
     commands:
-      - echo "build phase"
+      - echo "CODEBUILD_RESOLVED_SOURCE_VERSION: ${CODEBUILD_RESOLVED_SOURCE_VERSION}"
+      - chmod 554 scripts/generate-buildspec-report.sh && ./scripts/generate-buildspec-report.sh
   post_build:
     commands:
       - for i in $(ls node_modules | grep -v ^col-); do rm -Rf node_modules/$i; done
-      - chmod 554 scripts/generate-buildspec-report.sh && ./scripts/generate-buildspec-report.sh
 
 artifacts:
   files:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1004

CodeBuild succeeded but post_build phase complained:
```
Not a git repository (or any parent up to mount point /codebuild/output)
```

[AWS docs](http://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html#build-env-ref-env-vars) suggest `CODEBUILD_RESOLVED_SOURCE_VERSION`. This PR checks that value and moves `generate-buildspec-report.sh` to build phase. 