### PR TITLE
COL-1012 Use elbv2 settings for load balancer SSL config

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -11,103 +11,44 @@ packages:
     postgresql94-devel: []
 
 option_settings:
-  # Application health checks must be made over SSL.
   aws:elasticbeanstalk:application:
-    Application Healthcheck URL: HTTPS:443/
+    Application Healthcheck URL: HTTPS:443/api/status
 
   aws:elasticbeanstalk:container:nodejs:
     NodeVersion: 6.9.1
     ProxyServer: apache
     NodeCommand: 'node_modules/.bin/forever -a -m 10 app.js'
 
-  # The load balancer listens on a secure connection, decrypts to do its work, and re-encrypts for a secure
-  # connection to EC2 instances.
-  aws:elb:listener:443:
-    SSLCertificateId: arn:aws:acm:us-west-2:234923831700:certificate/46735ef4-18d4-41c3-8e5f-0fe42ee251b4
-    ListenerProtocol: HTTPS
-    InstancePort: 443
-    InstanceProtocol: HTTPS
+  aws:elasticbeanstalk:environment:
+    LoadBalancerType: application
 
-  aws:elb:loadbalancer:
-    SecurityGroups: '`{ "Ref" : "loadbalancersg" }`'
-    ManagedSecurityGroup: '`{ "Ref" : "loadbalancersg" }`'
+  # Instances talk to the load balancer over HTTPS.
+  aws:elasticbeanstalk:environment:process:default:
+    HealthCheckPath: /api/status
+    Port: '443'
+    Protocol: HTTPS
 
-  aws:elb:policies:backendencryption:
-    PublicKeyPolicyNames: backendkey
-    InstancePorts: 443
+  # Disable the load balancer's default listener on port 80.
+  aws:elbv2:listener:default:
+    ListenerEnabled: 'false'
 
-  # The load balancer expects this public key on the EC2 instances (see 01_create_apache_conf.config).
-  aws:elb:policies:backendkey:
-    PublicKey: |
-      -----BEGIN CERTIFICATE-----
-      MIIEIjCCAwoCCQCwhQUqTb0YaDANBgkqhkiG9w0BAQUFADCB0jELMAkGA1UEBhMC
-      VVMxEzARBgNVBAgTCkNhbGlmb3JuaWExETAPBgNVBAcTCEJlcmtlbGV5MSEwHwYD
-      VQQKExhVbml2ZXJzaXR5IG9mIENhbGlmb3JuaWExKDAmBgNVBAsTH0VkdWNhdGlv
-      bmFsIFRlY2hub2xvZ3kgU2VydmljZXMxIDAeBgNVBAMTF2V0cy1iZXJrZWxleS1z
-      dWl0ZWMubmV0MSwwKgYJKoZIhvcNAQkBFh1hd3Mtc3VpdGVjQGxpc3RzLmJlcmtl
-      bGV5LmVkdTAeFw0xNzAxMzAyMTMyNDFaFw0xODAxMzAyMTMyNDFaMIHSMQswCQYD
-      VQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTERMA8GA1UEBxMIQmVya2VsZXkx
-      ITAfBgNVBAoTGFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYTEoMCYGA1UECxMfRWR1
-      Y2F0aW9uYWwgVGVjaG5vbG9neSBTZXJ2aWNlczEgMB4GA1UEAxMXZXRzLWJlcmtl
-      bGV5LXN1aXRlYy5uZXQxLDAqBgkqhkiG9w0BCQEWHWF3cy1zdWl0ZWNAbGlzdHMu
-      YmVya2VsZXkuZWR1MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmiwl
-      d0KYQsyPczI9NYX9+lywQOU4jUFuls/VyN/WV9iwNYnIe3PI2kGcuVjwGNA2c1NK
-      WAjFUH4Ylbv0UjbXE2kPTIP7haJ+MzOWIuRP6xMyh6VBbw58y91btmDBts1KxeFt
-      uho2SQ/K6W+obZRAAGvwy//ejL5H5KU9MDhFSfhvr1Obo5Dl4KtJ6Q3RyM33PUxl
-      vFUUSyJq15vFkTS2081Ezj6grP4rDSwgWPpe3Nx7Qij1tbnWsNUhq34BiKUlTGo+
-      3zks+y0CRs2vqFBbBbziHc7T6sXi5hf9FpIw1fDY08a7bdJ96oDKX79UuAWwoK2E
-      AFeE8pPnAcpNq/BrrQIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQAXm7iNjbbmA0hm
-      pYmatH7rYyt3x/cMIPk+JqAE5Wl7LX3AWs+VJUEQfmx7eH/OlIuH1DZG0JYELmDw
-      yf0os30rNk1zz4+HT6+QdkikqVXWLljK3/F2UcLRQ1QxAUhhQZyjEA0S/QCeA+Um
-      qQQ3IN3HNqsQtW2s9lZh3lULtjQPjiaxA0bHE7wpfDqZ7/3pqYVqDbDgSea7KK7a
-      dlAHiyP7+LP4U00bQp/m1Hb5ykT/rLMjiVwqFpB+YjCsUsuPYq1UTLNA2zh7mvJP
-      BhNKFR9+k+Kpl9YBcbLGoC67OPLjPUIdrBLu660JInFuItCiiq6w4aLBPUDGblgy
-      8JH5mCAF
-      -----END CERTIFICATE-----
+  # Enable a custom load balancer listener on port 433.
+  aws:elbv2:listener:443:
+    ListenerEnabled: 'true'
+    Protocol: HTTPS
+    SSLCertificateArns: arn:aws:acm:us-west-2:234923831700:certificate/46735ef4-18d4-41c3-8e5f-0fe42ee251b4
 
 Resources:
 
-  # The load balancer listens on port 443 from any source.
-  loadbalancersg:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: load balancer security group
-      VpcId: vpc-264dc841
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          CidrIp: 0.0.0.0/0
-
-  # The load balancer initiates connections on port 443 only to destinations in the EC2 instance security group.
-  httpsToBackendInstances: 
-    Type: AWS::EC2::SecurityGroupEgress
-    Properties:
-      GroupId: {"Fn::GetAtt" : ["loadbalancersg", "GroupId"]}
-      IpProtocol: tcp
-      ToPort: 443
-      FromPort: 443
-      DestinationSecurityGroupId: {"Fn::GetAtt" : ["AWSEBSecurityGroup", "GroupId"]}
-
-  # EC2 instances accept connections on port 443 only from the load balancer.
-  httpsFromLoadBalancerSG: 
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId: {"Fn::GetAtt" : ["AWSEBSecurityGroup", "GroupId"]}
-      IpProtocol: tcp
-      ToPort: 443
-      FromPort: 443
-      SourceSecurityGroupId: {"Fn::GetAtt" : ["loadbalancersg", "GroupId"]}
-
-  # Instances may download protected files from a private S3 bucket. 
+  # Instances may download protected files from a private S3 bucket.
   AWSEBAutoScalingGroup:
     Metadata:
       AWS::CloudFormation::Authentication:
         S3Auth:
           type: "s3"
           buckets: ["elasticbeanstalk-us-west-2-234923831700"]
-          roleName: 
-            "Fn::GetOptionSetting": 
+          roleName:
+            "Fn::GetOptionSetting":
               Namespace: "aws:autoscaling:launchconfiguration"
               OptionName: "IamInstanceProfile"
               DefaultValue: "aws-elasticbeanstalk-ec2-role"

--- a/.ebextensions/01_create_apache_conf.config
+++ b/.ebextensions/01_create_apache_conf.config
@@ -4,7 +4,7 @@
 files:
 
   # The default Elastic Beanstalk .conf file for NodeJS containers must be overwritten. We create a
-  # replacement file here, then overwrite the default (02_overwrite_apache_conf.config) and restart Apache 
+  # replacement file here, then overwrite the default (02_overwrite_apache_conf.config) and restart Apache
   # (99_delayed_script.config).
   /tmp/suitec.httpd.conf:
     mode: '000644'
@@ -126,7 +126,6 @@ files:
         SSLSessionTickets     Off
 
         Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains; preload"
-        Header always set X-Frame-Options DENY
         Header always set X-Content-Type-Options nosniff
         Header set Access-Control-Allow-Origin "*"
 
@@ -136,7 +135,7 @@ files:
         RequestHeader set X-Forwarded-Proto "https" early
 
       </VirtualHost>
-      
+
   # The load balancer expects to find this SSL certificate on EC2 instances. Note that this is a self-signed
   # certificate for the load balancer's benefit only, not the domain-associated certificate that the load
   # balancer presents to users.


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1012

The new settings are, thankfully, rather simpler.