### PR TITLE
COL-1092, 'Return to Asset Library' now uses advSearchId as seen on Impact Studio

### DIFF
--- a/public/app/assetlibrary/item/assetLibraryItemController.js
+++ b/public/app/assetlibrary/item/assetLibraryItemController.js
@@ -79,6 +79,14 @@
     utilService.setParentHash({'asset': assetId});
 
     /**
+     * Restore search options when navigating back to the Asset Library list.
+     *
+     * NOTE: Requires SuiteC's custom 'getParentUrlData' and 'setParentHash' cross-window events to be
+     * supported in the hosting Canvas instance.
+     */
+    $scope.backToAssetLibraryId = utilService.getAdvancedSearchId($scope.$parent.searchOptions);
+
+    /**
      * Get the current asset
      *
      * @param  {Boolean}      [incrementViews]      Whether the total number of views for the asset should be incremented by 1. Defaults to `true`
@@ -449,20 +457,6 @@
         $scope.asset = updatedAsset;
       }
     });
-
-    /**
-     * Restore the asset library search options when navigating back to the asset library list. As navigating
-     * back to the asset library list doesn't trigger a new search, the easiest solution is to restore the hash
-     * value here
-     *
-     * NOTE: This functionality requires our custom 'getParentUrlData' and 'setParentHash' cross-window events to be
-     * supported in the hosting Canvas instance.
-     *
-     * @return {void}
-     */
-    var backToAssetLibrary = $scope.backToAssetLibrary = function() {
-      utilService.setParentHash($scope.$parent.searchOptions);
-    };
 
     /**
      * Close the current browser window. This is used when an asset has been opened

--- a/public/app/assetlibrary/item/item.html
+++ b/public/app/assetlibrary/item/item.html
@@ -1,5 +1,10 @@
 <div data-ng-show="state.current.name === 'assetlibrarylist.item'">
-  <a ui-sref="assetlibrarylist($parent.searchOptions)" class="col-back" data-ng-click="backToAssetLibrary()" data-ng-if="!whiteboardReferral && !crossToolRequest"><i class="fa fa-angle-left"></i> Back to Asset Library</a>
+  <a tool-href
+     class="col-back"
+     data-tool="assetlibrary"
+     data-id="backToAssetLibraryId"
+     data-referring-tool="assetlibrary"
+     data-ng-if="!whiteboardReferral && (!crossToolRequest || crossToolRequest.referringTool === 'assetlibrary')"><i class="fa fa-angle-left"></i> Back to Asset Library</a>
 
   <a tool-href
      class="col-back"
@@ -9,7 +14,10 @@
      data-referring-tool="assetlibrary"
      data-ng-if="crossToolRequest.referringTool === 'dashboard'"><i class="fa fa-angle-left"></i> Back to Impact Studio</a>
 
-  <button type="button" class="btn btn-link col-back" data-ng-if="whiteboardReferral" data-ng-click="closeWindow()"><i class="fa fa-angle-left"></i> Back to whiteboard</button>
+  <button type="button"
+          class="btn btn-link col-back"
+          data-ng-click="closeWindow()"
+          data-ng-if="whiteboardReferral"><i class="fa fa-angle-left"></i> Back to whiteboard</button>
 
   <!-- NOTIFICATIONS -->
   <div class="assetlibrary-item-notifications">

--- a/public/app/shared/utilService.js
+++ b/public/app/shared/utilService.js
@@ -57,7 +57,10 @@
      * @return {String}                                   Search options, stringified
      */
     var getAdvancedSearchId = function(searchOptions) {
-      return 'assetlibrarylist:' + JSON.stringify(searchOptions);
+      var opts = _.pickBy(searchOptions, function(value, key) {
+        return !_.isNil(value) && !_.isObject(value) && (!_.isString(value) || !_.isEmpty(value));
+      });
+      return 'assetlibrarylist:' + JSON.stringify(opts);
     };
 
     /**


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1092

Rather simple fix by targeting only the 'Return to Asset Library' link. The asset deep-link design does not change.  I added `_.pickBy` logic to `utilService.getAdvancedSearchId` such that undefined  and extraneous args are excluded from queryString. 