### PR TITLE
COL-747 Quiet AssertionErrors from mock Canvas

### DIFF
--- a/node_modules/col-canvas/tests/test-poller.js
+++ b/node_modules/col-canvas/tests/test-poller.js
@@ -418,6 +418,7 @@ describe('Canvas poller', function() {
                             ])
                           ])
                         ];
+                        assignments[0].submissions[2].attachments[0].expectProcessing = false;
                         CanvasTestsUtil.mockPollingRequests(dbCourse, mockedUsers, assignments, []);
                         CanvasPoller.handleCourse(dbCourse, null, function(err) {
                           assert.ok(!err);
@@ -523,6 +524,8 @@ describe('Canvas poller', function() {
               assignments[0].submissions[0].attempt++;
               assignments[0].submissions[0].submission_type = 'online_upload';
               assignments[0].submissions[0].attachments = [new CanvasFile('image/jpeg', 'Oh noes', 'ohnoes.jpg')];
+              assignments[0].submissions[0].attachments[0].expectProcessing = false;
+
               CanvasTestsUtil.mockPollingRequests(dbCourse, mockedUsers, assignments, []);
               CanvasPoller.handleCourse(dbCourse, null, function(err) {
                 assert.ok(!err);
@@ -827,6 +830,7 @@ describe('Canvas poller', function() {
                 new CanvasSubmission(user1.id, 'online_upload', [new CanvasFile('image/jpeg', 'File 1', 'file1.jpg')], 'unsubmitted')
               ])
             ];
+            assignments[0].submissions[0].attachments[0].expectProcessing = false;
 
             CanvasTestsUtil.mockPollingRequests(dbCourse, [], assignments, []);
             CanvasPoller.handleCourse(dbCourse, {'enableAssignmentCategories': true}, function(err) {
@@ -930,7 +934,9 @@ describe('Canvas poller', function() {
 
                     // The first user now re-submits their assignment
                     assignments[0].submissions[0].attempt++;
+                    var oldFilePath = assignments[0].submissions[0].attachments[0].filePath;
                     assignments[0].submissions[0].attachments = [new CanvasFile('image/jpeg', 'File 1-updated', 'file1-updated.jpg')];
+                    assignments[0].submissions[0].attachments[0].expectDeletionAtPath = oldFilePath;
                     CanvasTestsUtil.mockPollingRequests(dbCourse, [], assignments, []);
                     CanvasPoller.handleCourse(dbCourse, {'enableAssignmentCategories': true}, function(err) {
                       assert.ok(!err);
@@ -1458,7 +1464,7 @@ describe('Canvas poller', function() {
               _.remove(mockTabsResponse, {'label': 'Asset Library'});
               _.remove(mockTabsResponse, {'label': 'Engagement Index'});
               _.find(mockTabsResponse, {'label': 'Whiteboards'}).hidden = true;
-              CanvasTestsUtil.mockPollingRequests(dbCourse, null, null, null, null, mockTabsResponse);
+              CanvasTestsUtil.mockGetCourseTabs(dbCourse, mockTabsResponse);
 
               // Poll the course
               CanvasPoller.handleCourse(dbCourse, null, function(err) {

--- a/node_modules/col-canvas/tests/util.js
+++ b/node_modules/col-canvas/tests/util.js
@@ -237,6 +237,9 @@ var mockGetSubmissions = module.exports.mockGetSubmissions = function(course, as
 
           // The upload request
           attachment.filePath = mockFileUpload(course);
+
+          // Any duplicates of this attachment should not be processed a second time
+          attachment.expectProcessing = false;
         }
       });
     })


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-747

The AssertionErrors in question are real errors caused by the mock Canvas not getting requests in the order it expects. For some reason they were not actually causing the tests to fail, and were logged in NODE_ENV=travis but not NODE_ENV=test. I have no explanation for this behavior.