### PR TITLE
[QA] COL-1010, use of UsersAPI.getUsers to get user data is problematic

### DIFF
--- a/node_modules/col-users/lib/rest.js
+++ b/node_modules/col-users/lib/rest.js
@@ -44,12 +44,12 @@ Collabosphere.apiRouter.get('/users/me', function(req, res) {
  * Get user of current course by id
  */
 Collabosphere.apiRouter.get('/users/id/:id', function(req, res) {
-  UsersAPI.getUsers(req.ctx, [req.params.id], function(err, users) {
+  UsersAPI.getUser(req.params.id, function(err, user) {
     if (err) {
       return res.status(err.code).send(err.msg);
     }
 
-    return res.status(200).send(users[0]);
+    return res.status(200).send(user);
   });
 });
 

--- a/public/app/dashboard/profile.html
+++ b/public/app/dashboard/profile.html
@@ -16,18 +16,18 @@
         tabindex="-1"></oi-select>
     </div>
     <div data-ng-if="browse.previous && browse.next">
-      <i data-ng-click="loadProfile(browse.previous)" class="fa fa-caret-left"></i>
+      <i data-ng-click="loadProfileById(browse.previous.id)" class="fa fa-caret-left"></i>
       <button type="button"
         class="btn btn-link other-users-browse"
-        data-ng-click="loadProfile(browse.previous)">
+        data-ng-click="loadProfileById(browse.previous.id)">
         <span data-ng-bind="browse.previous.canvas_full_name"></span>
       </button> |
       <button type="button"
         class="btn btn-link other-users-browse"
-        data-ng-click="loadProfile(browse.next)">
+        data-ng-click="loadProfileById(browse.next.id)">
         <span data-ng-bind="browse.next.canvas_full_name"></span>
       </button>
-      <i data-ng-click="loadProfile(browse.next)" class="fa fa-caret-right" ></i>
+      <i data-ng-click="loadProfileById(browse.next.id)" class="fa fa-caret-right" ></i>
     </div>
   </div>
   <div class="profile-summary-container">

--- a/public/app/dashboard/profileController.js
+++ b/public/app/dashboard/profileController.js
@@ -39,7 +39,7 @@
     // If total asset count exceeds the following limit then we'll offer a link to 'Show all'.
     $scope.maxPerSwimlane = 4;
 
-    $scope.user = {
+    var defaultUserPreferences = {
       totalAssetsInCourse: null,
       assets: {
         isLoading: true,
@@ -255,11 +255,20 @@
       }
     };
 
-    var loadProfile = $scope.loadProfile = function(user) {
+    /**
+     * Combine standard user data and activity metadata
+     *
+     * @param  {Object}               user              User being rendered in profile
+     * @return {void}
+     */
+    var loadProfile = function(user) {
+      // Set default preferences
+      $scope.user = user;
+      _.extend($scope.user, defaultUserPreferences);
+
       $scope.isMyProfile = user.id === me.id;
 
-      // Combine activity metadata and standard user data
-      angular.extend($scope.user, user);
+      // Sort section(s)
       $scope.user.canvasCourseSections = user.canvas_course_sections && user.canvas_course_sections.sort();
 
       $scope.showEngagementIndexBox = me.course.engagementindex_url && ($scope.isMyProfile || me.is_admin || (user.share_points && me.share_points));
@@ -313,6 +322,18 @@
     };
 
     /**
+     * Combine standard user data and activity metadata
+     *
+     * @param  {Object}               userId              Id of user being rendered in profile
+     * @return {void}
+     */
+    var loadProfileById = $scope.loadProfileById = function(userId) {
+      userFactory.getUser(userId).success(function(user) {
+        loadProfile(user);
+      });
+    };
+
+    /**
      * Listen for pinning/unpinning events by 'me'
      */
     $scope.$on('assetPinEventByMe', function(ev, updatedAsset) {
@@ -334,11 +355,9 @@
 
     var init = function() {
       // Determine user
-      var otherUserId = $stateParams.userId || (referringTool && referringTool.requestedId);
-      if (otherUserId) {
-        userFactory.getUser(otherUserId).success(function(user) {
-          loadProfile(user);
-        });
+      var userId = $stateParams.userId || (referringTool && referringTool.requestedId);
+      if (userId) {
+        loadProfileById(userId);
       } else {
         loadProfile(me);
       }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1010

The `me` object (set in col-core module with `UsersAPI.getUser`) has all data we need. However, `otherUsers` list comes from `UsersAPI.getUsers` which is less rich. Two fixes here:
1. Front-end profileController wipes the slate fully clean when browsing to next user.
2. The `/users/id/:id` endpoint now relies on the richer result-set of `UsersAPI.getUser`. 