### PR TITLE
COL-956 Add mobile-specific Safari cookie instructions

### DIFF
--- a/public/app/shared/apiError.html
+++ b/public/app/shared/apiError.html
@@ -1,5 +1,5 @@
 <div class="text-center">
-  <div id="apierror-container" class="text-left" data-ng-if="errorStatus === 401 && !safariLti">
+  <div id="apierror-container" class="text-left" data-ng-if="errorStatus === 401 && !safariLti && !safariLtiMobile">
     <div id="apierror-title">
       <h2>Launch failure</h2>
     </div>
@@ -44,6 +44,21 @@
           <i class="fa fa-arrow-circle-o-right"></i>
         </button>
       </div>
+    </div>
+  </div>
+
+  <div id="apierror-container" class="text-left" data-ng-if="errorStatus === 401 && safariLtiMobile">
+    <div id="apierror-title">
+      <h2>Launch failure</h2>
+    </div>
+    <div>
+      SuiteC was unable to launch the tool you requested. You may need to adjust Safari's settings on your device to allow
+      SuiteC to set cookies.
+    </div>
+    <div>
+      Under your device's Settings app, select "Safari." Under "Privacy &amp; Security," select "Block Cookies"
+      and change the selected value to "Always Allow." You should now be able to launch the tool. Once the tool has
+      launched, you can return your Block Cookies setting to its original value.
     </div>
   </div>
 

--- a/public/app/shared/apiErrorController.js
+++ b/public/app/shared/apiErrorController.js
@@ -28,9 +28,15 @@
   'use strict';
 
   angular.module('collabosphere').controller('ApiErrorController', function(apiError, deviceDetector, $scope) {
-    // Instructions specific to Safari LTI tools should only be displayed if 1) the browser is Safari and 2) SuiteC
-    // is being run in an iframe.
-    $scope.safariLti = (window.top !== window.self) && (deviceDetector.browser === 'safari');
+    // Instructions specific to Safari LTI tools should only be displayed if the browser is Safari and SuiteC is
+    // being run in an iframe. Instructions for desktop and mobile differ.
+    if ((window.top !== window.self) && (deviceDetector.browser === 'safari')) {
+      if (deviceDetector.isMobile()) {
+        $scope.safariLtiMobile = true;
+      } else {
+        $scope.safariLti = true;
+      }
+    }
 
     $scope.errorStatus = apiError.status;
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-956

This goes beyond the scope of the original ticket, which was just to suppress the desktop instructions on mobile, but considering that SuiteC on iOS is now unusable without making this settings change, some explicit instructions seem called for.