### PR TITLE
COL-1097, download assets via proxy to S3.getObject

### DIFF
--- a/node_modules/col-assets/lib/rest.js
+++ b/node_modules/col-assets/lib/rest.js
@@ -24,13 +24,14 @@
  */
 
 var _ = require('lodash');
+var util = require('util');
 
 var AnalyticsAPI = require('col-analytics');
+var AssetsAPI = require('./api');
 var Collabosphere = require('col-core');
 var CollabosphereUtil = require('col-core/lib/util');
-
-var AssetsAPI = require('./api');
 var MigrateAssetsAPI = require('./migrate');
+var Storage = require('col-core/lib/storage');
 
 /*!
  * Get an asset
@@ -289,6 +290,41 @@ Collabosphere.apiRouter.delete('/assets/:assetId/comments/:commentId', function(
     AnalyticsAPI.track(req.ctx.user, 'Delete asset comment', AnalyticsAPI.getAssetCommentProperties(comment, asset));
 
     return res.sendStatus(200);
+  });
+});
+
+/*!
+ * Download an asset
+ */
+Collabosphere.apiRouter.get('/assets/:assetId/download', function(req, res) {
+  AssetsAPI.getAssetProfile(req.ctx, req.params.assetId, false, function(err, asset) {
+    if (err) {
+      return res.status(err.code).send(err.msg);
+    }
+    if (!asset.aws_s3_object_key) {
+      return res.status(404).send("Requested asset has a null or undefined S3 Object Key");
+    }
+
+    Storage.getObjectMetadataFromS3(asset.aws_s3_object_key, function(err, metadata) {
+      if (err) {
+        return res.status(err.code).send(err.msg);
+      }
+
+      if (metadata.ContentType) {
+        res.set('Content-Type', metadata.ContentType);
+        res.set('Content-Length', metadata.ContentLength);
+        res.set('Last-Modified', metadata.LastModified);
+      }
+
+      Storage.getObjectFromS3(asset.aws_s3_object_key, function(data) {
+        var filename = _.split(asset.aws_s3_object_key, '/').pop();
+
+        res.set('Content-Disposition', util.format('attachment; filename="%s"', filename));
+        data.createReadStream().pipe(res);
+
+        return res.status(200);
+      });
+    });
   });
 });
 

--- a/node_modules/col-assets/tests/test-assets.js
+++ b/node_modules/col-assets/tests/test-assets.js
@@ -130,7 +130,8 @@ describe('Assets', function() {
               AssetsTestUtil.assertFileCreateAndStorage(client, course, function(asset) {
                 client.assets.getAsset(course, asset.id, null, function(err, asset) {
                   assert.ok(asset);
-                   assert.ok(_.endsWith(asset.download_url, asset.aws_s3_object_key));
+                  assert.ok(!asset.download_url);
+
                   return callback();
                 });
               });

--- a/node_modules/col-core/lib/db.js
+++ b/node_modules/col-core/lib/db.js
@@ -554,11 +554,6 @@ var setUpModel = function(sequelize) {
           return _.pick(user.toJSON(), userFields);
         });
 
-        // File downloads are backed by Amazon S3 (Canvas Files API is the legacy solution)
-        if (asset.aws_s3_object_key) {
-          asset.download_url = config.get('aws.s3.baseDownloadUrl') + '/' + asset.aws_s3_object_key;
-        }
-
         delete asset.asset_users;
 
         // 'Impact' and 'trending' values are used for internal calculations and not surfaced through the JSON API.

--- a/node_modules/col-core/lib/storage.js
+++ b/node_modules/col-core/lib/storage.js
@@ -122,6 +122,45 @@ var useAmazonS3 = module.exports.useAmazonS3 = function(course) {
 };
 
 /**
+ * Get object from Amazon S3
+ *
+ * @param  {String}     key                         Intended to be an Object Key in AWS S3
+ * @param  {Function}   callback                    Standard callback function
+ * @param  {Object}     callback.data               Data returned from Amazon S3
+ */
+var getObjectFromS3 = module.exports.getObjectFromS3 = function(key, callback) {
+  var params = {
+    'Bucket': bucket,
+    'Key': key
+  };
+
+  return callback(s3.getObject(params));
+};
+
+/**
+ * Get object metadata from Amazon S3
+ *
+ * @param  {String}     key                         Intended to be an Object Key in AWS S3
+ * @param  {Function}   callback                    Standard callback function
+ * @param  {Object}     callback.err                An error object, if any
+ * @param  {Object}     callback.data               Metadata returned from Amazon S3
+ */
+var getObjectMetadataFromS3 = module.exports.getObjectMetadataFromS3 = function(key, callback) {
+  var params = {
+    'Bucket': bucket,
+    'Key': key
+  };
+
+  s3.headObject(params, function(err, metadata) {
+    if (err) {
+      return callback(err);
+    }
+
+    return callback(null, metadata);
+   });
+};
+
+/**
  * Store file in Amazon S3
  *
  * @param  {String}     key                         Intended to be an Object Key in AWS S3

--- a/node_modules/col-whiteboards/lib/api.js
+++ b/node_modules/col-whiteboards/lib/api.js
@@ -51,7 +51,7 @@ var CourseAPI = require('col-course');
 var DB = require('col-core/lib/db');
 var EmailUtil = require('col-core/lib/email');
 var log = require('col-core/lib/logger')('col-whiteboards');
-var S3 = require('col-core/lib/storage');
+var Storage = require('col-core/lib/storage');
 var UserConstants = require('col-users/lib/constants');
 var UsersAPI = require('col-users');
 
@@ -1596,9 +1596,9 @@ var getWhiteboardAsPngFile = function(whiteboard, callback) {
         }
 
         // Upload the file to storage
-        if (S3.useAmazonS3(course)) {
+        if (Storage.useAmazonS3(course)) {
           // Upload the file to Amazon S3
-          S3.storeWhiteboardImage(whiteboard, imagePath, function(err, objectKey, contentType) {
+          Storage.storeWhiteboardImage(whiteboard, imagePath, function(err, objectKey, contentType) {
             if (err) {
               log.error({'err': err, 'whiteboard': whiteboard.id}, 'Failed to upload whiteboard PNG to AWS S3');
               return cleanUpFile(imagePath, callback, err);

--- a/public/app/assetlibrary/item/assetLibraryItemController.js
+++ b/public/app/assetlibrary/item/assetLibraryItemController.js
@@ -168,6 +168,14 @@
     };
 
     /**
+     * @param  {Object}               asset         Asset being viewed by user
+     * @return {String}                             URL to download asset file
+     */
+    $scope.getDownloadUrl = function(asset) {
+      return asset.aws_s3_object_key ? utilService.getApiUrl('/assets/' + assetId + '/download') : asset.download_url;
+    };
+
+    /**
      * Get activities for the current asset ID
      *
      * @return {void}

--- a/public/app/assetlibrary/item/item.html
+++ b/public/app/assetlibrary/item/item.html
@@ -42,9 +42,9 @@
         <span>Remix</span>
       </button>
       <a id="download-asset" class="btn btn-default"
-        data-ng-href="{{asset.download_url}}"
+        data-ng-href="{{getDownloadUrl(asset)}}"
         target="_blank"
-        data-ng-if="asset.type !== 'link' && asset.download_url">
+        data-ng-if="asset.type !== 'link' && (asset.download_url || asset.aws_s3_object_key)">
         <i class="fa fa-download"></i>
         <span>Download</span>
       </a>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1097

We might circumvent the need for CloudFront by maintaining our own lightweight proxy. The AWS S3 module makes it easy to get a handle on the IO-stream and file metadata. If this approach is fruitful then we can eliminate `download_url` column after migration off of Canvas Files API.