### PR TITLE
COL-1059, if pinner is co-owner of the asset then his collaborators get neither "pin" nor "get_pin" credit

### DIFF
--- a/node_modules/col-activities/lib/api.js
+++ b/node_modules/col-activities/lib/api.js
@@ -889,17 +889,17 @@ var createPinActivity = module.exports.createPinActivity = function(ctx, asset, 
  * @param  {Object}         callback.err        An error that occurred, if any
  */
 var createGetPinActivity = module.exports.createGetPinActivity = function(ctx, asset, callback) {
-  var otherUsers = _.reject(asset.users, {'id': ctx.user.id});
+  var isNotAssetOwner = !_.find(asset.users, {'id': ctx.user.id});
 
-  if (otherUsers.length) {
+  if (isNotAssetOwner) {
     getActivitiesForAssetId(ctx, asset.id, function(err, activities) {
       if (err) {
         return callback(err);
       }
       // Consider all asset_users
-      var done = _.after(otherUsers.length, callback);
+      var done = _.after(asset.users.length, callback);
 
-      _.each(otherUsers, function(user) {
+      _.each(asset.users, function(user) {
         var hasReceivedPin = activities.get_pin_asset && !!_.find(activities.get_pin_asset, function(activity) {
           return (activity.actor_id === ctx.user.id) && (activity.user.id === user.id);
         });

--- a/node_modules/col-activities/tests/test-points.js
+++ b/node_modules/col-activities/tests/test-points.js
@@ -317,15 +317,15 @@ describe('Activity Points', function() {
 
               // Verify appropriate activity counts
               ActivitiesTestUtil.assertGetActivitiesForUserId(client1, course, dbUser1.id, function(activities1) {
-                // user1 received two pins
+                // user1 received one pin
                 assert.ok(!activities1.actions.counts.user.pin_asset);
-                assert.strictEqual(activities1.impacts.counts.user.get_pin_asset, 2);
+                assert.strictEqual(activities1.impacts.counts.user.get_pin_asset, 1);
 
                 // Verify course totals
-                assert.strictEqual(activities1.impacts.counts.course.get_pin_asset, 3);
+                assert.strictEqual(activities1.impacts.counts.course.get_pin_asset, 2);
 
                 ActivitiesTestUtil.assertGetActivitiesForUserId(client2, course, dbUser2.id, function(activities2) {
-                  // Nothing for user2
+                  // user2 gets no credit for pinning his own asset but he does get credit from user3's pin
                   assert.ok(!activities2.actions.counts.user.pin_asset);
                   assert.strictEqual(activities2.impacts.counts.user.get_pin_asset, 1);
 
@@ -373,7 +373,7 @@ describe('Activity Points', function() {
                           assert.strictEqual(activities3.actions.counts.user.repin_asset, 1);
 
                           // user1, a co-creator of the asset, gets two get_pins and one get_repin
-                          assert.strictEqual(activities1.impacts.counts.user.get_pin_asset, 2);
+                          assert.strictEqual(activities1.impacts.counts.user.get_pin_asset, 1);
                           assert.strictEqual(activities1.impacts.counts.user.get_repin_asset, 1);
 
                           // user2, a co-creator of the asset, one get_pin and one get_repin


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1059

Rewarding nepotism was a feature, not a bug.
