### PR TITLE
[QA] COL-1069, isLoading=true during subsequent searches in Asset Library

### DIFF
--- a/public/app/assetlibrary/list/assetLibraryListController.js
+++ b/public/app/assetlibrary/list/assetLibraryListController.js
@@ -91,6 +91,9 @@
      * @return {void}
      */
     var getAssets = $scope.getAssets = function() {
+      // Hide 'no results' message in the UI until we have results
+      $scope.isLoading = true;
+
       // Keep track of the search options in the parent container's hash to allow
       // for deep linking to a search
       // NOTE: For deep linking to work, our custom 'getParentUrlData' and 'setParentHash' cross-window events must be supported


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1069

`isLoading = true` before subsequent Asset Library searches.