### PR TITLE
COL-1122 Add caliper-js dependency and wrapping analytics module

### DIFF
--- a/.ebextensions/04_download_local_configuration.config
+++ b/.ebextensions/04_download_local_configuration.config
@@ -1,4 +1,11 @@
 #
+# Prior to running 'npm install', download API token for private Github access.
+#
+commands:
+  01_download_netrc:
+    command: "aws s3 cp s3://suitec-config/.netrc /tmp/.netrc"
+
+#
 # The EB_ENVIRONMENT variable tells an Elastic Beanstalk environment its own name (e.g., suitec-dev).
 # Download the appropriate configuration file from the suitec-config S3 bucket and store it as
 # local-production.json (since all our environments are running under NODE_ENV=production).

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,8 @@ before_install:
   - psql suitec_travis -c 'create extension pg_trgm;' -U postgres
   - psql suitec_travis -c 'create role suitec superuser login; alter schema public owner to suitec;' -U postgres
 
+  # Set API key for caliper-js access on Github
+  - echo -e "machine github.com\n  login $CALIPER_JS_ACCESS_TOKEN" >> ~/.netrc
+
 script:
   - node_modules/.bin/gulp travis

--- a/config/default.json
+++ b/config/default.json
@@ -14,6 +14,9 @@
     }
   },
   "analytics": {
+    "caliper": {
+      "enabled": false
+    },
     "mixpanel": {
       "enabled": true,
       "apiKey": "qwertyuiop"

--- a/config/test.js
+++ b/config/test.js
@@ -25,6 +25,10 @@
 
 module.exports = {
   'analytics': {
+    'caliper': {
+      'enabled': true,
+      'url': 'http://example.com/caliper'
+    },
     'mixpanel': {
       'enabled': false
     }

--- a/config/travis.js
+++ b/config/travis.js
@@ -25,6 +25,10 @@
 
 module.exports = {
   'analytics': {
+    'caliper': {
+      'enabled': true,
+      'url': 'http://example.com/caliper'
+    },
     'mixpanel': {
       'enabled': false
     }

--- a/node_modules/col-analytics/lib/api.js
+++ b/node_modules/col-analytics/lib/api.js
@@ -26,8 +26,10 @@
 var _ = require('lodash');
 var config = require('config');
 
+var CaliperAPI = require('./caliper');
 var MixpanelAPI = require('./mixpanel');
 
+var caliperEnabled = config.get('analytics.caliper.enabled');
 var mixpanelEnabled = config.get('analytics.mixpanel.enabled');
 
 /**
@@ -36,6 +38,9 @@ var mixpanelEnabled = config.get('analytics.mixpanel.enabled');
  * @return {void}
  */
 var init = function() {
+  if (caliperEnabled) {
+    CaliperAPI.init();
+  }
   if (mixpanelEnabled) {
     MixpanelAPI.init();
   }
@@ -56,14 +61,17 @@ var identifyUser = module.exports.identifyUser = function(user) {
 /**
  * Track an event
  *
- * @param  {User}           user            The user for which to track the event
- * @param  {String}         event           The unique identifier of the event to track
- * @param  {Object}         [options]       Additional options to store against the specified event
+ * @param  {User}           user            The user associated with the event
+ * @param  {String}         event           A string identifying the event type
+ * @param  {Object}         [metadata]      Optional event metadata
  * @return {void}
  */
-var track = module.exports.track = function(user, event, options) {
+var track = module.exports.track = function(user, event, metadata) {
+  if (caliperEnabled) {
+    CaliperAPI.track(user, event, metadata);
+  }
   if (mixpanelEnabled) {
-    MixpanelAPI.track(user, event, options);
+    MixpanelAPI.track(user, event, metadata);
   }
 };
 

--- a/node_modules/col-analytics/lib/caliper.js
+++ b/node_modules/col-analytics/lib/caliper.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+var config = require('config');
+
+var Caliper = require('caliperjs/src/sensor');
+
+var CourseAPI = require('col-course');
+var log = require('col-core/lib/logger')('col-analytics/caliper');
+
+var sensor = Caliper.Sensor;
+
+/**
+ * Initialize Caliper sensor
+ *
+ * @return {void}
+ */
+var init = module.exports.init = function() {
+  var schema = config.get('app.https') ? 'https' : 'http';
+  var sensorId = schema + '://' + config.get('app.host') + '/sensor/1';
+  sensor.initialize(sensorId);
+
+  var client = Caliper.Clients.HttpClient;
+  client.initialize(sensorId.concat('/client/1'), {
+    'url': config.get('analytics.caliper.url')
+  });
+  sensor.registerClient(client);
+};
+
+/**
+ * Track an event via Caliper sensor
+ *
+ * @param  {User}           user            The user associated with the event
+ * @param  {String}         event           A string identifying the event type
+ * @param  {Object}         [metadata]      Optional event metadata
+ * @return {void}
+ */
+var track = module.exports.track = function(user, event, metadata) {
+  try {
+    getCourseIfMissing(user, function(err, course) {
+      if (err) {
+        log.error({'user': user}, 'Could not retrieve course for user');
+      }
+
+      // TODO create event based on user + course + metadata and send via sensor
+    });
+  } catch (err) {
+    log.error(err);
+  }
+};
+
+var getCourseIfMissing = function(user, callback) {
+  if (user.course) {
+    return callback(null, user.course);
+  }
+
+  CourseAPI.getCourse(user.course_id, callback);
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bower": "1.8.0",
     "bunyan": "1.8.5",
     "bunyan-prettystream": "0.1.3",
+    "caliperjs": "git+https://github.com/paulkerschen/caliper-js.git#develop",
     "config": "1.24.0",
     "content-disposition": "0.5.2",
     "cookie": "0.3.1",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1122

We work around the private status of the caliper.js library by (for now) installing from a fork under a developer account. Access is granted via https/API key rather than ssh so that both Travis and Elastic Beanstalk can use it. (Elastic Beanstalk downloads the key from S3; Travis has been given the key in an environment variable.)

With this change, developer machines, etc. wishing to run `npm install` will need to either copy the ~/.netrc file from S3 or use a Github account with "collaborator" status on the personal caliper-js fork.