### PR TITLE
COL-1112, AWS.S3 connector type (mock or real) is configurable; see aws-sdk-factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ config/*
 node_modules/*
 !node_modules/col-*
 
+# Mock Amazon S3
+mock-s3-bucket
+
 public/lib
 
 public/app/canvas-customization.js

--- a/config/default.json
+++ b/config/default.json
@@ -5,6 +5,7 @@
       "secretAccessKey": ""
     },
     "s3": {
+      "awsSdkPackage": "aws-sdk",
       "cutoverDate": "2017-08-14",
       "bucket": "suitec-dev",
       "baseDownloadUrl": "https://foo.cloudfront.net",

--- a/config/travis.js
+++ b/config/travis.js
@@ -29,7 +29,9 @@ module.exports = {
   },
   'aws': {
     's3': {
-      'cutoverDate': '9999-99-99'
+      'awsSdkPackage': 'mock-aws-s3',
+      'bucket': 'mock-s3-bucket',
+      'cutoverDate': '9999-12-31'
     }
   },
   'db': {

--- a/node_modules/col-assets/tests/test-assets.js
+++ b/node_modules/col-assets/tests/test-assets.js
@@ -29,6 +29,7 @@ var randomstring = require('randomstring');
 
 var AssetsTestUtil = require('./util');
 var LtiTestsUtil = require('col-lti/tests/util');
+var moment = require('moment-timezone');
 var TestsUtil = require('col-tests');
 var UsersTestUtil = require('col-users/tests/util');
 var WhiteboardsTestUtil = require('col-whiteboards/tests/util');
@@ -106,27 +107,30 @@ describe('Assets', function() {
     describe('File', function() {
 
       /**
-       * Test that verifies that a new file asset can be created
+       * Test verifies file creation against Canvas
        */
-      it('can be created', function(callback) {
+      it('can be created and stored in Canvas', function(callback) {
         TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
-          // Create a file asset with no optional metadata
-          AssetsTestUtil.assertCreateFile(client, course, 'UC Davis', AssetsTestUtil.getFileStream('logo-ucberkeley.png'), null, function(asset) {
+          AssetsTestUtil.assertFileCreateAndStorage(client, course, function(asset) {
+            assert.ok(asset);
 
-            // Create a file asset with no title. This should default the title to the name of the file
-            AssetsTestUtil.assertCreateFile(client, course, null, AssetsTestUtil.getFileStream('logo-ucberkeley.png'), null, function(asset) {
-              assert.equal(asset.title, 'logo-ucberkeley.png');
+            return callback();
+          });
+        });
+      });
 
-              // Create a file asset with optional metadata
-              var opts = {
-                'description': 'University of California, Berkeley logo',
-                'source': 'http://www.universityofcalifornia.edu/uc-system'
-              };
-              AssetsTestUtil.assertCreateFile(client, course, 'UC Berkeley', AssetsTestUtil.getFileStream('logo-ucberkeley.png'), opts, function(asset) {
+      /**
+       * Test verifies file creation against Amazon S3
+       */
+      it('can be created and stored in Amazon S3', function(callback) {
+        TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
+          // Course created_at date determines Amazon S3 (storage) eligibility
+          course.created_at = moment("9999-12-31", "YYYY-MM-DD");
 
-                return callback();
-              });
-            });
+          AssetsTestUtil.assertFileCreateAndStorage(client, course, function(asset) {
+            assert.ok(asset);
+
+            return callback();
           });
         });
       });

--- a/node_modules/col-assets/tests/util.js
+++ b/node_modules/col-assets/tests/util.js
@@ -191,9 +191,13 @@ var assertAsset = module.exports.assertAsset = function(asset, opts) {
     assert.ok(asset.mime);
 
     // Ensure a correct download URL has been provided
-    assert.ok(asset.download_url);
-    var validationResult = Joi.validate(asset.download_url, Joi.string().uri().required());
-    assert.ok(!validationResult.error);
+    if (asset.download_url) {
+      assert.ok(!asset.aws_s3_object_key);
+      var validationResult = Joi.validate(asset.download_url, Joi.string().uri().required());
+      assert.ok(!validationResult.error);
+    } else {
+      assert.ok(asset.aws_s3_object_key);
+    }
 
     if (opts.expectedAsset) {
       assert.strictEqual(asset.download_url, opts.expectedAsset.download_url);
@@ -1514,6 +1518,35 @@ var assertRemixWhiteboardFails = module.exports.assertRemixWhiteboardFails = fun
     assert.strictEqual(err.code, code);
 
     return callback();
+  });
+};
+
+/**
+ * Assert that asset (file) can be created and stored (Canvas filesystem or Amazon S3 per course created_at date)
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertFileCreateAndStorage = module.exports.assertFileCreateAndStorage = function(client, course, callback) {
+  // Create a file asset with no optional metadata
+  assertCreateFile(client, course, 'UC Davis', getFileStream('logo-ucberkeley.png'), null, function(asset) {
+
+    // Create a file asset with no title. This should default the title to the name of the file
+    assertCreateFile(client, course, null, getFileStream('logo-ucberkeley.png'), null, function(asset) {
+      assert.equal(asset.title, 'logo-ucberkeley.png');
+
+      // Create a file asset with optional metadata
+      var opts = {
+        'description': 'University of California, Berkeley logo',
+        'source': 'http://www.universityofcalifornia.edu/uc-system'
+      };
+      assertCreateFile(client, course, 'UC Berkeley', getFileStream('logo-ucberkeley.png'), opts, function(asset) {
+
+        return callback(asset);
+      });
+    });
   });
 };
 

--- a/node_modules/col-core/lib/aws-sdk-factory.js
+++ b/node_modules/col-core/lib/aws-sdk-factory.js
@@ -1,5 +1,5 @@
 /**
- * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ * Copyright ©2016. The Regents of the University of California (Regents). All Rights Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and its documentation
  * for educational, research, and not-for-profit purposes, without fee and without a
@@ -23,35 +23,24 @@
  * ENHANCEMENTS, OR MODIFICATIONS.
  */
 
-module.exports = {
-  'analytics': {
-    'enabled': false
-  },
-  'aws': {
-    's3': {
-      'awsSdkPackage': 'mock-aws-s3',
-      'bucket': 'mock-s3-bucket',
-      'cutoverDate': '9999-12-31'
+var config = require('config');
+
+/**
+ * Default AWS SDK is 'aws-sdk' but if NODE_ENV equals, for example, 'test' then use mock-aws-s3
+ *
+ * @param  {String}         bucket           S3 bucket assigned per environment
+ * @return {Object}                          Appropriate AWS SDK, configured per NODE_ENV
+ */
+var S3 = module.exports.S3 = function(bucket) {
+  var AWS = new require(config.get('aws.s3.awsSdkPackage'));
+
+  return new AWS.S3({
+    'accessKeyId': config.get('aws.credentials.accessKeyId'),
+    'secretAccessKey': config.get('aws.credentials.secretAccessKey'),
+    'region': config.get('aws.s3.region'),
+    'apiVersion': config.get('aws.s3.version'),
+    'params': {
+      'Bucket': bucket
     }
-  },
-  'db': {
-    'database': 'suitec_test',
-    'dropOnStartup': true
-  },
-  'log': {
-    'level': 'error',
-    'stream': 'logs/test.log'
-  },
-  'canvasPoller': {
-    'enabled': false
-  },
-  'previews': {
-    'enabled': false
-  },
-  'email': {
-    'enabled': false,
-    // We set these values two hours in the future so that the integration tests will pick up just-created activities.
-    'dailyHour': ((new Date().getHours() + 2) % 34),
-    'weeklyHour': ((new Date().getHours() + 2) % 34)
-  }
+  });
 };

--- a/node_modules/col-core/lib/storage.js
+++ b/node_modules/col-core/lib/storage.js
@@ -24,7 +24,7 @@
  */
 
 var _ = require('lodash');
-var AWS = require('aws-sdk');
+var AWS = require('./aws-sdk-factory');
 var config = require('config');
 var fs = require('fs');
 var log = require('./logger')('col-core/storage');
@@ -36,15 +36,7 @@ var util = require('util');
 
 var bucket = config.get('aws.s3.bucket');
 
-var s3 = new AWS.S3({
-  'accessKeyId': config.get('aws.credentials.accessKeyId'),
-  'secretAccessKey': config.get('aws.credentials.secretAccessKey'),
-  'region': config.get('aws.s3.region'),
-  'apiVersion': config.get('aws.s3.version'),
-  'params': {
-    'Bucket': bucket
-  }
-});
+var s3 = AWS.S3(bucket);
 
 /**
  * Delete file object from AWS S3

--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
     "xml2js": "0.4.17",
     "yargs": "7.0.2"
   },
+  "devDependencies": {
+    "mock-aws-s3": "2.5.1"
+  },
   "bundledDependencies": [
     "col-activities",
     "col-analytics",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1112

My attempt at factory pattern for `aws-sdk` dependency. Tests and Travis run against mock-Canvas; we need the same for AWS S3.

Fyi: https://github.com/MathieuLoutre/mock-aws-s3