### PR TITLE
COL-1037 Front-end modal and alerts for collaboration messages

### DIFF
--- a/node_modules/col-canvas/lib/api.js
+++ b/node_modules/col-canvas/lib/api.js
@@ -473,6 +473,7 @@ var postConversation = module.exports.postConversation = function(ctx, recipient
   };
   request(opts, function(err, response, body) {
     if (err) {
+      delete opts.headers;
       log.error({'err': err, 'course': ctx.course.id, 'opts': opts}, 'Failed to post to a Canvas conversation');
       return callback({'code': 500, 'msg': 'Failed to post to a Canvas conversation'});
     } else if (response.statusCode !== 201) {

--- a/node_modules/col-users/lib/api.js
+++ b/node_modules/col-users/lib/api.js
@@ -562,6 +562,7 @@ var messageUser = module.exports.messageUser = function(ctx, userId, subject, bo
       'course_id': ctx.course.id
     }
   };
+
   DB.User.findOne(recipientUserOptions).complete(function(err, recipientUser) {
     if (err) {
       log.error({'err': err, 'id': userId, 'course_id': ctx.course.id}, 'Failed to get a user');
@@ -571,6 +572,18 @@ var messageUser = module.exports.messageUser = function(ctx, userId, subject, bo
       return callback({'code': 404, 'msg': 'A user with the specified id could not be found in the course'});
     }
 
-    return CanvasAPI.postConversation(ctx, recipientUser.canvas_user_id, subject, body, callback);
+    // Retrieve Canvas API key, which isn't automatically fetched by authentication middleware
+    DB.Canvas.findOne({
+      'where': {'canvas_api_domain': ctx.course.canvas.canvas_api_domain},
+      'attributes': ['api_key']
+    }).complete(function(err, canvas) {
+      if (err) {
+        log.error({'err': err, 'course': ctx.course}, 'Failed to retrieve Canvas API key');
+        return callback({'code': 500, 'msg': err.message});
+      }
+      ctx.course.canvas.api_key = canvas.api_key;
+
+      return CanvasAPI.postConversation(ctx, recipientUser.canvas_user_id, subject, body, callback);
+    });
   });
 };

--- a/public/app/dashboard/lookingForCollaborators.html
+++ b/public/app/dashboard/lookingForCollaborators.html
@@ -14,7 +14,9 @@
       </span>
     </label>
   </div>
-  <button data-ng-if="!isMyProfile && user.looking_for_collaborators" class="looking-for-collaborators-button">
+  <button class="looking-for-collaborators-button"
+          data-ng-click="launchCollaborationModal(user)"
+          data-ng-if="!isMyProfile && user.looking_for_collaborators">
     <i class="fa fa-user-plus"></i> Looking for Collaborators
   </button>
 </div>

--- a/public/app/dashboard/profile.html
+++ b/public/app/dashboard/profile.html
@@ -1,4 +1,5 @@
 <div class="profile-container">
+  <div data-ng-include="'/app/shared/notifications.html'"></div>
   <div class="other-users-container">
     <div>
       <span data-ng-if="browse.otherUsers.length">

--- a/public/app/dashboard/profileController.js
+++ b/public/app/dashboard/profileController.js
@@ -27,7 +27,19 @@
 
   'use strict';
 
-  angular.module('collabosphere').controller('ProfileController', function(analyticsService, assetLibraryFactory, me, profileFactory, crossToolRequest, userFactory, utilService, $scope, $state, $stateParams) {
+  angular.module('collabosphere').controller('ProfileController', function(
+    analyticsService,
+    assetLibraryFactory,
+    collaborationMessageService,
+    crossToolRequest,
+    me,
+    profileFactory,
+    userFactory,
+    utilService,
+    $scope,
+    $state,
+    $stateParams
+  ) {
 
     // Dummy function (i.e., no-op callback) used in profile template
     var noOp = $scope.noOp = angular.noop;
@@ -449,6 +461,9 @@
         userFactory.updateLookingForCollaborators($scope.me.looking_for_collaborators);
       }
     };
+
+    // Make collaboration modal launch available to the scope.
+    $scope.launchCollaborationModal = collaborationMessageService.launchCollaborationModal;
 
     /**
      * Listen for pinning/unpinning events by 'me'

--- a/public/app/engagementindex/leaderboard/leaderboard.html
+++ b/public/app/engagementindex/leaderboard/leaderboard.html
@@ -1,3 +1,5 @@
+<div data-ng-include="'/app/shared/notifications.html'"></div>
+
 <h2>Engagement Index</h2>
 
 <div data-ng-if="me.is_admin && (!me.course.active || me.course.reactivated)" data-ng-include="'/app/shared/syncdisabled.html'"></div>

--- a/public/app/engagementindex/leaderboard/leaderboardController.js
+++ b/public/app/engagementindex/leaderboard/leaderboardController.js
@@ -27,7 +27,16 @@
 
   'use strict';
 
-  angular.module('collabosphere').controller('LeaderboardController', function(analyticsService, courseFactory, me, crossToolRequest, userFactory, utilService, $scope) {
+  angular.module('collabosphere').controller('LeaderboardController', function(
+    analyticsService,
+    collaborationMessageService,
+    courseFactory,
+    crossToolRequest,
+    me,
+    userFactory,
+    utilService,
+    $scope
+  ) {
 
     // Make the me object available to the scope
     $scope.me = me;
@@ -402,6 +411,9 @@
     var updateLookingForCollaborators = $scope.updateLookingForCollaborators = function() {
       userFactory.updateLookingForCollaborators($scope.me.looking_for_collaborators);
     };
+
+    // Make collaboration modal launch available to the scope.
+    $scope.launchCollaborationModal = collaborationMessageService.launchCollaborationModal;
 
     // Track if following link from another tool.
     if (crossToolRequest) {

--- a/public/app/engagementindex/leaderboard/list.html
+++ b/public/app/engagementindex/leaderboard/list.html
@@ -74,8 +74,10 @@
                  data-ng-change="updateLookingForCollaborators()">
           <span data-ng-bind="me.looking_for_collaborators ? 'Looking' : 'Not looking'"></span>
         </label>
-        <button data-ng-if="user.id !== me.id && user.looking_for_collaborators"
-                class="looking-for-collaborators-button looking-for-collaborators-button-small">
+        <button class="looking-for-collaborators-button looking-for-collaborators-button-small"
+                title="Looking for Collaborators"
+                data-ng-click="launchCollaborationModal(user)"
+                data-ng-if="user.id !== me.id && user.looking_for_collaborators">
           <i class="fa fa-user-plus"></i>
         </button>
       </td>

--- a/public/app/shared/collaborationMessageModal.css
+++ b/public/app/shared/collaborationMessageModal.css
@@ -1,0 +1,7 @@
+.collaboration-message-field {
+  margin: 15px 0 10px 0;
+}
+
+.collaboration-message-header {
+  font-weight: 600;
+}

--- a/public/app/shared/collaborationMessageModal.html
+++ b/public/app/shared/collaborationMessageModal.html
@@ -1,0 +1,32 @@
+<div class="modal">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-ng-click="closeModal()" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h3 class="modal-title">Connect with Others Looking for Collaborators</h3>
+      </div>
+      <div class="modal-body">
+        <h2>
+          Send a collaboration invite.
+        </h2>
+        <div class="collaboration-message-field">
+          <span class="collaboration-message-header">Message to:</span> <span data-ng-bind="recipient.canvas_full_name"></span>
+        </div>
+        <div class="collaboration-message-field">
+          <span class="collaboration-message-header">Subject: Looking to Collaborate</a>
+        </div>
+        <div class="collaboration-message-field">
+          <span class="collaboration-message-header">Message:</span>
+        </div>
+        <textarea class="form-control" placeholder="I'm looking to collaborate on..." rows="5" data-ng-model="messageBody">
+        </textarea>
+      </div>
+      <div class="modal-footer">
+        <form name="whiteboardsReuseForm" class="form-horizontal" data-ng-submit="closeModal(messageBody)" novalidate>
+          <button type="button" class="btn btn-default" data-ng-click="closeModal()">Cancel</button>
+          <button type="submit" class="btn btn-primary" data-ng-disabled="!messageBody">Send Invite</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/public/app/shared/collaborationMessageService.js
+++ b/public/app/shared/collaborationMessageService.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+(function(angular) {
+
+  'use strict';
+
+  angular.module('collabosphere').service('collaborationMessageService', function(me, userFactory, $alert, $modal, $rootScope) {
+
+    /**
+     * Show a notification after sending a collaboration message
+     *
+     * @param  {String}      type          Notification type: 'success' or 'error'
+     * @param  {String}      content       Notification text
+     * @return {void}
+     */
+    var showNotification = function(type, content) {
+      $alert({
+        'container': '#notifications-placeholder',
+        'content': content,
+        'duration': 3,
+        'keyboard': true,
+        'show': true,
+        'templateUrl': 'notifications-template',
+        'type': type
+      });
+    };
+
+    /**
+     * Send a collaboration invite message
+     *
+     * @param  {User}        recipient         The user receiving the message
+     * @param  {String}      messageBody       Message body text
+     * @return {Promise}                       $http Promise
+     */
+    var sendCollaborationInvite = function(recipient, messageBody) {
+      return userFactory.messageUser(recipient.id, 'Looking to Collaborate', messageBody).then(function() {
+        showNotification('success', 'Your message was sent to <strong>' + recipient.canvas_full_name + '</strong>.');
+      }).catch(function() {
+        showNotification('danger', 'There was an error sending your message.');
+      });
+    };
+
+    /**
+     * Launch the collaboration message modal window
+     *
+     * @param  {User}        recipient         The user receiving the message
+     * @return {void}
+     */
+    var launchCollaborationModal = function(recipient) {
+      // Create a new scope for the modal dialog
+      var scope = $rootScope.$new(true);
+      scope.me = me;
+      scope.recipient = recipient;
+      scope.closeModal = function(messageBody) {
+        var modal = this;
+        var removeModal = function() {
+          modal.$hide();
+          modal.$destroy();
+        };
+        if (messageBody) {
+          sendCollaborationInvite(recipient, messageBody).then(removeModal);
+        } else {
+          removeModal();
+        }
+      };
+      $modal({
+        'animation': false,
+        'backdrop': false,
+        'scope': scope,
+        'templateUrl': '/app/shared/collaborationMessageModal.html'
+      });
+    };
+
+    return {
+      'launchCollaborationModal': launchCollaborationModal
+    };
+
+  });
+
+}(window.angular));

--- a/public/app/shared/notifications.html
+++ b/public/app/shared/notifications.html
@@ -1,0 +1,9 @@
+<div id="notifications-placeholder"></div>
+<script type="text/ng-template" id="notifications-template">
+  <div class="alert" ng-class="'alert-' + type">
+    <button type="button" class="btn btn-link pull-right close" ng-click="$hide()">
+      <i class="fa fa-times-circle"><span class="sr-only">Close</span></i>
+    </button>
+    <strong ng-bind="title"></strong>&nbsp;<span ng-bind-html="content"></span>
+  </div>
+</script>

--- a/public/app/shared/userFactory.js
+++ b/public/app/shared/userFactory.js
@@ -89,6 +89,22 @@
     };
 
     /**
+     * Send a Canvas conversation message to a user
+     *
+     * @param  {Number}             recipientId        The SuiteC id of the recipient user
+     * @param  {String}             messageSubject     The message subject
+     * @param  {String}             messageBody        The message body
+     * @return {Promise}                               $http promise
+     */
+    var messageUser = function(recipientId, messageSubject, messageBody) {
+      var message = {
+        'messageSubject': messageSubject,
+        'messageBody': messageBody
+      };
+      return $http.post(utilService.getApiUrl('/users/id/ ' + recipientId + '/message'), message);
+    };
+
+    /**
      * Update the points share status for a user. This will determine whether the user's
      * points are shared with the course
      *
@@ -127,6 +143,7 @@
       'getAllUsers': getAllUsers,
       'getUser': getUser,
       'getLeaderboard': getLeaderboard,
+      'messageUser': messageUser,
       'updateLookingForCollaborators': updateLookingForCollaborators,
       'updateSharePoints': updateSharePoints
     };

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,6 @@
   <link rel="stylesheet" href="/lib/fontawesome/css/font-awesome.css" />
   <link rel="stylesheet" href="/lib/oi.select/dist/select.min.css" />
   <link rel="stylesheet" href="/assets/css/main.css" />
-  <link rel="stylesheet" href="/app/shared/syncdisabled.css" />
   <link rel="stylesheet" href="/app/assetlibrary/addbookmarklet/addbookmarklet.css" />
   <link rel="stylesheet" href="/app/assetlibrary/addlink/addlink.css" />
   <link rel="stylesheet" href="/app/assetlibrary/addlinkcontainer/addlinkcontainer.css" />
@@ -28,6 +27,8 @@
   <link rel="stylesheet" href="/app/engagementindex/points/points.css" />
   <link rel="stylesheet" href="/app/shared/activityTimeline.css" />
   <link rel="stylesheet" href="/app/shared/apiError.css" />
+  <link rel="stylesheet" href="/app/shared/collaborationMessageModal.css" />
+  <link rel="stylesheet" href="/app/shared/syncdisabled.css" />
   <link rel="stylesheet" href="/app/whiteboards/addlinkmodal/addlinkmodal.css" />
   <link rel="stylesheet" href="/app/whiteboards/list/list.css" />
   <link rel="stylesheet" href="/app/whiteboards/board/board.css" />
@@ -90,6 +91,7 @@
   <script src="/app/shared/apiErrorController.js"></script>
   <script src="/app/shared/analyticsService.js"></script>
   <script src="/app/shared/autosuggestFilter.js"></script>
+  <script src="/app/shared/collaborationMessageService.js"></script>
   <script src="/app/shared/courseFactory.js"></script>
   <script src="/app/shared/formatDateFilter.js"></script>
   <script src="/app/shared/hashtagsFilter.js"></script>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1037

Since this modal and the associated confirmation alerts may appear in any of the four tools, they're abstracted into a shared service and templates.

A back-end fix for API key authorization is in a separate commit.

<img width="908" alt="modal" src="https://user-images.githubusercontent.com/2413467/27448404-896342de-5739-11e7-95d1-6857960572e1.png">

<img width="910" alt="success" src="https://user-images.githubusercontent.com/2413467/27448416-91cde5aa-5739-11e7-9c83-d552c6e0955a.png">

<img width="916" alt="error" src="https://user-images.githubusercontent.com/2413467/27448421-96924b08-5739-11e7-9092-bb645fd4c34f.png">
