### PR TITLE
COL-573, fix failing file downloads (variable naming); remove obsolete baseDownloadUrl

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -6,7 +6,6 @@
     },
     "s3": {
       "awsSdkPackage": "aws-sdk",
-      "baseDownloadUrl": "http://some.cloudfront.url",
       "bucket": "s3-bucket-development",
       "cutoverDate": "2017-08-14",
       "region": "us-west-2",

--- a/node_modules/col-core/lib/storage.js
+++ b/node_modules/col-core/lib/storage.js
@@ -122,7 +122,7 @@ var useAmazonS3 = module.exports.useAmazonS3 = function(course) {
  * @param  {Object}     callback.data               Data returned from Amazon S3
  * @return {Object}                                 Callback return
  */
-var getObject = module.exports.getObject = function(key, callback) {
+var getObject = module.exports.getObject = function(s3Uri, callback) {
   var params = getS3Params(s3Uri);
 
   return callback(s3.getObject(params));


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-573

If we resurrect the CloudFront design then `baseDownloadUrl` might return. (Storage code will get better test coverage soon.)