### PR TITLE
COL-1028 User.looking_for_collaborators: database and feed

### DIFF
--- a/config/schema.sql
+++ b/config/schema.sql
@@ -15,14 +15,14 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner:
 --
 
 CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 
 --
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner:
 --
 
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
@@ -560,7 +560,8 @@ CREATE TABLE users (
     updated_at timestamp with time zone NOT NULL,
     course_id integer NOT NULL,
     canvas_course_sections character varying(255)[],
-    personal_bio character varying(255)
+    personal_bio character varying(255),
+    looking_for_collaborators boolean DEFAULT false NOT NULL
 );
 
 

--- a/node_modules/col-core/lib/db.js
+++ b/node_modules/col-core/lib/db.js
@@ -292,16 +292,17 @@ var setUpModel = function(sequelize) {
    * the same physical student might end up with two student records within Collabosphere. As
    * there's no overlap between courses, this is acceptable.
    *
-   * @property  {Number}      canvas_user_id            The id of the user in Canvas
-   * @property  {String}      canvas_course_role        The role of the user in the course
-   * @property  {String}      [canvas_course_sections]  Array of section names per course, user enrollments
-   * @property  {String}      canvas_full_name          The full name of the student
-   * @property  {String}      [canvas_image]            The URL that points to a profile picture for the user
-   * @property  {String}      [canvas_email]            The email of the student
-   * @property  {String}      [personal_bio]            User's personal description
-   * @property  {Number}      points                    The total Engagement Index points that the user has accumulated in the course
-   * @property  {Boolean}     share_points              Whether the user wants to share their point total with the other students in the course
-   * @property  {String}      bookmarklet_token         The bookmarklet access token for the user
+   * @property  {Number}      canvas_user_id              The id of the user in Canvas
+   * @property  {String}      canvas_course_role          The role of the user in the course
+   * @property  {String}      [canvas_course_sections]    Array of section names per course, user enrollments
+   * @property  {String}      canvas_full_name            The full name of the student
+   * @property  {String}      [canvas_image]              The URL that points to a profile picture for the user
+   * @property  {String}      [canvas_email]              The email of the student
+   * @property  {String}      [personal_bio]              User's personal description
+   * @property  {Number}      points                      The total Engagement Index points that the user has accumulated in the course
+   * @property  {Boolean}     share_points                Whether the user wants to share their point total with the other students in the course
+   * @property  {String}      bookmarklet_token           The bookmarklet access token for the user
+   * @property  {Boolean}     looking_for_collaborators   Whether the user should display a 'looking for collaborators' notification
    */
   var User = module.exports.User = sequelize.define('user', {
     'canvas_user_id': {
@@ -353,6 +354,11 @@ var setUpModel = function(sequelize) {
     'bookmarklet_token': {
       'type': Sequelize.STRING(32),
       'allowNull': false
+    },
+    'looking_for_collaborators': {
+      'type': Sequelize.BOOLEAN,
+      'allowNull': false,
+      'defaultValue': false
     }
   }, {
     'underscored': true,

--- a/node_modules/col-users/lib/constants.js
+++ b/node_modules/col-users/lib/constants.js
@@ -24,7 +24,30 @@
  */
 
 var Constants = module.exports = {
-  'BASIC_USER_FIELDS': ['id', 'canvas_user_id', 'canvas_course_role', 'canvas_course_sections', 'canvas_enrollment_state', 'canvas_full_name', 'canvas_image', 'personal_bio'],
-  'EMAIL_FIELDS': ['canvas_email'],
-  'POINTS_USER_FIELDS': ['id', 'canvas_user_id', 'canvas_course_role', 'canvas_enrollment_state', 'canvas_full_name', 'canvas_image', 'points', 'share_points', 'last_activity']
+  'BASIC_USER_FIELDS': [
+    'id',
+    'canvas_user_id',
+    'canvas_course_role',
+    'canvas_course_sections',
+    'canvas_enrollment_state',
+    'canvas_full_name',
+    'canvas_image',
+    'personal_bio',
+    'looking_for_collaborators'
+  ],
+  'EMAIL_FIELDS': [
+    'canvas_email'
+  ],
+  'POINTS_USER_FIELDS': [
+    'id',
+    'canvas_user_id',
+    'canvas_course_role',
+    'canvas_enrollment_state',
+    'canvas_full_name',
+    'canvas_image',
+    'points',
+    'share_points',
+    'last_activity',
+    'looking_for_collaborators'
+  ]
 };

--- a/node_modules/col-users/tests/util.js
+++ b/node_modules/col-users/tests/util.js
@@ -52,6 +52,7 @@ var assertMe = module.exports.assertMe = function(me, opts) {
   assert.ok(me.updated_at);
   assert.ok(_.isFinite(me.points));
   assert.ok(_.isBoolean(me.is_admin));
+  assert.ok(_.isBoolean(me.looking_for_collaborators));
   assert(me.share_points === null || _.isBoolean(me.share_points));
 
   // Ensure that all expected properties are present on the course property
@@ -100,6 +101,7 @@ var assertMe = module.exports.assertMe = function(me, opts) {
     assert.strictEqual(me.points, opts.expectedMe.points);
     assert.strictEqual(me.share_points, opts.expectedMe.share_points);
     assert.strictEqual(me.is_admin, opts.expectedMe.is_admin);
+    assert.strictEqual(me.looking_for_collaborators, opts.expectedMe.looking_for_collaborators);
 
     // Ensure that all the expected properties on the course property are the same
     assert.strictEqual(me.course.id, opts.expectedMe.course.id);
@@ -142,6 +144,7 @@ var assertUser = module.exports.assertUser = function(user, opts) {
   assert.ok(user.canvas_full_name);
   assert.ok(user.canvas_enrollment_state);
   assert.ok(_.isUndefined(user.bookmarklet_token));
+  assert.ok(_.isBoolean(user.looking_for_collaborators));
 
   if (opts.expectPoints) {
     assert.ok(_.isFinite(user.points));
@@ -174,6 +177,7 @@ var assertUser = module.exports.assertUser = function(user, opts) {
     assert.equal(user.personal_bio, opts.expectedUser.personal_bio);
     assert.strictEqual(user.points, opts.expectedUser.points);
     assert.strictEqual(user.share_points, opts.expectedUser.share_points);
+    assert.strictEqual(user.looking_for_collaborators, opts.expectedUser.looking_for_collaborators);
 
     // Ensure that all optional properties are the same as the ones for the
     // expected user

--- a/scripts/20170620-col1028/add_users_looking_for_collaborators.sql
+++ b/scripts/20170620-col1028/add_users_looking_for_collaborators.sql
@@ -1,0 +1,7 @@
+-- Users can toggle looking_for_collaborators on Impact Studio profile page
+
+ALTER TABLE users ADD looking_for_collaborators boolean NOT NULL DEFAULT false;
+
+/**** ROLLBACK ****
+
+ALTER TABLE users DROP looking_for_collaborators;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1028

Since this value is expected to surface across the app, including the Engagement Index, it must be added to `BASIC_USER_FIELDS` and `POINTS_USER_FIELDS`.

Suppressing this value from the feed based on Impact Studio use turns out to be impractical, as it would require too many joins to the `courses` table to check for `dashboard_url`. We're better off enforcing that logic in the front end, which always has course properties available.