### PR TITLE
COL-1071, travis.yml db name: suitec_travis; update db names in README; gulpfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ before_install:
   - cd $TRAVIS_BUILD_DIR
 
   # Configure postgres
-  - psql -c 'create database collabospheretravis;' -U postgres
-  - psql collabospheretravis -c 'create extension pg_trgm;' -U postgres
+  - psql -c 'create database suitec_travis;' -U postgres
+  - psql suitec_travis -c 'create extension pg_trgm;' -U postgres
 
 script:
-  - node_modules/.bin/gulp test-travis
+  - node_modules/.bin/gulp travis

--- a/README.md
+++ b/README.md
@@ -47,13 +47,12 @@ brew install postgresql
 postgres -D /usr/local/var/postgres
 
 # Create a database and user
-createuser collabosphere --no-createdb --no-superuser --no-createrole --pwprompt
+createuser suitec --no-createdb --no-superuser --no-createrole --pwprompt
 
-Enter password for new role:  collabosphere
-Enter it again:  collabosphere
+# Enter (and re-enter) the password: suitec
 
-createdb collabosphere --owner=collabosphere
-createdb collabospheretest --owner=collabosphere
+createdb suitec --owner=suitec
+createdb suitec_test --owner=suitec
 ```
 
 ### Node

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "collabosphere",
-  "description": "Collabosphere Instructure Canvas LTI Tools",
+  "name": "suitec",
+  "description": "SuiteC LTI Tools",
   "version": "0.1.0",
   "repository": {
     "type": "git",

--- a/config/default.json
+++ b/config/default.json
@@ -10,7 +10,7 @@
   "app": {
     "https": false,
     "port": 2000,
-    "host": "collabosphere.berkeley"
+    "host": "suitec.berkeley"
   },
   "canvasPoller": {
     "enabled": true,
@@ -22,13 +22,13 @@
     "secret": "String to encrypt the cookies with. Change me in production"
   },
   "db": {
-    "database": "collabosphere",
-    "username": "collabosphere",
-    "password": "collabosphere",
+    "database": "suitec",
+    "username": "suitec",
+    "password": "suitec",
     "host": "localhost",
     "port": 5432,
     "dropOnStartup": false,
-    "version": "9.4.4",
+    "version": "9.5.4",
     "sync": true,
     "ssl": false
   },

--- a/config/test.js
+++ b/config/test.js
@@ -28,7 +28,7 @@ module.exports = {
     'enabled': false
   },
   'db': {
-    'database': 'collabospheretest',
+    'database': 'suitec_test',
     'dropOnStartup': true
   },
   'log': {

--- a/config/travis.js
+++ b/config/travis.js
@@ -28,9 +28,8 @@ module.exports = {
     'enabled': false
   },
   'db': {
-    'database': 'collabospheretravis',
+    'database': 'suitec_travis',
     'username': 'postgres',
-    'version': '9.4.1',
     'password': '',
     'dropOnStartup': true
   },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -341,6 +341,9 @@ gulp.task('csslint', function() {
  * Run the Mocha test suite
  */
 gulp.task('mocha', function() {
+  // Use default environment if none is specified
+  process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
   return gulp
     .src(['node_modules/col-tests/lib/beforeTests.js', 'node_modules/col-*/tests/**/*.js'])
     .pipe(mocha({
@@ -354,22 +357,21 @@ gulp.task('mocha', function() {
 });
 
 /**
- * Run the full Collabosphere test suite
+ * Perform tests and run all linters
  */
 gulp.task('test', function() {
-  // Set the environment to `test`
+  // Set the environment
   process.env.NODE_ENV = 'test';
 
   runSequence('eslint', 'csslint', 'mocha');
 });
 
 /**
- * Run the full Collabosphere TravisCI test suite (including code coverage)
+ * Perform tests, run all linters and measure code coverage
  */
-gulp.task('test-travis', function() {
-  // Set the environment to `travis`
+gulp.task('travis', function() {
+  // Set the environment
   process.env.NODE_ENV = 'travis';
 
   runSequence('eslint', 'csslint', 'mocha');
 });
-

--- a/node_modules/col-activities/README.md
+++ b/node_modules/col-activities/README.md
@@ -1,3 +1,3 @@
-# The Collabosphere activity module
+# The SuiteC activity module
 
 The activity module is responsible for managing activities and the activity type configuration

--- a/node_modules/col-analytics/README.md
+++ b/node_modules/col-analytics/README.md
@@ -1,3 +1,3 @@
-# The Collabosphere analytics module
+# The SuiteC analytics module
 
 The analytics module is responsible for processing and formatting user-level analytics

--- a/node_modules/col-assets/README.md
+++ b/node_modules/col-assets/README.md
@@ -1,3 +1,3 @@
-# The Collabosphere assets module
+# The SuiteC assets module
 
 The assets module is responsible for managing assets in the Asset Library

--- a/node_modules/col-canvas/README.md
+++ b/node_modules/col-canvas/README.md
@@ -1,4 +1,4 @@
-# The Collabosphere canvas module
+# The SuiteC canvas module
 
 The canvas module is responsible for managing API and LTI information
 for Canvas instances

--- a/node_modules/col-categories/README.md
+++ b/node_modules/col-categories/README.md
@@ -1,3 +1,3 @@
-# The Collabosphere categories module
+# The SuiteC categories module
 
 The categories module is responsible for managing the available categories in a course

--- a/node_modules/col-config/README.md
+++ b/node_modules/col-config/README.md
@@ -1,3 +1,3 @@
-# The Collabosphere config module
+# The SuiteC config module
 
 The config module is responsible for providing a configuration feed to the UI

--- a/node_modules/col-core/README.md
+++ b/node_modules/col-core/README.md
@@ -1,4 +1,4 @@
-# The Collabosphere core module
+# The SuiteC core module
 
 The core module is responsible for bootstrapping the application server
 and database.

--- a/node_modules/col-course/README.md
+++ b/node_modules/col-course/README.md
@@ -1,4 +1,4 @@
-# The Collabosphere course module
+# The SuiteC course module
 
 The course module is responsible for managing information about the courses
-in which Collabosphere is used
+in which SuiteC is used

--- a/node_modules/col-lti/README.md
+++ b/node_modules/col-lti/README.md
@@ -1,3 +1,3 @@
-# The Collabosphere LTI module
+# The SuiteC LTI module
 
-The LTI module is responsible for launching the Collabosphere LTI tools
+The LTI module is responsible for launching the SuiteC LTI tools

--- a/node_modules/col-rest/README.md
+++ b/node_modules/col-rest/README.md
@@ -1,3 +1,3 @@
-# The Collabosphere rest module
+# The SuiteC rest module
 
 The rest module is responsible for talking to the REST apis

--- a/node_modules/col-tests/README.md
+++ b/node_modules/col-tests/README.md
@@ -1,4 +1,4 @@
-# The Collabosphere tests module
+# The SuiteC tests module
 
 The tests module is responsible for setting up the application test framework.
-This Mocha-based framework is used for the automated Collabosphere unit tests.
+This Mocha-based framework is used for the automated SuiteC unit tests.

--- a/node_modules/col-users/README.md
+++ b/node_modules/col-users/README.md
@@ -1,4 +1,4 @@
-# The Collabosphere users module
+# The SuiteC users module
 
 The users module is responsible for managing user information on a per
 course basis.

--- a/node_modules/col-whiteboards/README.md
+++ b/node_modules/col-whiteboards/README.md
@@ -1,3 +1,3 @@
-# The Collabosphere whiteboards module
+# The SuiteC whiteboards module
 
 The whiteboards module is responsible for managing whiteboards in the Whiteboard Tool

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "collabosphere",
-  "description": "Collabosphere Instructure Canvas LTI Tools",
+  "name": "suitec",
+  "description": "SuiteC LTI Tools",
   "version": "2.2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1071

Notes:
* devs might need to rename local db per changes in `default.json`
* default env for `gulp mocha`
* naming changes for Travis builds
* README changes: https://github.com/johncrossman/suitec/blob/COL-1071_renaming/README.md 