### PR TITLE
COL-1104, courses db table gets 'aws_s3_object_key'; eligible-for-S3 cutoff date in config

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -5,7 +5,9 @@
       "secretAccessKey": ""
     },
     "s3": {
+      "cutoverDate": "2017-08-14",
       "bucket": "suitec-dev",
+      "baseDownloadUrl": "https://foo.cloudfront.net",
       "region": "us-west-2",
       "version": "2006-03-01"
     }

--- a/config/schema.sql
+++ b/config/schema.sql
@@ -267,6 +267,7 @@ CREATE TABLE assets (
     id integer NOT NULL,
     type enum_assets_type NOT NULL,
     url character varying(255),
+    aws_s3_object_key character varying(255),
     download_url character varying(255),
     title character varying(255),
     canvas_assignment_id integer,

--- a/config/test.js
+++ b/config/test.js
@@ -27,6 +27,11 @@ module.exports = {
   'analytics': {
     'enabled': false
   },
+  'aws': {
+    's3': {
+      'cutoverDate': '9999-99-99'
+    }
+  },
   'db': {
     'database': 'suitec_test',
     'dropOnStartup': true

--- a/config/travis.js
+++ b/config/travis.js
@@ -27,6 +27,11 @@ module.exports = {
   'analytics': {
     'enabled': false
   },
+  'aws': {
+    's3': {
+      'cutoverDate': '9999-99-99'
+    }
+  },
   'db': {
     'database': 'suitec_travis',
     'username': 'suitec',

--- a/node_modules/col-core/lib/db.js
+++ b/node_modules/col-core/lib/db.js
@@ -406,6 +406,8 @@ var setUpModel = function(sequelize) {
    * @property {String}       [pdf_url]               The PDF url of the asset
    * @property {Object}       [preview_metadata]      The preview metadata
    * @property {String}       [url]                   The url of the asset
+   * @property {String}       [aws_s3_object_key]     The Object Key of asset stored in AWS S3
+   * @property {String}       [download_url]          The url used by users to download asset (file)
    * @property {String}       [source]                The source of the asset
    * @property {String}       [body]                  The body of the asset
    * @property {Number}       likes                   The number of likes on the asset
@@ -420,6 +422,10 @@ var setUpModel = function(sequelize) {
       'allowNull': false
     },
     'url': {
+      'type': Sequelize.STRING,
+      'allowNull': true
+    },
+    'aws_s3_object_key': {
       'type': Sequelize.STRING,
       'allowNull': true
     },

--- a/node_modules/col-core/lib/storage.js
+++ b/node_modules/col-core/lib/storage.js
@@ -94,4 +94,15 @@ var storeAsset = module.exports.storeAsset = function(ctx, assetId, filePath, ca
       return callback(null, url);
     });
   });
+
+  /**
+   * Course is eligible for AWS S3 storage based on created_at date.
+   *
+   * @param  {Course}         course          The Canvas course in which the user is interacting with the API
+   * @return {Boolean}                        True if course is eligible to store assets in AWS S3
+   */
+  var useAmazonS3 = module.exports.useAmazonS3 = function(course) {
+    var s3CutoverDate = moment(config.get("aws.s3.cutoverDate"), "YYYY-MM-DD");
+    return s3CutoverDate.isValid() && moment(ctx.course.created_at).startOf('day').diff(s3CutoverDate, 'days') >= 0;
+  };
 };

--- a/scripts/20170711-col1104/add_assets_aws_s3_object_key.sql
+++ b/scripts/20170711-col1104/add_assets_aws_s3_object_key.sql
@@ -1,0 +1,7 @@
+-- After uploading an asset to AWS S3 we store the new Object Key in the db
+
+ALTER TABLE assets ADD aws_s3_object_key varchar(255);
+
+/**** ROLLBACK ****
+
+ALTER TABLE assets DROP aws_s3_object_key;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1104

Proposal:
1. course `created_at` date must be greater than `aws.s3.suitecCutoverDate` to be eligible for AWS S3 (I will document this config if PR is merged)
1. `assets` table gets column for S3 Object Key
1. asset downloadUrl (for users) is concatenation of `aws.s3. baseDownloadUrl` (CloudFront) and S3 key.

If we're happy with this paradigm then future PRs will leverage (and test) the design.  