### PR TITLE
COL-987, swim lanes must settle down when you toggle between empty and non-empty lanes

### DIFF
--- a/public/app/dashboard/profile.css
+++ b/public/app/dashboard/profile.css
@@ -237,7 +237,11 @@
 }
 
 .profile-assets-container {
-  margin-bottom: 30px;
+  min-height: 360px;
+}
+
+.profile-assets-container-tall {
+  min-height: 420px;
 }
 
 .profile-container {
@@ -300,11 +304,16 @@
 }
 
 .profile-filters h3 {
+  margin-bottom: 15px;
   position: relative;
 }
 
 .profile-input-invalid {
   color: #A94442;
+}
+
+.profile-list-compact {
+  margin-top: 0;
 }
 
 .profile-summary-avatar {

--- a/public/app/dashboard/profile.html
+++ b/public/app/dashboard/profile.html
@@ -172,7 +172,7 @@
     </div>
   </div>
 
-  <div class="profile-assets-container">
+  <div data-ng-class="{'profile-assets-container': user.totalAssetsInCourse, 'profile-assets-container-tall': !user.totalAssetsInCourse}">
     <div class="profile-filters">
       <h3>{{isMyProfile ? 'My Assets' : 'Assets'}}{{user.totalAssetsInCourse || user.hasPins ? ':' : ''}}</h3>
 
@@ -195,9 +195,8 @@
       </div>
     </div>
 
-    <div class="col-list-container">
-      <div class="alert alert-info assetlibrary-list-noresults"
-           data-ng-if="!user.assets.isLoading && ((!user.totalAssetsInCourse && !user.hasPins) || !user.assets.results.length)">
+    <div class="profile-list-compact col-list-container">
+      <div class="help-block alert alert-info" data-ng-if="(!user.totalAssetsInCourse && !user.hasPins) || !user.assets.results.length">
         No matching assets were found.
       </div>
       <ul>
@@ -242,7 +241,7 @@
           </div>
         </li>
 
-        <li class="assetlibrary-list-item list-inline col-xs-6 col-sm-4 col-md-3"
+        <li class="profile-list-compact assetlibrary-list-item list-inline col-xs-6 col-sm-4 col-md-3"
             data-ng-repeat="asset in user.assets.results">
           <div class="col-list-item-container">
             <a tool-href
@@ -282,14 +281,12 @@
       </div>
     </div>
 
-    <div class="col-list-container">
-      <div class="alert alert-info assetlibrary-list-noresults"
-        data-ng-if="!community.assets.isLoading && (!community.totalAssetsInCourse || !community.assets.results.length)">
-
+    <div class="profile-list-compact col-list-container">
+      <div class="help-block alert alert-info" data-ng-if="!community.totalAssetsInCourse || !community.assets.results.length">
         No matching assets were found.
       </div>
       <ul>
-        <li class="assetlibrary-list-item list-inline col-xs-6 col-sm-4 col-md-3"
+        <li class="profile-list-compact assetlibrary-list-item list-inline col-xs-6 col-sm-4 col-md-3"
             data-ng-repeat="asset in community.assets.results">
           <div class="col-list-item-container">
             <a tool-href

--- a/public/app/dashboard/profileController.js
+++ b/public/app/dashboard/profileController.js
@@ -42,7 +42,6 @@
     $scope.user = {
       totalAssetsInCourse: null,
       assets: {
-        isLoading: true,
         sortBy: 'recent',
         advancedSearchId: null,
         filterLabels: {
@@ -61,7 +60,6 @@
     $scope.community = {
       totalAssetsInCourse: null,
       assets: {
-        isLoading: true,
         sortBy: 'recent',
         advancedSearchId: null,
         filterLabels: {
@@ -153,8 +151,6 @@
      * @return {void}
      */
     var sortUserAssets = $scope.sortUserAssets = function(sortType, track) {
-      $scope.user.assets.isLoading = true;
-
       // First, set marker to identify user as having one or more pins in this course.
       // User with one or more pins, and no uploaded assets, needs filters under 'My Assets'
       // such that s/he can navigate to 'Pinned' list.
@@ -194,7 +190,6 @@
           sort: isShowAllFilter ? '' : sortType,
           user: $scope.user.id
         });
-        $scope.user.assets.isLoading = false;
       });
     };
 
@@ -206,8 +201,6 @@
      * @return {void}
      */
     var sortCommunityAssets = $scope.sortCommunityAssets = function(sortType, track) {
-      $scope.community.assets.isLoading = true;
-
       var searchOptions = {
         'sort': sortType,
         'limit': $scope.maxPerSwimlane
@@ -237,7 +230,6 @@
         $scope.community.assets.advancedSearchId = utilService.getAdvancedSearchId({
           sort: isShowAllFilter ? '' : sortType
         });
-        $scope.community.assets.isLoading = false;
       });
     };
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-987

Put fixed min-height on swim lanes. In addition to herky-jerky UI, the "No matching assets" alert flickered when toggling between lanes.  This was fixed by removing the use of `isLoading`. 

The most dramatic case of empty real estate is below. This is only seen when user has zero uploaded assets. The empty space is a call to action!

![image](https://user-images.githubusercontent.com/7606442/27007120-77f6fa0e-4dfc-11e7-9c3a-59b0126aaf6a.png)

----

![image](https://user-images.githubusercontent.com/7606442/27007118-6eba50e4-4dfc-11e7-9fd3-e8b98a28f7a8.png)
