### PR TITLE
COL-1004, revert buildspec.yml to put CodePipeline back on track

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,8 +15,7 @@ phases:
       - ./node_modules/.bin/gulp eslint
   build:
     commands:
-      - echo "CODEBUILD_RESOLVED_SOURCE_VERSION: ${CODEBUILD_RESOLVED_SOURCE_VERSION}"
-      - chmod 554 scripts/generate-buildspec-report.sh && ./scripts/generate-buildspec-report.sh
+      - echo "build phase"
   post_build:
     commands:
       - for i in $(ls node_modules | grep -v ^col-); do rm -Rf node_modules/$i; done


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1004

CodeBuild still ain't happy. Let's revert and put off this non-urgent issue. Sad!

For comparison, `buildspec.yml` now matches what we have on `qa` branch: https://github.com/ets-berkeley-edu/suitec/blob/qa/buildspec.yml 