### PR TITLE
COL-1083, hashtagFilter must report 'state' to construct toolHref URL

### DIFF
--- a/public/app/dashboard/profile.html
+++ b/public/app/dashboard/profile.html
@@ -55,7 +55,7 @@
         </a>
       </div>
     </div>
-    <div class="profile-summary-column-variable">
+    <div id="about-user" class="profile-summary-column-variable">
       <h1 class="profile-summary-header" data-ng-bind="user.canvas_full_name"></h1>
       <div data-ng-include="'/app/dashboard/lookingForCollaborators.html'"></div>
       <div>
@@ -66,7 +66,9 @@
         <span data-ng-if="user.last_activity">{{user.last_activity | formatDate}}</span>
         <span data-ng-if="!user.last_activity">Never</span>
       </div>
-      <div class="profile-user-description" data-ng-if="user.personal_bio" data-ng-bind-html="user.personal_bio | linky:'_blank' | toolHrefHashtag:'dashboard':user.id"></div>
+      <div class="profile-user-description"
+           data-ng-bind-html="user.personal_bio | linky:'_blank' | toolHrefHashtag:referringState('about-user'):'dashboard':user.id"
+           data-ng-if="user.personal_bio"></div>
     </div>
     <div class="profile-summary-column-with-border" data-ng-if="showEngagementIndexBox">
       <div class="profile-summary-column-square">

--- a/public/app/shared/toolHrefHashtagFilter.js
+++ b/public/app/shared/toolHrefHashtagFilter.js
@@ -34,16 +34,17 @@
      * for that keyword.
      *
      * @param  {String}     input                Text containing hashtags. Hashtags will be replaced with proper hrefs.
-     * @param  {String}     crossToolRequest     SuiteC tool in which user initiated the action
+     * @param  {String}     state                Page state (e.g., scroll position) at time of departure
+     * @param  {String}     referringTool        SuiteC tool in which user initiated the action
      * @param  {String}     referringId          State of the referring tool, at time of exit
      * @return {String}                          The processed text, in which hashtags were replaced with links
      */
-    return function(input, crossToolRequest, referringId) {
+    return function(input, state, referringTool, referringId) {
       return input.replace(/#(\w*[a-zA-Z_\-\.]+\w*)/gim, function(match, hashtag) {
         // Remove trailing punctuation, as it might have been picked up by regex above
         var trimmed = hashtag.replace(/[\.\-]+$/g, '');
         var id = utilService.getAdvancedSearchId({'keywords': trimmed});
-        var url = utilService.getToolHref('assetlibrary', id, crossToolRequest, referringId);
+        var url = utilService.getToolHref('assetlibrary', id, state, referringTool, referringId);
         return '<a href="' + url + '" target="_parent">#' + hashtag + '</a>';
       });
     };


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1083

We use `state` to remember Impact Studio filter settings when (temporarily) navigating to Asset Library.