### PR TITLE
COL-1104, storage of assets > downloadURL is legacy Canvas or CloudFront + S3 Object Key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ config/*
 node_modules/*
 !node_modules/col-*
 
-# Mock Amazon S3
-mock-s3-bucket
+# Localhost Amazon S3
+s3-bucket-*
 
 public/lib
 

--- a/config/default.json
+++ b/config/default.json
@@ -6,9 +6,9 @@
     },
     "s3": {
       "awsSdkPackage": "aws-sdk",
+      "baseDownloadUrl": "http://some.cloudfront.url",
+      "bucket": "s3-bucket-development",
       "cutoverDate": "2017-08-14",
-      "bucket": "suitec-dev",
-      "baseDownloadUrl": "https://foo.cloudfront.net",
       "region": "us-west-2",
       "version": "2006-03-01"
     }

--- a/config/test.js
+++ b/config/test.js
@@ -30,7 +30,7 @@ module.exports = {
   'aws': {
     's3': {
       'awsSdkPackage': 'mock-aws-s3',
-      'bucket': 'mock-s3-bucket',
+      'bucket': 's3-bucket-test',
       'cutoverDate': '9999-12-31'
     }
   },

--- a/config/travis.js
+++ b/config/travis.js
@@ -30,7 +30,7 @@ module.exports = {
   'aws': {
     's3': {
       'awsSdkPackage': 'mock-aws-s3',
-      'bucket': 'mock-s3-bucket',
+      'bucket': 's3-bucket-travis',
       'cutoverDate': '9999-12-31'
     }
   },

--- a/node_modules/col-assets/lib/api.js
+++ b/node_modules/col-assets/lib/api.js
@@ -39,6 +39,7 @@ var CollabosphereConstants = require('col-core/lib/constants');
 var CollabosphereUtil = require('col-core/lib/util');
 var DB = require('col-core/lib/db');
 var log = require('col-core/lib/logger')('col-assets');
+var Storage = require('col-core/lib/storage');
 var UserConstants = require('col-users/lib/constants');
 
 /**
@@ -703,46 +704,80 @@ var createFile = module.exports.createFile = function(ctx, title, file, opts, ca
     return callback({'code': 400, 'msg': validationResult.error.details[0].message});
   }
 
-  // Upload the file to Canvas
-  CanvasAPI.uploadFileToCanvas(ctx, file.file, null, function(err, canvasItem) {
-    if (err) {
-      return callback(err);
-    }
+  // Prepare to register file asset in the DB
+  var assetProperties = {
+    'course_id': ctx.course.id,
+    'user_id': ctx.user.id,
+    'type': 'file',
+    'title': title,
+    'description': opts.description,
+    'canvas_assignment_id': opts.assignment,
+    'source': opts.source,
+    'thumbnail_url': opts.thumbnail_url,
+    'image_url': opts.image_url,
+    'embed_id': opts.embed_id,
+    'embed_key': opts.embed_key,
+    'embed_code': opts.embed_code,
+    'visible': opts.visible
+  };
 
-    // Create the file asset in the DB
-    var asset = DB.Asset.build({
-      'course_id': ctx.course.id,
-      'user_id': ctx.user.id,
-      'type': 'file',
-      'title': title,
-      'download_url': canvasItem.url,
-      'mime': canvasItem['content-type'],
-      'description': opts.description,
-      'canvas_assignment_id': opts.assignment,
-      'source': opts.source,
-      'thumbnail_url': opts.thumbnail_url,
-      'image_url': opts.image_url,
-      'embed_id': opts.embed_id,
-      'embed_key': opts.embed_key,
-      'embed_code': opts.embed_code,
-      'visible': opts.visible
-    });
-    createAsset(ctx, asset, opts, function(err, asset) {
+  if (Storage.useAmazonS3(ctx.course)) {
+    // Upload the file to Amazon S3
+    Storage.storeAsset(ctx.course.id, file.file, function(err, objectKey, contentType) {
+      if (err) {
+        return callback(err);
+      }
 
-      // Attempt to clean up the uploaded file from the temp space
-      fs.unlink(file.file, function(cleanupErr) {
-        if (cleanupErr) {
-          log.warn({
-            'err': cleanupErr,
-            'file': file.file,
-            'asset': asset.id
-          }, 'Unable to clean up uploaded file from temp space');
+      var asset = DB.Asset.build(_.merge(assetProperties, {
+        'aws_s3_object_key': objectKey,
+        'mime': contentType
+      }));
+
+      createAsset(ctx, asset, opts, function(err, asset) {
+        if (err) {
+          log.error({'err': err, 'course': ctx.course.id, 'file': file.file}, 'Failed to create asset');
+          return callback(err);
         }
 
-        return callback(err, asset);
+        // Attempt to clean up the uploaded file from the temp space
+        fs.unlink(file.file, function(err) {
+          if (err) {
+            log.warn({'err': err, 'file': file.file, 'asset': asset.id}, 'Failed to remove file from temp space');
+          }
+
+          return callback(err, asset);
+        });
       });
     });
-  });
+
+  } else {
+    // Upload the file to Canvas (deprecated)
+    CanvasAPI.uploadFileToCanvas(ctx, file.file, null, function(err, canvasItem) {
+      if (err) {
+        return callback(err);
+      }
+
+      var asset = DB.Asset.build(_.merge(assetProperties, {
+        'download_url': canvasItem.url,
+        'mime': canvasItem['content-type']
+      }));
+
+      createAsset(ctx, asset, opts, function(err, asset) {
+        if (err) {
+          return callback(err);
+        }
+
+        // Attempt to clean up the uploaded file from the temp space
+        fs.unlink(file.file, function(err) {
+          if (err) {
+            log.warn({'err': err, 'file': file.file, 'asset': asset.id}, 'Failed to remove file from temp space');
+          }
+
+          return callback(err, asset);
+        });
+      });
+    });
+  }
 };
 
 /**
@@ -795,6 +830,7 @@ var createWhiteboard = module.exports.createWhiteboard = function(ctx, whiteboar
     'description': opts.description,
     'source': whiteboard.id.toString(),
     // These are temporary URL values, replaced after creation with updated values from the preview service.
+    'aws_s3_object_key': whiteboard.aws_s3_object_key,
     'download_url': whiteboard.image_url,
     'image_url': whiteboard.image_url,
     'thumbnail_url': whiteboard.thumbnail_url,
@@ -1195,7 +1231,7 @@ var generatePreviews = module.exports.generatePreviews = function(asset, callbac
 
   var assetUrl = null;
   if (asset.type === 'file' || asset.type === 'whiteboard') {
-    assetUrl = asset.download_url;
+    assetUrl = asset.aws_s3_object_key ? config.get('aws.s3.baseDownloadUrl') + '/' + asset.aws_s3_object_key : asset.download_url;
   } else if (asset.type === 'link') {
     assetUrl = asset.url;
   }
@@ -1284,7 +1320,8 @@ var handlePreviewsCallback = module.exports.handlePreviewsCallback = function(au
  *
  * @param  {Asset}          asset                           The asset for which the preview metadata is being updated
  * @param  {Object}         opts                            The preview metadata updates that need to be applied
- * @param  {String}         [opts.previewStatus]            The status of the previews of the asset=======
+ * @param  {String}         [opts.previewStatus]            The status of the previews of the asset
+ * @param  {String}         [opts.s3ObjectKey]              Amazon S3 Object Key of file
  * @param  {String}         [opts.downloadUrl]              The updated download URL of the asset
  * @param  {String}         [opts.thumbnailUrl]             The updated thumbnail URL of the asset
  * @param  {String}         [opts.imageUrl]                 The updated large image URL of the asset
@@ -1296,6 +1333,7 @@ var updateAssetPreview = module.exports.updateAssetPreview = function(asset, opt
   // Parameter validation
   var validationSchema = Joi.object().keys({
     'previewStatus': Joi.string().optional(),
+    's3ObjectKey': Joi.string().optional(),
     'downloadUrl': Joi.string().optional(),
     'thumbnailUrl': Joi.string().optional(),
     'imageUrl': Joi.string().optional(),
@@ -1313,6 +1351,9 @@ var updateAssetPreview = module.exports.updateAssetPreview = function(asset, opt
   var update = {};
   if (opts.previewStatus) {
     update.preview_status = opts.previewStatus;
+  }
+  if (opts.s3ObjectKey) {
+    update.aws_s3_object_key = opts.s3ObjectKey;
   }
   if (opts.downloadUrl) {
     update.download_url = opts.downloadUrl;

--- a/node_modules/col-assets/tests/test-assets.js
+++ b/node_modules/col-assets/tests/test-assets.js
@@ -28,8 +28,12 @@ var assert = require('assert');
 var randomstring = require('randomstring');
 
 var AssetsTestUtil = require('./util');
+var config = require('config');
+var CourseTestUtil = require('col-course/tests/util');
+var DB = require('col-core/lib/db');
 var LtiTestsUtil = require('col-lti/tests/util');
 var moment = require('moment-timezone');
+var Storage = require('col-core/lib/storage');
 var TestsUtil = require('col-tests');
 var UsersTestUtil = require('col-users/tests/util');
 var WhiteboardsTestUtil = require('col-whiteboards/tests/util');
@@ -107,28 +111,45 @@ describe('Assets', function() {
     describe('File', function() {
 
       /**
-       * Test verifies file creation against Canvas
+       * Test verifies file creation against Amazon S3
        */
-      it('can be created and stored in Canvas', function(callback) {
-        TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
-          AssetsTestUtil.assertFileCreateAndStorage(client, course, function(asset) {
-            assert.ok(asset);
+      it('can be created and stored in Amazon S3', function(callback) {
+        var course = TestsUtil.generateCourse(global.tests.canvas.ucdavis);
 
-            return callback();
+        TestsUtil.getAssetLibraryClient(null, course, null, function(client, course, user) {
+          // Course created_at date determines Amazon S3 (storage) eligibility
+          var values = {
+            'created_at': moment("9999-12-31", "YYYY-MM-DD").tz(config.get('timezone'))
+          };
+          DB.Course.update(values, {'where': {'canvas_course_id': course.id}}).complete(function(err) {
+            assert.ok(!err);
+
+            CourseTestUtil.getDbCourse(course.id, function(dbCourse) {
+              assert.ok(TestsUtil.expectAmazonS3(dbCourse));
+
+              AssetsTestUtil.assertFileCreateAndStorage(client, course, function(asset) {
+                client.assets.getAsset(course, asset.id, null, function(err, asset) {
+                  assert.ok(asset);
+                   assert.ok(_.endsWith(asset.download_url, asset.aws_s3_object_key));
+                  return callback();
+                });
+              });
+            });
           });
         });
       });
 
       /**
-       * Test verifies file creation against Amazon S3
+       * Test verifies file creation against Canvas
        */
-      it('can be created and stored in Amazon S3', function(callback) {
+      it('can be created and stored in Canvas', function(callback) {
         TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
-          // Course created_at date determines Amazon S3 (storage) eligibility
-          course.created_at = moment("9999-12-31", "YYYY-MM-DD");
+          assert.ok(!Storage.useAmazonS3(course));
 
           AssetsTestUtil.assertFileCreateAndStorage(client, course, function(asset) {
             assert.ok(asset);
+            assert.ok(asset.download_url);
+            assert.ok(!asset.aws_s3_object_key);
 
             return callback();
           });
@@ -169,28 +190,28 @@ describe('Assets', function() {
     it('can be retrieved', function(callback) {
       TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
         // Create a link asset with no optional metadata
-        AssetsTestUtil.assertCreateLink(client, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset) {
-          AssetsTestUtil.assertGetAsset(client, course, asset.id, asset, 0, function(asset) {
+        AssetsTestUtil.assertCreateLink(client, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(linkAsset1) {
+          AssetsTestUtil.assertGetAsset(client, course, linkAsset1.id, linkAsset1, 0, function(asset) {
 
             // Create a link asset with optional metadata
             var opts = {
               'description': 'University of California, Berkeley homepage',
               'source': 'http://www.universityofcalifornia.edu/uc-system'
             };
-            AssetsTestUtil.assertCreateLink(client, course, 'UC Berkeley', 'http://www.berkeley.edu/', opts, function(asset) {
-              AssetsTestUtil.assertGetAsset(client, course, asset.id, asset, 0, function(asset) {
+            AssetsTestUtil.assertCreateLink(client, course, 'UC Berkeley', 'http://www.berkeley.edu/', opts, function(linkAsset2) {
+              AssetsTestUtil.assertGetAsset(client, course, linkAsset2.id, linkAsset2, 0, function(linkAsset2) {
 
                 // Create a file asset with no optional metadata
-                AssetsTestUtil.assertCreateFile(client, course, 'UC Berkeley', AssetsTestUtil.getFileStream('logo-ucberkeley.png'), null, function(asset) {
-                  AssetsTestUtil.assertGetAsset(client, course, asset.id, asset, 0, function(asset) {
+                AssetsTestUtil.assertCreateFile(client, course, 'UC Berkeley', AssetsTestUtil.getFileStream('logo-ucberkeley.png'), null, function(fileAsset1) {
+                  AssetsTestUtil.assertGetAsset(client, course, fileAsset1.id, fileAsset1, 0, function(asset) {
 
                     // Create a file asset with optional metadata
                     opts = {
                       'description': 'University of California, Berkeley logo',
                       'source': 'http://www.universityofcalifornia.edu/uc-system'
                     };
-                    AssetsTestUtil.assertCreateFile(client, course, 'UC Berkeley', AssetsTestUtil.getFileStream('logo-ucberkeley.png'), opts, function(asset) {
-                      AssetsTestUtil.assertGetAsset(client, course, asset.id, asset, 0, function(asset) {
+                    AssetsTestUtil.assertCreateFile(client, course, 'UC Berkeley', AssetsTestUtil.getFileStream('logo-ucberkeley.png'), opts, function(fileAsset2) {
+                      AssetsTestUtil.assertGetAsset(client, course, fileAsset2.id, fileAsset2, 0, function(fileAsset2) {
 
                         return callback();
                       });

--- a/node_modules/col-assets/tests/util.js
+++ b/node_modules/col-assets/tests/util.js
@@ -192,11 +192,8 @@ var assertAsset = module.exports.assertAsset = function(asset, opts) {
 
     // Ensure a correct download URL has been provided
     if (asset.download_url) {
-      assert.ok(!asset.aws_s3_object_key);
       var validationResult = Joi.validate(asset.download_url, Joi.string().uri().required());
       assert.ok(!validationResult.error);
-    } else {
-      assert.ok(asset.aws_s3_object_key);
     }
 
     if (opts.expectedAsset) {
@@ -480,7 +477,9 @@ var assertCreateFile = module.exports.assertCreateFile = function(client, course
   opts = opts || {};
 
   // The file will be uploaded to Canvas
-  CanvasTestsUtil.mockFileUpload(course);
+  if (!TestsUtil.expectAmazonS3(course)) {
+    CanvasTestsUtil.mockFileUpload(course);
+  }
 
   client.assets.createFile(course, title, file, opts, function(err, asset, response) {
     assert.ok(!err);

--- a/node_modules/col-canvas/lib/poller.js
+++ b/node_modules/col-canvas/lib/poller.js
@@ -982,28 +982,39 @@ var downloadUrlRegex = /files\/(\d+)\/download/;
  * @param  {Object}     callback.err                      An error that occurred, if any
  */
 var removeFileSubmissionAsset = function(ctx, asset, callback) {
-  // If the asset has no download URL, don't attempt removal.
-  if (!asset.download_url) {
-    return callback();
-  }
+  if (asset.aws_s3_object_key) {
+    S3.deleteAsset(asset.aws_s3_object_key, function(err) {
+      if (err) {
+        log.error({'err': err, 'objectKey': asset.aws_s3_object_key}, 'Poller failed to delete S3 file object');
+        return callback(err);
+      }
 
-  // If the asset's download URL doesn't match the expected Canvas pattern, don't attempt removal.
-  var match = downloadUrlRegex.exec(asset.download_url);
-  var fileId = match && match[1];
-  if (!fileId) {
-    log.debug({'asset': asset.id, 'download_url': asset.download_url}, 'Could not extract Canvas file ID from download_url');
-    return callback();
-  }
+      return callback();
+    });
 
-  // If we do have a parseable URL, delete the file from the Canvas filesystem.
-  CanvasAPI.deleteFile(ctx, {'id': fileId}, function(err, response) {
-    if (err) {
-      log.error({'err': err, 'asset': asset.id}, 'Failed to delete an asset from the Canvas filesystem');
-      return callback(err);
+  } else if (asset.download_url) {
+    // If the asset's download URL doesn't match the expected Canvas pattern, don't attempt removal.
+    var match = downloadUrlRegex.exec(asset.download_url);
+    var fileId = match && match[1];
+    if (!fileId) {
+      log.debug({'asset': asset.id, 'download_url': asset.download_url}, 'Could not extract Canvas file ID from download_url');
+      return callback();
     }
 
+    // If we do have a parseable URL, delete the file from the Canvas filesystem.
+    CanvasAPI.deleteFile(ctx, {'id': fileId}, function(err, response) {
+      if (err) {
+        log.error({'err': err, 'asset': asset.id}, 'Failed to delete an asset from the Canvas filesystem');
+        return callback(err);
+      }
+
+      return callback();
+    });
+
+  } else {
+
     return callback();
-  });
+  }
 };
 
 /* Discussions */

--- a/node_modules/col-canvas/tests/test-poller.js
+++ b/node_modules/col-canvas/tests/test-poller.js
@@ -126,10 +126,7 @@ describe('Canvas poller', function() {
     this.timeout(15000);
 
     // Delete all courses from the DB so we can run a full polling cycle
-    var options = {
-      'cascade': true
-    };
-    DB.Course.truncate(options).complete(function(err) {
+    DB.Course.truncate({'cascade': true}).complete(function(err) {
       assert.ok(!err);
 
       // Generate a test course
@@ -149,13 +146,13 @@ describe('Canvas poller', function() {
             // Get the actual course object so we can pass it into the poller
             getCourse(course2.id, function(dbCourse2) {
 
-            // Mock the requests for this course
-            var mockedCanvasUsers = [
-              new CanvasUser('Active student', course2.id, 'active', null, 'user1@berkeley.edu'),
-              new CanvasUser('Active teacher', course2.id, 'active', 'TeacherEnrollment'),
-              new CanvasUser('Completed student', course2.id, 'completed', null, 'user3@berkeley.edu')
-            ];
-            CanvasTestsUtil.mockPollingRequests(dbCourse2, mockedCanvasUsers);
+              // Mock the requests for this course
+              var mockedCanvasUsers = [
+                new CanvasUser('Active student', course2.id, 'active', null, 'user1@berkeley.edu'),
+                new CanvasUser('Active teacher', course2.id, 'active', 'TeacherEnrollment'),
+                new CanvasUser('Completed student', course2.id, 'completed', null, 'user3@berkeley.edu')
+              ];
+              CanvasTestsUtil.mockPollingRequests(dbCourse2, mockedCanvasUsers);
 
               var initialCoursePoll = CanvasPoller.getLastCoursePoll();
 
@@ -170,12 +167,11 @@ describe('Canvas poller', function() {
                 assert.ok(lastCoursePoll <= Date.now());
 
                 // Verify the users for the second course were created
-                var ctx = {'course': dbCourse2};
                 var options = {
                   'enrollmentStates': _.values(CollabosphereConstants.ENROLLMENT_STATE),
                   'includeEmail': true
                 };
-                UsersAPI.getAllUsers(ctx, options, function(err, users) {
+                UsersAPI.getAllUsers({'course': dbCourse2}, options, function(err, users) {
                   assert.ok(!err);
                   assert.strictEqual(users.length, 4);
                   return callback();

--- a/node_modules/col-core/lib/db.js
+++ b/node_modules/col-core/lib/db.js
@@ -30,9 +30,9 @@ var path = require('path');
 var Sequelize = require('sequelize');
 
 var ActivitiesDefaults = require('col-activities/lib/default');
-
 var CollabosphereConstants = require('./constants');
 var log = require('./logger')('col-core/db');
+var Storage = require('./storage');
 var UserConstants = require('col-users/lib/constants');
 
 // A sequelize instance that will be connected to the database
@@ -554,6 +554,11 @@ var setUpModel = function(sequelize) {
           return _.pick(user.toJSON(), userFields);
         });
 
+        // File downloads are backed by Amazon S3 (Canvas Files API is the legacy solution)
+        if (asset.aws_s3_object_key) {
+          asset.download_url = config.get('aws.s3.baseDownloadUrl') + '/' + asset.aws_s3_object_key;
+        }
+
         delete asset.asset_users;
 
         // 'Impact' and 'trending' values are used for internal calculations and not surfaced through the JSON API.
@@ -763,7 +768,19 @@ var setUpModel = function(sequelize) {
   }, {
     'timestamps': true,
     'paranoid': true,
-    'underscored': true
+    'underscored': true,
+    'instanceMethods': {
+      'toJSON': function() {
+        var whiteboard = _.clone(this.dataValues);
+
+        // File downloads are backed by Amazon S3 (Canvas Files API is the legacy solution)
+        if (whiteboard.aws_s3_object_key) {
+          whiteboard.image_url = config.get('aws.s3.baseDownloadUrl') + '/' + whiteboard.aws_s3_object_key;
+        }
+
+        return whiteboard;
+      }
+    }
   });
 
   // Each whiteboard belongs to a specific course

--- a/node_modules/col-core/lib/storage.js
+++ b/node_modules/col-core/lib/storage.js
@@ -170,6 +170,7 @@ var putObjectToS3 = function(key, filePath, callback) {
  *
  * @param  {String}     id                    Course id or similar; an identifier
  * @param  {Number}     padToLength           Desired length of result
+ * @return {String}                           Deterministic transformation of id
  * @api private
  */
 var reverseAndPad = function(id, padToLength) {

--- a/node_modules/col-tests/lib/util.js
+++ b/node_modules/col-tests/lib/util.js
@@ -32,6 +32,7 @@ var AssetsTestUtil = require('col-assets/tests/util');
 var EmailUtil = require('col-core/lib/email');
 var LtiTestUtil = require('col-lti/tests/util');
 var RestAPI = require('col-rest');
+var Storage = require('col-core/lib/storage');
 var WhiteboardsTestUtil = require('col-whiteboards/tests/util');
 
 /**
@@ -230,6 +231,14 @@ var generateUser = module.exports.generateUser = function(canvas, id, roles, giv
     'guid': _.random(100000),
     'userImage': userImage || 'http://url.to/an/image.jpg'
   };
+};
+
+/**
+ * @param  {Course}        course      The Canvas course in which the user is interacting with the API
+ * @return {Boolean}                   True if course qualifies for AWS S3 storage
+ */
+var expectAmazonS3 = module.exports.expectAmazonS3 = function(course) {
+  return Storage.useAmazonS3(course);
 };
 
 // Variable that will keep track of the expected and sent number of emails for a user

--- a/node_modules/col-whiteboards/lib/api.js
+++ b/node_modules/col-whiteboards/lib/api.js
@@ -51,6 +51,7 @@ var CourseAPI = require('col-course');
 var DB = require('col-core/lib/db');
 var EmailUtil = require('col-core/lib/email');
 var log = require('col-core/lib/logger')('col-whiteboards');
+var S3 = require('col-core/lib/storage');
 var UserConstants = require('col-users/lib/constants');
 var UsersAPI = require('col-users');
 
@@ -364,6 +365,7 @@ var getWhiteboards = module.exports.getWhiteboards = function(ctx, filters, limi
  * @param  {Object}         opts                            Options for the new whiteboard
  * @param  {String}         opts.title                      The title of the whiteboard
  * @param  {String}         [opts.image_url]                An initial preview image URL for the whiteboard
+ * @param  {String}         [opts.aws_s3_object_key]        Amazon S3 (storage) Object Key of whiteboard image
  * @param  {String}         [opts.thumbnail_url]            An initial thumbnail URL for the whiteboard
  * @param  {Function}       callback                        Standard callback function
  * @param  {Object}         callback.err                    An error that occurred, if any
@@ -384,6 +386,7 @@ var createWhiteboard = module.exports.createWhiteboard = function(ctx, members, 
     'members': Joi.array().unique().items(Joi.number()).required(),
     'opts': Joi.object().keys({
       'title': Joi.string().max(255).required(),
+      'aws_s3_object_key': Joi.string().optional(),
       'image_url': Joi.string().optional(),
       'thumbnail_url': Joi.string().optional()
     })
@@ -408,6 +411,7 @@ var createWhiteboard = module.exports.createWhiteboard = function(ctx, members, 
     var whiteboard = {
       'course_id': ctx.course.id,
       'title': opts.title,
+      'aws_s3_object_key': opts.aws_s3_object_key,
       'image_url': opts.image_url,
       'thumbnail_url': opts.thumbnail_url
     };
@@ -1583,29 +1587,39 @@ var getWhiteboardAsPngFile = function(whiteboard, callback) {
         return callback({'code': 500, 'msg': 'There was an error exporting the whiteboard.'});
       }
 
-      // Get the full course and canvas object this whiteboard belongs to. We need that information
-      // to build a context that can be passed into the CanvasAPI later
+      // Get the realm of objects (e.g., course) surrounding this whiteboard. We need the
+      // information to build context that can be passed into the storage API.
       CourseAPI.getCourse(whiteboard.course_id, function(err, course) {
         if (err) {
-          // If for some reason the course could not be retrieved, the image file still needs to be
-          // cleaned up
+          // If the course could not be retrieved then clean up the image file
           return cleanUpFile(imagePath, callback, err);
         }
 
-        // Upload the file to Canvas
-        var ctx = {'course': course};
-        var remoteName = util.format('%d_whiteboard_%d.png', ctx.course.id, whiteboard.id);
-        CanvasAPI.uploadFileToCanvas(ctx, imagePath, remoteName, function(err, canvasItem) {
-          if (err) {
-            log.error({
-              'err': err,
-              'whiteboard': whiteboard.id
-            }, 'Could not upload the PNG representation of the board to Canvas');
-            return cleanUpFile(imagePath, callback, err);
-          }
+        // Upload the file to storage
+        if (S3.useAmazonS3(course)) {
+          // Upload the file to Amazon S3
+          S3.storeWhiteboardImage(whiteboard, imagePath, function(err, objectKey, contentType) {
+            if (err) {
+              log.error({'err': err, 'whiteboard': whiteboard.id}, 'Failed to upload whiteboard PNG to AWS S3');
+              return cleanUpFile(imagePath, callback, err);
+            }
 
-          return cleanUpFile(imagePath, callback, null, dimensions, canvasItem);
-        });
+            return cleanUpFile(imagePath, callback, null, dimensions, objectKey);
+          });
+
+        } else {
+          var ctx = {'course': course};
+          var remoteName = util.format('%d_whiteboard_%d.png', ctx.course.id, whiteboard.id);
+
+          CanvasAPI.uploadFileToCanvas(ctx, imagePath, remoteName, function(err, canvasItem) {
+            if (err) {
+              log.error({'err': err, 'whiteboard': whiteboard.id}, 'Failed to upload whiteboard PNG to Canvas');
+              return cleanUpFile(imagePath, callback, err);
+            }
+
+            return cleanUpFile(imagePath, callback, null, dimensions, canvasItem);
+          });
+        }
       });
     });
   });
@@ -1887,7 +1901,7 @@ var generateScheduledThumbnails = function(callback) {
  */
 var generateThumbnail = function(whiteboard, callback) {
   log.info({'whiteboard': whiteboard.id}, 'Getting the PNG data for a whiteboard');
-  getWhiteboardAsPngFile(whiteboard, function(err, dimensions, canvasItem) {
+  getWhiteboardAsPngFile(whiteboard, function(err, dimensions, storedItem) {
     if (err) {
       log.error({
         'err': err,
@@ -1898,7 +1912,8 @@ var generateThumbnail = function(whiteboard, callback) {
     log.info({'whiteboard': whiteboard.id}, 'Got the PNG data for a whiteboard');
 
     // Store the large image URL
-    var update = {'imageUrl': canvasItem.url};
+    var update = storedItem.aws_s3_object_key ? {'aws_s3_object_key': storedItem.aws_s3_object_key} : {'imageUrl': storedItem.url};
+
     updateWhiteboardPreview(whiteboard, update, function(err, updatedWhiteboard) {
       if (err) {
         log.error({'err': err, 'whiteboard': whiteboard.id}, 'Unable to update whiteboard preview');
@@ -1906,11 +1921,11 @@ var generateThumbnail = function(whiteboard, callback) {
       }
 
       // Pass on the image information to the caller
-      callback(err, updatedWhiteboard, dimensions, canvasItem);
+      callback(err, updatedWhiteboard, dimensions);
 
       // If the preview integration has been enabled, generate a thumbnail for the whiteboard asynchronously
       if (config.get('previews.enabled')) {
-        Collabosphere.generatePreviews(whiteboard.id, canvasItem.url, '/api/whiteboards-callback', function(err) {
+        Collabosphere.generatePreviews(whiteboard.id, storedItem.url, '/api/whiteboards-callback', function(err) {
           if (err) {
             log.error({'err': err, 'whiteboard': whiteboard.id}, 'Unable to generate a thumbnail');
           }
@@ -2013,6 +2028,7 @@ var cleanUpFile = function(fileToRemove, callback, arg1) {
  * @param  {Object}         [opts]                          The preview metadata updates that need to be applied
  * @param  {Object}         [opts.thumbnailUrl]             The updated thumbnail URL of the whiteboard
  * @param  {Object}         [opts.imageUrl]                 The updated image URL of the whiteboard
+ * @param  {String}         [opts.aws_s3_object_key]        Amazon S3 Object Key of image file
  * @param  {Function}       callback                        Standard callback function
  * @param  {Object}         callback.err                    An error that occurred, if any
  * @api private
@@ -2050,6 +2066,9 @@ var updateWhiteboardPreview = function(whiteboard, opts, callback) {
   }
   if (opts.imageUrl) {
     update.image_url = opts.imageUrl;
+  }
+  if (opts.aws_s3_object_key) {
+    update.aws_s3_object_key = opts.aws_s3_object_key;
   }
   whiteboard.updateAttributes(update).complete(function(err) {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "col-whiteboards"
   ],
   "scripts": {
-    "pretest": "test -f logs/test.log && rm logs/test.log || echo 'No test log to remove'",
+    "pretest": "echo 'Clean up old artifacts before running tests'; rm -f logs/test.log; rm -Rf s3-bucket-test",
     "test": "gulp test"
   },
   "engines": {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1104

* download_url remains but construction might use new CloudFront + S3 convention
* dev, test and travis have distinct `s3-bucket` on localhost
* poller is sensitive to `asset.aws_s3_object_key`