### PR TITLE
COL-1081 Insert get_view_asset activities where not present

### DIFF
--- a/scripts/20170703-col1081/insert_get_view_asset_activities.sql
+++ b/scripts/20170703-col1081/insert_get_view_asset_activities.sql
@@ -1,0 +1,34 @@
+INSERT INTO activities (
+  type,
+  object_id,
+  object_type,
+  metadata,
+  created_at,
+  updated_at,
+  asset_id,
+  course_id,
+  user_id,
+  actor_id,
+  reciprocal_id
+)
+SELECT
+  'get_view_asset',
+  act.object_id,
+  act.object_type,
+  act.metadata,
+  act.created_at,
+  act.updated_at,
+  act.asset_id,
+  act.course_id,
+  asset_users.user_id,
+  act.user_id,
+  act.id
+FROM activities act
+JOIN asset_users ON act.asset_id = asset_users.asset_id
+WHERE act.type = 'view_asset'
+AND act.id NOT IN (
+  SELECT reciprocal_id
+  FROM activities
+  WHERE type = 'get_view_asset'
+  AND reciprocal_id IS NOT NULL
+);


### PR DESCRIPTION
Second and much simpler PR for https://jira.ets.berkeley.edu/jira/browse/COL-1081.

Select every `view_asset` activity not already matched to a `get_view_asset` activity; join to the `asset_users` table to get all asset owners; for each asset owner, insert a matching `get_view_asset` activity.

The query has been tested locally with good results.