### PR TITLE
COL-1081 Add reciprocal ids to activities db table

### DIFF
--- a/config/schema.sql
+++ b/config/schema.sql
@@ -178,7 +178,8 @@ CREATE TABLE activities (
     asset_id integer,
     course_id integer NOT NULL,
     user_id integer NOT NULL,
-    actor_id integer
+    actor_id integer,
+    reciprocal_id integer
 );
 
 
@@ -888,10 +889,24 @@ ALTER TABLE ONLY whiteboards
 
 
 --
+-- Name: activities_actor_id_idx; Type: INDEX; Schema: public; Owner: suitec
+--
+
+CREATE INDEX activities_actor_id_idx ON activities USING btree (actor_id);
+
+
+--
 -- Name: activities_asset_id_idx; Type: INDEX; Schema: public; Owner: suitec
 --
 
 CREATE INDEX activities_asset_id_idx ON activities USING btree (asset_id);
+
+
+--
+-- Name: activities_created_at_idx; Type: INDEX; Schema: public; Owner: suitec
+--
+
+CREATE INDEX activities_created_at_idx ON activities USING btree (created_at);
 
 
 --
@@ -937,6 +952,14 @@ ALTER TABLE ONLY activities
 
 ALTER TABLE ONLY activities
     ADD CONSTRAINT activities_course_id_fkey FOREIGN KEY (course_id) REFERENCES courses(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: activities activities_reciprocal_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: suitec
+--
+
+ALTER TABLE ONLY activities
+    ADD CONSTRAINT activities_reciprocal_id_fkey FOREIGN KEY (reciprocal_id) REFERENCES activities(id) ON UPDATE CASCADE ON DELETE SET NULL;
 
 
 --

--- a/node_modules/col-activities/lib/api.js
+++ b/node_modules/col-activities/lib/api.js
@@ -481,7 +481,8 @@ var getActivitiesForAssetId = module.exports.getActivitiesForAssetId = function(
  * @param  {Activity}         callback.activity                   The created activity
  */
 var createActivity = module.exports.createActivity = function(course, user, type, objectId, objectType, metadata, actor, callback) {
-  metadata = metadata || {};
+  // Copy metadata object so that modifications don't affect any other activities that may use the same metadata.
+  metadata = _.extend({}, metadata);
 
   // Parameter validation
   var validationSchema = Joi.object().keys({
@@ -523,6 +524,10 @@ var createActivity = module.exports.createActivity = function(course, user, type
   }
   if (actor) {
     activity.actor_id = actor.id;
+  }
+  if (metadata.reciprocalId) {
+    activity.reciprocal_id = metadata.reciprocalId;
+    delete metadata.reciprocalId;
   }
 
   // TODO: Wrap this in a transaction
@@ -870,6 +875,7 @@ var recalculateImpactScores = module.exports.recalculateImpactScores = function(
  * @param  {Number}         asset               The asset to be pinned or repinned
  * @param  {Function}       callback            Standard callback function
  * @param  {Object}         callback.err        An error that occurred, if any
+ * @param  {Activity}       callback.activity   The created activity
  */
 var createPinActivity = module.exports.createPinActivity = function(ctx, asset, callback) {
   var proceed = !_.find(asset.users, {'id': ctx.user.id});
@@ -883,14 +889,14 @@ var createPinActivity = module.exports.createPinActivity = function(ctx, asset, 
       var type = hasPinned ? 'repin_asset' : 'pin_asset';
 
       log.info({'user': ctx.user.id, 'asset': asset.id}, 'Create \'' + type + '\' activity');
-      createActivity(ctx.course, ctx.user, type, asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, null, null, function(err) {
+      createActivity(ctx.course, ctx.user, type, asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, null, null, function(err, activity) {
         if (err) {
           log.error({'err': err.message, 'user': ctx.user.id, 'asset': asset.id}, 'Failed to create a ' + type + ' activity');
 
           return callback(err);
         }
 
-        return callback();
+        return callback(null, activity);
       });
     });
 
@@ -904,10 +910,11 @@ var createPinActivity = module.exports.createPinActivity = function(ctx, asset, 
  *
  * @param  {Context}        ctx                 Standard context containing the current user
  * @param  {Number}         asset               The pinned or repinned asset
+ * @param  {Number}         reciprocalId        Id of the reciprocal pin_asset or repin_asset activity
  * @param  {Function}       callback            Standard callback function
  * @param  {Object}         callback.err        An error that occurred, if any
  */
-var createGetPinActivity = module.exports.createGetPinActivity = function(ctx, asset, callback) {
+var createGetPinActivity = module.exports.createGetPinActivity = function(ctx, asset, reciprocalId, callback) {
   var isNotAssetOwner = !_.find(asset.users, {'id': ctx.user.id});
 
   if (isNotAssetOwner) {
@@ -923,9 +930,10 @@ var createGetPinActivity = module.exports.createGetPinActivity = function(ctx, a
           return (activity.actor_id === ctx.user.id) && (activity.user.id === user.id);
         });
         var type = hasReceivedPin ? 'get_repin_asset' : 'get_pin_asset';
+        var metadata = {'reciprocalId': reciprocalId};
 
         log.info({'user': user.id, 'asset': asset.id}, 'Create \'' + type + '\' activity');
-        createActivity(ctx.course, user, type, asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, null, ctx.user, function(err) {
+        createActivity(ctx.course, user, type, asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, metadata, ctx.user, function(err) {
           if (err) {
             log.error({'err': err.message, 'user': user.id, 'asset': asset.id}, 'Failed to create a ' + type + ' activity');
 

--- a/node_modules/col-activities/tests/test-activities.js
+++ b/node_modules/col-activities/tests/test-activities.js
@@ -142,6 +142,17 @@ describe('Activities', function() {
       });
     });
 
+    it('keeps track of reciprocals', function(callback) {
+      ActivitiesTestUtil.setupCourseWithActivity(function(dbCourse, course, users) {
+        ActivitiesTestUtil.assertReciprocals(course, 'get_asset_comment_reply', 'asset_comment', function() {
+          ActivitiesTestUtil.assertReciprocals(course, 'get_asset_comment', 'asset_comment', function() {
+
+            return callback();
+          });
+        });
+      });
+    });
+
     it('excludes deleted assets', function(callback) {
       // Create some assets and activities.
       ActivitiesTestUtil.setupCourseWithActivity(function(dbCourse, course, users) {

--- a/node_modules/col-activities/tests/test-points.js
+++ b/node_modules/col-activities/tests/test-points.js
@@ -179,7 +179,10 @@ describe('Activity Points', function() {
                           // Verify that a user viewing their own asset still does not update points
                           ActivitiesTestUtil.assertViewAssetActivity(client1, client1, course, asset.id, function() {
 
-                            return callback();
+                            ActivitiesTestUtil.assertReciprocals(course, 'get_view_asset', 'view_asset', function() {
+
+                              return callback();
+                            });
                           });
                         });
                       });
@@ -211,7 +214,10 @@ describe('Activity Points', function() {
               // Verify that re-liking an asset doesn't update the points
               ActivitiesTestUtil.assertLikeActivity(client2, client1, course, asset.id, true, function() {
 
-                return callback();
+                ActivitiesTestUtil.assertReciprocals(course, 'get_like', 'like', function() {
+
+                  return callback();
+                });
               });
             });
           });
@@ -334,7 +340,10 @@ describe('Activity Points', function() {
                     assert.strictEqual(activities3.actions.counts.user.pin_asset, 1);
                     assert.ok(!activities3.impacts.counts.user.get_pin_asset);
 
-                    return callback();
+                      ActivitiesTestUtil.assertReciprocals(course, 'get_pin_asset', 'pin_asset', function() {
+
+                      return callback();
+                    });
                   });
                 });
               });
@@ -380,7 +389,10 @@ describe('Activity Points', function() {
                           assert.strictEqual(activities2.impacts.counts.user.get_pin_asset, 1);
                           assert.strictEqual(activities2.impacts.counts.user.get_repin_asset, 1);
 
-                          return callback();
+                            ActivitiesTestUtil.assertReciprocals(course, 'get_repin_asset', 'repin_asset', function() {
+
+                            return callback();
+                          });
                         });
                       });
                     });
@@ -498,7 +510,13 @@ describe('Activity Points', function() {
                                         ActivitiesTestUtil.assertCreateReplyActivity(client3, [client1, client2], client1, course, asset.id, commentByUser1.id, function() {
                                           // As an unaffiliated user reply on a comment from an another unaffiliated user
                                           ActivitiesTestUtil.assertCreateReplyActivity(client3, [client1, client2], client4, course, asset.id, commentByUser4.id, function() {
-                                            return callback();
+
+                                            ActivitiesTestUtil.assertReciprocals(course, 'get_asset_comment', 'asset_comment', function() {
+                                              ActivitiesTestUtil.assertReciprocals(course, 'get_asset_comment_reply', 'asset_comment', function() {
+
+                                                return callback();
+                                              });
+                                            });
                                           });
                                         });
                                       });
@@ -639,7 +657,10 @@ describe('Activity Points', function() {
                 // Verify that remixing one's own whiteboard generates activity points as remixer but not as creator
                 ActivitiesTestUtil.assertRemixWhiteboardActivities(creatorClient1, course, exportedWhiteboard, function() {
 
-                  return callback();
+                  ActivitiesTestUtil.assertReciprocals(course, 'get_remix_whiteboard', 'remix_whiteboard', function() {
+
+                    return callback();
+                  });
                 });
               });
             });

--- a/node_modules/col-activities/tests/util.js
+++ b/node_modules/col-activities/tests/util.js
@@ -31,6 +31,7 @@ var randomstring = require('randomstring');
 
 var AssetsTestUtil = require('col-assets/tests/util');
 var CourseTestUtil = require('col-course/tests/util');
+var DB = require('col-core/lib/db');
 var EmailUtil = require('col-core/lib/email');
 var LtiTestUtil = require('col-lti/tests/util');
 var TestsUtil = require('col-tests');
@@ -1172,6 +1173,35 @@ var assertEditActivityTypeConfigurationFails = module.exports.assertEditActivity
     assert.strictEqual(err.code, code);
 
     return callback();
+  });
+};
+
+/**
+ * Assert that reciprocal activities can be matched
+ *
+ * @param  {Course}              course               The course in which activities are taking place
+ * @param  {String}              passiveType          Passive activity type expected to be present
+ * @param  {String}              activeType           Active activity type expected to match
+ * @param  {Function}            callback             Standard callback function
+ * @throws {AssertionError}                           Error thrown when an assertion failed
+ */
+var assertReciprocals = module.exports.assertReciprocals = function(course, passiveType, activeType, callback) {
+  CourseTestUtil.getDbCourse(course.id, function(dbCourse) {
+    DB.Activity.findAll({'where': {'course_id': dbCourse.id}}).complete(function(err, activities) {
+      assert.ok(!err);
+      var passiveActivities = _.filter(activities, {'type': passiveType});
+      assert.ok(passiveActivities.length);
+      _.each(passiveActivities, function(activity) {
+        // For every passive activity, assert that the reciprocal active activity can be matched.
+        assert.ok(activity.reciprocal_id);
+        assert.ok(_.find(activities, {
+          'type': activeType,
+          'id': activity.reciprocal_id,
+          'user_id': activity.actor_id
+        }));
+      });
+      return callback();
+    });
   });
 };
 

--- a/node_modules/col-assets/lib/api.js
+++ b/node_modules/col-assets/lib/api.js
@@ -1711,15 +1711,19 @@ var like = module.exports.like = function(ctx, assetId, like, callback) {
           // Add the like / dislike activity
           var type = like ? 'like' : 'dislike';
 
-          ActivitiesAPI.createActivity(ctx.course, ctx.user, type, asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, null, null, function(err) {
+          ActivitiesAPI.createActivity(ctx.course, ctx.user, type, asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, null, null, function(err, likeActivity) {
             if (err) {
               return callback(err);
+            }
+            if (!likeActivity) {
+              log.error({'user': ctx.user, 'assetId': asset.id}, 'Failed to retrieve newly created like/dislike activity');
+              return callback({'code': 500, 'msg': 'Failed to retrieve newly created like/dislike activity'});
             }
 
             // Add the get like / get dislike activities
             var receiveType = like ? 'get_like' : 'get_dislike';
 
-            AssetsUtil.createGetLikeActivities(ctx, asset, receiveType, function(err) {
+            AssetsUtil.createGetLikeActivities(ctx, asset, receiveType, likeActivity.id, function(err) {
               if (err) {
                 return callback(err);
               }
@@ -1798,12 +1802,14 @@ var pin = module.exports.pin = function(ctx, assetId, pin, callback) {
         if (err) {
           return callback(err);
         }
-        ActivitiesAPI.createPinActivity(ctx, asset, function(err) {
+        ActivitiesAPI.createPinActivity(ctx, asset, function(err, pinActivity) {
           if (err) {
             return callback(err);
           }
 
-          ActivitiesAPI.createGetPinActivity(ctx, asset, function(err) {
+          var reciprocalId = pinActivity ? pinActivity.id : null;
+
+          ActivitiesAPI.createGetPinActivity(ctx, asset, reciprocalId, function(err) {
             if (err) {
               return callback(err);
             }
@@ -1862,11 +1868,17 @@ var createWhiteboardFromAsset = module.exports.createWhiteboardFromAsset = funct
         return callback(null, whiteboard);
       }
 
-      ActivitiesAPI.createActivity(ctx.course, ctx.user, 'remix_whiteboard', asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, metadata, null, function(err) {
+      ActivitiesAPI.createActivity(ctx.course, ctx.user, 'remix_whiteboard', asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, metadata, null, function(err, remixWhiteboardActivity) {
         if (err) {
           log.error({'user': ctx.user, 'err': err}, 'Failed to create a remix_whiteboard activity');
           return callback(err);
         }
+        if (!remixWhiteboardActivity) {
+          log.error({'user': ctx.user, 'assetId': asset.id}, 'Failed to retrieve newly created remix_whiteboard activity');
+          return callback({'code': 500, 'msg': 'Failed to retrieve newly created remix_whiteboard activity'});
+        }
+
+        metadata.reciprocalId = remixWhiteboardActivity.id;
 
         AssetsUtil.createGetRemixWhiteboardActivities(ctx, asset, metadata, function(err) {
           if (err) {

--- a/node_modules/col-assets/lib/util.js
+++ b/node_modules/col-assets/lib/util.js
@@ -79,13 +79,17 @@ var incrementViewsIfRequired = module.exports.incrementViewsIfRequired = functio
       return callback({'code': 500, 'msg': err.message});
     }
 
-    ActivitiesAPI.createActivity(ctx.course, ctx.user, 'view_asset', asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, null, null, function(err) {
+    ActivitiesAPI.createActivity(ctx.course, ctx.user, 'view_asset', asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, null, null, function(err, viewActivity) {
       if (err) {
         log.error({'user': ctx.user, 'err': err}, 'Failed to create activity \'view_asset\' for user');
         return callback(err);
       }
+      if (!viewActivity) {
+        log.error({'user': ctx.user, 'assetId': asset.id}, 'Failed to retrieve newly created view activity');
+        return callback({'code': 500, 'msg': 'Failed to retrieve newly created view activity'});
+      }
 
-      createGetViewActivities(ctx, asset, function(err) {
+      createGetViewActivities(ctx, asset, viewActivity.id, function(err) {
         if (err) {
           return callback(err);
         }
@@ -101,15 +105,19 @@ var incrementViewsIfRequired = module.exports.incrementViewsIfRequired = functio
  *
  * @param  {Context}        ctx               Standard context containing the current user and the current course
  * @param  {Asset}          asset             The asset receiving the view
+ * @param  {Number}         reciprocalId      The id of the reciprocal activity
  * @param  {Function}       callback          Standard callback function
  * @param  {Object}         callback.err      An error that occurred, if any
  * @api private
  */
-var createGetViewActivities = function(ctx, asset, callback) {
+var createGetViewActivities = function(ctx, asset, reciprocalId, callback) {
   var done = _.after(asset.users.length, callback);
   var errorCallback = _.once(callback);
+  var metadata = {
+    'reciprocalId': reciprocalId
+  };
   _.each(asset.users, function(user) {
-    ActivitiesAPI.createActivity(ctx.course, user, 'get_view_asset', asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, null, ctx.user, function(err) {
+    ActivitiesAPI.createActivity(ctx.course, user, 'get_view_asset', asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, metadata, ctx.user, function(err) {
       if (err) {
         log.error({
           'err': err,
@@ -131,15 +139,19 @@ var createGetViewActivities = function(ctx, asset, callback) {
  * @param  {Context}        ctx               Standard context containing the current user and the current course
  * @param  {Asset}          asset             The asset that is liked or disliked
  * @param  {String}         type              Which type of activities the asset users are getting. One of `get_like` or `get_dislike`
+ * @param  {Number}         reciprocalId      The id of the reciprocal `like` or `dislike` activity
  * @param  {Function}       callback          Standard callback function
  * @param  {Object}         callback.err      An error that occurred, if any
  * @api private
  */
-var createGetLikeActivities = module.exports.createGetLikeActivities = function(ctx, asset, type, callback) {
+var createGetLikeActivities = module.exports.createGetLikeActivities = function(ctx, asset, type, reciprocalId, callback) {
   var done = _.after(asset.users.length, callback);
   var errorCallback = _.once(callback);
+  var metadata = {
+    'reciprocalId': reciprocalId
+  };
   _.each(asset.users, function(user) {
-    ActivitiesAPI.createActivity(ctx.course, user, type, asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, null, ctx.user, function(err) {
+    ActivitiesAPI.createActivity(ctx.course, user, type, asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, metadata, ctx.user, function(err) {
       if (err) {
         log.error({
           'err': err,
@@ -292,17 +304,19 @@ var getComment = module.exports.getComment = function(id, callback) {
  * @api private
  */
 var createCommentActivities = module.exports.createCommentActivities = function(ctx, asset, comment, parent, callback) {
-  createCommentActivityGetAssetComment(ctx, asset, comment, parent, function(err) {
+  createCommentActivityAssetComment(ctx, asset, comment, parent, function(err, commentActivity) {
     if (err) {
       return callback(err);
     }
 
-    createCommentActivityAssetComment(ctx, asset, comment, parent, function(err) {
+    var reciprocalId = commentActivity ? commentActivity.id : null;
+
+    createCommentActivityGetAssetComment(ctx, asset, comment, parent, reciprocalId, function(err) {
       if (err) {
         return callback(err);
       }
 
-      return createCommentActivityGetAssetCommentReply(ctx, asset, comment, parent, callback);
+      return createCommentActivityGetAssetCommentReply(ctx, asset, comment, parent, reciprocalId, callback);
     });
   });
 };
@@ -381,11 +395,12 @@ var deleteGetAssetCommentReplyActivity = module.exports.deleteGetAssetCommentRep
  * @param  {Asset}          asset                           The asset to which the comment is added
  * @param  {Comment}        comment                         The created comment
  * @param  {Comment}        [parent]                        The parent comment to which the comment is a reply, if any
+ * @param  {Number}         [reciprocalId]                  The id of the reciprocal asset_comment activity, if any
  * @param  {Function}       callback                        Standard callback function
  * @param  {Object}         callback.err                    An error that occurred, if any
  * @api private
  */
-var createCommentActivityGetAssetComment = function(ctx, asset, comment, parent, callback) {
+var createCommentActivityGetAssetComment = function(ctx, asset, comment, parent, reciprocalId, callback) {
   // We create a `get_asset_comment` activity for the asset owner if the person
   // who creates the comment is:
   //  - not the asset owner or
@@ -397,6 +412,9 @@ var createCommentActivityGetAssetComment = function(ctx, asset, comment, parent,
     });
     var errorCallback = _.once(callback);
     var metadata = {'assetId': asset.id};
+    if (reciprocalId) {
+      metadata.reciprocalId = reciprocalId;
+    }
 
     _.each(asset.users, function(assetUser) {
       ActivitiesAPI.createActivity(ctx.course, assetUser, 'get_asset_comment', comment.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.COMMENT, metadata, ctx.user, function(err) {
@@ -427,6 +445,7 @@ var createCommentActivityGetAssetComment = function(ctx, asset, comment, parent,
  * @param  {Comment}        [parent]                        The parent comment to which the comment is a reply, if any
  * @param  {Function}       callback                        Standard callback function
  * @param  {Object}         callback.err                    An error that occurred, if any
+ * @param  {Activity}       callback.activity               The newly created activity, if any
  * @api private
  */
 var createCommentActivityAssetComment = function(ctx, asset, comment, parent, callback) {
@@ -450,16 +469,20 @@ var createCommentActivityAssetComment = function(ctx, asset, comment, parent, ca
  * @param  {Asset}          asset                           The asset to which the comment is added
  * @param  {Comment}        comment                         The created comment
  * @param  {Comment}        [parent]                        The parent comment to which the comment is a reply
+ * @param  {Number}         [reciprocalId]                  The id of the reciprocal asset_comment activity, if any
  * @param  {Function}       callback                        Standard callback function
  * @param  {Object}         callback.err                    An error that occurred, if any
  * @api private
  */
-var createCommentActivityGetAssetCommentReply = function(ctx, asset, comment, parent, callback) {
+var createCommentActivityGetAssetCommentReply = function(ctx, asset, comment, parent, reciprocalId, callback) {
   // We create an `get_asset_comment_reply` activity for the parent commenter if:
   //  - there is a parent comment and
   //  - the parent commenter is another user
   if (parent && ctx.user.id !== parent.user.id) {
     var metadata = {'assetId': asset.id};
+    if (reciprocalId) {
+      metadata.reciprocalId = reciprocalId;
+    }
     return ActivitiesAPI.createActivity(ctx.course, parent.user, 'get_asset_comment_reply', parent.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.COMMENT, metadata, ctx.user, callback);
   } else {
     return callback();

--- a/node_modules/col-core/lib/db.js
+++ b/node_modules/col-core/lib/db.js
@@ -914,6 +914,10 @@ var setUpModel = function(sequelize) {
     'metadata': {
       'type': Sequelize.JSON,
       'allowNull': true
+    },
+    'reciprocal_id': {
+      'type': Sequelize.INTEGER,
+      'allowNull': true
     }
   }, {
     'underscored': true
@@ -972,6 +976,15 @@ var setUpModel = function(sequelize) {
   // received points through likes and comments from these users should not lose points in the Engagement
   // Index. Therefore, the actor ids will be set to null when such a user is removed.
   Activity.belongsTo(User, {'as': 'actor', 'onDelete': 'SET NULL'});
+
+  // "Passive" activities (of form 'get_*') are associated to a reciprocal "active" activity.
+  Activity.belongsTo(Activity, {
+    'foreignKey': {
+      'name': 'reciprocal_id',
+      'allowNull': true
+    },
+    'as': 'reciprocal'
+  });
 
   /**
    * The `activity_type` table will keep track of the different activities that can occur

--- a/node_modules/col-whiteboards/lib/api.js
+++ b/node_modules/col-whiteboards/lib/api.js
@@ -894,49 +894,51 @@ var whiteboardAddActivity = function(socket, elements, callback) {
           return callback(err);
         }
 
-        var assetHasOtherCreators = false;
-        var doneWithError = _.once(done);
-
-        var doneWithUser = _.after(asset.users.length, function() {
-          // If the asset is associated with no users except the user performing the activity, skip 'whiteboard_add_asset' activity creation.
-          if (!assetHasOtherCreators) {
-            return done();
-          }
-          // Otherwise create the 'whiteboard_add_asset' activity.
-          var metadata = {'assetId': element.assetId};
-          ActivitiesAPI.createActivity(socket.ctx.course, socket.ctx.user, 'whiteboard_add_asset', socket.whiteboard.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.WHITEBOARD, metadata, null, function(err) {
-            if (err) {
-              // Do not propagate errors as that would prevent further activities being created.
-              log.error({'user': socket.ctx.user, 'course': socket.ctx.course, 'err': err}, 'Failed to create activity \'whiteboard_add_asset\' for user');
-            }
-
-            return done();
-          });
+        // If the asset is associated with no users except the user performing the activity, skip activity creation.
+        var assetHasOtherCreators = _.find(asset.users, function(user) {
+          user.id !== socket.ctx.user.id;
         });
 
-        // Create 'get_whiteboard_add_asset' activities for asset creators.
-        _.each(asset.users, function(user) {
-          // If the current user is among the asset creators, skip the 'get_whiteboard_add_asset' activity for that user.
-          if (user.id === socket.ctx.user.id) {
-            return doneWithUser();
+        if (!assetHasOtherCreators) {
+          return done();
+        }
+
+        // Otherwise create the 'whiteboard_add_asset' activity.
+        var metadata = {'assetId': element.assetId};
+        ActivitiesAPI.createActivity(socket.ctx.course, socket.ctx.user, 'whiteboard_add_asset', socket.whiteboard.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.WHITEBOARD, metadata, null, function(err, whiteboardAddAssetActivity) {
+          if (err) {
+            log.error({'user': socket.ctx.user, 'course': socket.ctx.course, 'err': err}, 'Failed to create activity \'whiteboard_add_asset\' for user');
+            return done();
           }
 
-          // Otherwise mark the existence of an asset creator who is not the current user, so that a 'whiteboard_add_asset' activity will be created.
-          assetHasOtherCreators = true;
+          if (!whiteboardAddAssetActivity) {
+            log.error({'user': socket.ctx.user, 'course': socket.ctx.course}, 'Failed to retrieve newly created \'whiteboard_add_asset\' activity');
+            return done();
+          }
 
-          var metadata = {'assetId': element.assetId};
-          ActivitiesAPI.createActivity(socket.ctx.course, user, 'get_whiteboard_add_asset', socket.whiteboard.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.WHITEBOARD, metadata, socket.ctx.user, function(err) {
-            if (err) {
-              log.error({
-                'err': err,
-                'user': user.id,
-                'asset': asset.id
-              }, 'Failed to create a get_whiteboard_add_asset activity');
-
-              return doneWithError(err);
+          // Create 'get_whiteboard_add_asset' activities for asset creators.
+          _.each(asset.users, function(user) {
+            // If the current user is among the asset creators, skip the 'get_whiteboard_add_asset' activity for that user.
+            if (user.id === socket.ctx.user.id) {
+              return;
             }
 
-            return doneWithUser();
+            var metadata = {
+              'assetId': element.assetId,
+              'reciprocalId': whiteboardAddAssetActivity.id
+            };
+
+            ActivitiesAPI.createActivity(socket.ctx.course, user, 'get_whiteboard_add_asset', socket.whiteboard.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.WHITEBOARD, metadata, socket.ctx.user, function(err) {
+              if (err) {
+                log.error({
+                  'err': err,
+                  'user': user.id,
+                  'asset': asset.id
+                }, 'Failed to create a get_whiteboard_add_asset activity');
+
+                return done(err);
+              }
+            });
           });
         });
       });

--- a/scripts/20170703-col1081/add_reciprocal_ids.sql
+++ b/scripts/20170703-col1081/add_reciprocal_ids.sql
@@ -1,0 +1,215 @@
+-- Add reciprocal_id column to activities, with a foreign key reference to activity id.
+
+ALTER TABLE activities ADD reciprocal_id integer;
+ALTER TABLE activities
+  ADD CONSTRAINT activities_reciprocal_id_fkey FOREIGN KEY (reciprocal_id) REFERENCES activities(id) ON UPDATE CASCADE ON DELETE SET NULL;
+
+-- Add indexes on creation time and actor.
+
+CREATE INDEX activities_created_at_idx ON activities USING btree (created_at);
+CREATE INDEX activities_actor_id_idx ON activities USING btree (actor_id);
+
+-- Find reciprocal like activities and update ids. Correlation is based on course id, user id, asset
+-- id and timestamp (`like` is created immediately before `get_like`).
+
+WITH get_like_reciprocal_mapping AS (
+  SELECT act.id AS activity_id, reciprocal_act.id AS reciprocal_id
+  FROM activities act
+  LEFT JOIN activities reciprocal_act ON
+    reciprocal_act.course_id = act.course_id
+    AND reciprocal_act.created_at = (SELECT MAX(created_at) FROM activities
+      WHERE activities.course_id = act.course_id
+      AND activities.created_at <= act.created_at
+      AND activities.type = 'like'
+    )
+    AND EXTRACT(epoch FROM (act.created_at - reciprocal_act.created_at)) < 1
+    AND reciprocal_act.asset_id = act.asset_id
+    AND reciprocal_act.user_id = act.actor_id
+  WHERE act.type = 'get_like'
+)
+UPDATE activities
+SET reciprocal_id = get_like_reciprocal_mapping.reciprocal_id
+FROM get_like_reciprocal_mapping
+WHERE type = 'get_like'
+AND activities.id = get_like_reciprocal_mapping.activity_id;
+
+-- Find reciprocal view activities and update ids. Correlation is based on course id, user id, asset
+-- id and timestamp (`view_asset` is created immediately before `get_view_asset`).
+
+WITH get_view_asset_reciprocal_mapping AS (
+  SELECT act.id AS activity_id, reciprocal_act.id AS reciprocal_id
+  FROM activities act
+  LEFT JOIN activities reciprocal_act ON
+    reciprocal_act.course_id = act.course_id
+    AND reciprocal_act.created_at = (SELECT MAX(created_at) FROM activities
+      WHERE activities.course_id = act.course_id
+      AND activities.created_at <= act.created_at
+      AND activities.type = 'view_asset'
+    )
+    AND EXTRACT(epoch FROM (act.created_at - reciprocal_act.created_at)) < 1
+    AND reciprocal_act.asset_id = act.asset_id
+    AND reciprocal_act.user_id = act.actor_id
+  WHERE act.type = 'get_view_asset'
+)
+UPDATE activities
+SET reciprocal_id = get_view_asset_reciprocal_mapping.reciprocal_id
+FROM get_view_asset_reciprocal_mapping
+WHERE type = 'get_view_asset'
+AND activities.id = get_view_asset_reciprocal_mapping.activity_id;
+
+-- Find reciprocal pin activities and update ids. Correlation is based on course id, user id, asset
+-- id and timestamp (`pin_asset` is created immediately before `get_pin_asset`).
+
+WITH get_pin_asset_reciprocal_mapping AS (
+  SELECT act.id AS activity_id, reciprocal_act.id AS reciprocal_id
+  FROM activities act
+  LEFT JOIN activities reciprocal_act ON
+    reciprocal_act.course_id = act.course_id
+    AND reciprocal_act.created_at = (SELECT MAX(created_at) FROM activities
+      WHERE activities.course_id = act.course_id
+      AND activities.created_at <= act.created_at
+      AND activities.type = 'pin_asset'
+    )
+    AND EXTRACT(epoch FROM (act.created_at - reciprocal_act.created_at)) < 1
+    AND reciprocal_act.asset_id = act.asset_id
+    AND reciprocal_act.user_id = act.actor_id
+  WHERE act.type = 'get_pin_asset'
+)
+UPDATE activities
+SET reciprocal_id = get_pin_asset_reciprocal_mapping.reciprocal_id
+FROM get_pin_asset_reciprocal_mapping
+WHERE type = 'get_pin_asset'
+AND activities.id = get_pin_asset_reciprocal_mapping.activity_id;
+
+-- Find reciprocal repin activities and update ids. Correlation is based on course id, user id, asset
+-- id and timestamp (`repin_asset` is created immediately before `get_repin_asset`).
+
+WITH get_repin_asset_reciprocal_mapping AS (
+  SELECT act.id AS activity_id, reciprocal_act.id AS reciprocal_id
+  FROM activities act
+  LEFT JOIN activities reciprocal_act ON
+    reciprocal_act.course_id = act.course_id
+    AND reciprocal_act.created_at = (SELECT MAX(created_at) FROM activities
+      WHERE activities.course_id = act.course_id
+      AND activities.created_at <= act.created_at
+      AND activities.type = 'repin_asset'
+    )
+    AND EXTRACT(epoch FROM (act.created_at - reciprocal_act.created_at)) < 1
+    AND reciprocal_act.asset_id = act.asset_id
+    AND reciprocal_act.user_id = act.actor_id
+  WHERE act.type = 'get_repin_asset'
+)
+UPDATE activities
+SET reciprocal_id = get_repin_asset_reciprocal_mapping.reciprocal_id
+FROM get_repin_asset_reciprocal_mapping
+WHERE type = 'get_repin_asset'
+AND activities.id = get_repin_asset_reciprocal_mapping.activity_id;
+
+-- Find reciprocal add asset to whiteboard activities and update ids. Correlation is based on course id, user id, asset
+-- id and timestamp (`whiteboard_add_asset` is created immediately after `get_whiteboard_add_asset`).
+
+WITH get_whiteboard_add_asset_reciprocal_mapping AS (
+  SELECT act.id AS activity_id, reciprocal_act.id AS reciprocal_id
+  FROM activities act
+  LEFT JOIN activities reciprocal_act ON
+    reciprocal_act.course_id = act.course_id
+    AND reciprocal_act.created_at = (SELECT MIN(created_at) FROM activities
+      WHERE activities.course_id = act.course_id
+      AND activities.created_at >= act.created_at
+      AND activities.type = 'whiteboard_add_asset'
+    )
+    AND EXTRACT(epoch FROM (reciprocal_act.created_at - act.created_at)) < 1
+    AND reciprocal_act.asset_id = act.asset_id
+    AND reciprocal_act.user_id = act.actor_id
+  WHERE act.type = 'get_whiteboard_add_asset'
+)
+UPDATE activities
+SET reciprocal_id = get_whiteboard_add_asset_reciprocal_mapping.reciprocal_id
+FROM get_whiteboard_add_asset_reciprocal_mapping
+WHERE type = 'get_whiteboard_add_asset'
+AND activities.id = get_whiteboard_add_asset_reciprocal_mapping.activity_id;
+
+-- Find reciprocal remix activities and update ids. Correlation is based on course id, user id, asset
+-- id and timestamp (`remix_whiteboard` is created immediately before `get_remix_whiteboard`).
+
+WITH get_remix_whiteboard_reciprocal_mapping AS (
+  SELECT act.id AS activity_id, reciprocal_act.id AS reciprocal_id
+  FROM activities act
+  LEFT JOIN activities reciprocal_act ON
+    reciprocal_act.course_id = act.course_id
+    AND reciprocal_act.created_at = (SELECT MAX(created_at) FROM activities
+      WHERE activities.course_id = act.course_id
+      AND activities.created_at <= act.created_at
+      AND activities.type = 'remix_whiteboard'
+    )
+    AND EXTRACT(epoch FROM (act.created_at - reciprocal_act.created_at)) < 1
+    AND reciprocal_act.asset_id = act.asset_id
+    AND reciprocal_act.user_id = act.actor_id
+  WHERE act.type = 'get_remix_whiteboard'
+)
+UPDATE activities
+SET reciprocal_id = get_remix_whiteboard_reciprocal_mapping.reciprocal_id
+FROM get_remix_whiteboard_reciprocal_mapping
+WHERE type = 'get_remix_whiteboard'
+AND activities.id = get_remix_whiteboard_reciprocal_mapping.activity_id;
+
+-- Find reciprocal discussion activities and update ids. Correlation is based on course id, user id and entryId.
+
+WITH get_discussion_entry_reply_reciprocal_mapping AS (
+  SELECT act.id AS activity_id, reciprocal_act.id AS reciprocal_id
+  FROM activities act
+  LEFT JOIN activities reciprocal_act ON
+    reciprocal_act.course_id = act.course_id
+    AND reciprocal_act.metadata->>'entryId' = act.metadata->>'entryId'
+    AND reciprocal_act.user_id = act.actor_id
+    AND reciprocal_act.type = 'discussion_entry'
+  WHERE act.type = 'get_discussion_entry_reply'
+)
+UPDATE activities
+SET reciprocal_id = get_discussion_entry_reply_reciprocal_mapping.reciprocal_id
+FROM get_discussion_entry_reply_reciprocal_mapping
+WHERE type = 'get_discussion_entry_reply'
+AND id = get_discussion_entry_reply_reciprocal_mapping.activity_id;
+
+-- Find reciprocal comment activities and update ids. Correlation is based on course id, user id and comment id.
+
+WITH get_asset_comment_reciprocal_mapping AS (
+  SELECT act.id AS activity_id, reciprocal_act.id AS reciprocal_id
+  FROM activities act
+  LEFT JOIN activities reciprocal_act ON
+    reciprocal_act.course_id = act.course_id
+    AND reciprocal_act.object_id = act.object_id
+    AND reciprocal_act.user_id = act.actor_id
+    AND reciprocal_act.type = 'asset_comment'
+  WHERE act.type = 'get_asset_comment'
+)
+UPDATE activities
+SET reciprocal_id = get_asset_comment_reciprocal_mapping.reciprocal_id
+FROM get_asset_comment_reciprocal_mapping
+WHERE type = 'get_asset_comment'
+AND id = get_asset_comment_reciprocal_mapping.activity_id;
+
+-- Find reciprocal comment reply activities and update ids. Correlation is based on course id, user id, asset
+-- id (if present) and timestamp (`asset_comment` is created immediately before `get_asset_comment_reply`).
+
+WITH get_asset_comment_reply_reciprocal_mapping AS (
+  SELECT act.id AS activity_id, reciprocal_act.id AS reciprocal_id
+  FROM activities act
+  LEFT JOIN activities reciprocal_act ON
+    reciprocal_act.course_id = act.course_id
+    AND reciprocal_act.created_at = (SELECT MAX(created_at) FROM activities
+      WHERE activities.course_id = act.course_id
+      AND activities.created_at <= act.created_at
+      AND activities.type = 'asset_comment'
+    )
+    AND EXTRACT(epoch FROM (act.created_at - reciprocal_act.created_at)) < 1
+    AND ((act.asset_id IS NULL AND reciprocal_act.asset_id IS NULL)
+         OR reciprocal_act.asset_id = act.asset_id)
+    AND reciprocal_act.user_id = act.actor_id
+  WHERE act.type = 'get_asset_comment_reply'
+)
+UPDATE activities
+SET reciprocal_id = get_asset_comment_reply_reciprocal_mapping.reciprocal_id
+FROM get_asset_comment_reply_reciprocal_mapping
+WHERE type = 'get_asset_comment_reply'
+AND activities.id = get_asset_comment_reply_reciprocal_mapping.activity_id;


### PR DESCRIPTION
The solution to https://jira.ets.berkeley.edu/jira/browse/COL-1081 is to create `get_view_asset` activities for every `view_asset` activity that is lacking them. However, this requires an association between reciprocal activities, which doesn't currently exist in the database. This PR creates that association.

Passive activities of a `get_*` type are given a many-to-one association to their corresponding "active" activity. Going forward, this association will be tracked as part of activity creation, which in some cases involves changing the order of those creations.

Adding reciprocal ids to older activities is trickier, because we have to infer the associations based on user ids, timestamps, and other metadata. The SQL included in this PR makes a best effort at such inference. I've tested it in suitec-dev and the results seem sane, although 693 activities of `get_*` form, or 0.9% of the total, couldn't find a reciprocal matching the given criteria and were left blank. Such doubtful cases seem to arise when a flurry of simultaneous activities makes timestamp correlation harder; nonetheless, I think this is an acceptable margin, and leaving the doubtful cases blank makes it easy to repair them manually later, if we so choose.