### PR TITLE
NOJIRA, SuiteCLand gets proper ComputeType in buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,7 +2,7 @@ version: 0.1
 
 eb_codebuild_settings:
   CodeBuildServiceRole: arn:aws:iam::234923831700:role/service-role/codebuild-suitec-service-role
-  ComputeType: Linux
+  ComputeType: BUILD_GENERAL1_MEDIUM
   Image: aws/codebuild/nodejs:6.3.1
   Timeout: 60
 


### PR DESCRIPTION
See "Build Environment Compute Types" at http://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html

preview-service is happy with the same setting:
https://github.com/ets-berkeley-edu/suitec-preview-service/blob/master/buildspec.yml