### PR TITLE
COL-951 Remove Sequelize sync; test against db schema in source control

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   # Configure postgres
   - psql -c 'create database suitec_travis;' -U postgres
   - psql suitec_travis -c 'create extension pg_trgm;' -U postgres
+  - psql suitec_travis -c 'create role suitec superuser login; alter schema public owner to suitec;' -U postgres
 
 script:
   - node_modules/.bin/gulp travis

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ createuser suitec --no-createdb --no-superuser --no-createrole --pwprompt
 
 createdb suitec --owner=suitec
 createdb suitec_test --owner=suitec
+
+# Give SuiteC schema ownership on the test database so that it can reset the schema during tests
+psql suitec_test -c 'alter schema public owner to suitec;'
 ```
 
 ### Node

--- a/config/default.json
+++ b/config/default.json
@@ -40,7 +40,6 @@
     "port": 5432,
     "dropOnStartup": false,
     "version": "9.5.4",
-    "sync": true,
     "ssl": false
   },
   "email": {

--- a/config/schema.sql
+++ b/config/schema.sql
@@ -7,27 +7,11 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner:
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner:
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
 SET search_path = public, pg_catalog;
 
 --
@@ -63,6 +47,7 @@ CREATE TYPE enum_activities_type AS ENUM (
     'comment',
     'get_comment',
     'get_asset_comment_reply',
+    'pin_asset',
     'repin_asset',
     'get_pin_asset',
     'get_repin_asset',

--- a/config/travis.js
+++ b/config/travis.js
@@ -29,7 +29,7 @@ module.exports = {
   },
   'db': {
     'database': 'suitec_travis',
-    'username': 'postgres',
+    'username': 'suitec',
     'password': '',
     'dropOnStartup': true
   },

--- a/node_modules/col-core/lib/db.js
+++ b/node_modules/col-core/lib/db.js
@@ -25,6 +25,8 @@
 
 var _ = require('lodash');
 var config = require('config');
+var fs = require('fs');
+var path = require('path');
 var Sequelize = require('sequelize');
 
 var ActivitiesDefaults = require('col-activities/lib/default');
@@ -80,41 +82,43 @@ var init = module.exports.init = function(callback) {
     // Set up the model
     setUpModel(sequelize);
 
-    // Synchronize models with the database
-    return sync(callback);
+    return callback();
   });
 };
 
 /**
- * Synchronize models with the database
+ * Reset the database schema from config/schema.sql
  *
  * @param  {Function}       callback            Standard callback function
  * @param  {Object}         callback.err        An error object, if any
  */
-var sync = function(callback) {
-  // Allow model synchronization to be skipped. This is useful in production so a user without
-  // table modification rights can be configured
-  if (config.get('db.sync') === false) {
-    log.debug('Skipping DB synchronization');
-    return callback();
+var resetSchema = module.exports.resetSchema = function(callback) {
+  // This method should never be called in a production environment, or any other environment that's not
+  // configured for it.
+  if (process.env.NODE_ENV === 'production' || config.get('db.dropOnStartup') !== true) {
+    log.error('Environment settings disallow automated reset of database schema');
+    return callback({'code': 500, 'msg': 'Environment settings disallow automated reset of database schema'});
   }
 
-  // By setting `force` to `true` we will drop each table and recreate it. This is useful
-  // during development/testing when models tend to change. We NEVER do this in production though
-  var force = false;
-  if (process.env.NODE_ENV !== 'production' && config.get('db.dropOnStartup') === true) {
-    force = true;
-  }
-
-  sequelize.sync({'force': force}).complete(function(err) {
+  fs.readFile(path.join(process.cwd(), 'config', 'schema.sql'), function(err, sql) {
     if (err) {
-      log.error({'err': err}, 'Unable to sync the model to the database');
-      return callback({'code': 500, 'msg': 'Unable to sync the model to the database'});
+      log.error({'err': err}, 'Failed to load schema SQL');
+      return callback({'code': 500, 'msg': 'Failed to load schema SQL'});
     }
 
-    log.debug('Synced model to database');
+    sql = 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;' + sql;
 
-    return callback();
+    sequelize.query(sql).complete(function(err) {
+      if (err) {
+        console.log(err);
+        log.error({'err': err}, 'Failed to reset database schema');
+        return callback({'code': 500, 'msg': 'Failed to reset database schema'});
+      }
+
+      log.debug('Reset database schema');
+
+      return callback();
+    });
   });
 };
 

--- a/node_modules/col-tests/lib/beforeTests.js
+++ b/node_modules/col-tests/lib/beforeTests.js
@@ -41,18 +41,23 @@ before(function(callback) {
   Collabosphere.init(function(err) {
     assert.ok(!err);
 
-    // Create 2 Canvas instances that can be used in the tests
-    createCanvas(function(ucberkeleyCanvas) {
-      createCanvas(function(ucdavisCanvas) {
+    // Reset database schema
+    DB.resetSchema(function(dbErr) {
+      assert.ok(!dbErr);
 
-        // Expose the Canvas instances on the global object
-        global.tests = {
-          'canvas': {
-            'ucberkeley': ucberkeleyCanvas,
-            'ucdavis': ucdavisCanvas
-          }
-        };
-        return callback();
+      // Create 2 Canvas instances that can be used in the tests
+      createCanvas(function(ucberkeleyCanvas) {
+        createCanvas(function(ucdavisCanvas) {
+
+          // Expose the Canvas instances on the global object
+          global.tests = {
+            'canvas': {
+              'ucberkeley': ucberkeleyCanvas,
+              'ucdavis': ucdavisCanvas
+            }
+          };
+          return callback();
+        });
       });
     });
   });


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-951

Our dependency on Sequelize's falsely comforting "sync" behavior is removed. Instead, local and Travis test runs create their database schemas directly from SQL. This require a permissions change to the `suitec` user in test environments (see README). Devs will also have to take care to keep their local databases synced up with the latest migrations, since Sequelize will no longer be helpfully attempting to manage it for us.