### PR TITLE
COL-1124 Caliper event transmission, test coverage

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -15,7 +15,9 @@
   },
   "analytics": {
     "caliper": {
-      "enabled": false
+      "enabled": false,
+      "url": "http://example.com/caliper",
+      "apiKey": "qwertyuiop"
     },
     "mixpanel": {
       "enabled": true,

--- a/config/travis.js
+++ b/config/travis.js
@@ -27,7 +27,7 @@ module.exports = {
   'analytics': {
     'caliper': {
       'enabled': true,
-      'url': 'http://example.com/caliper'
+      'url': 'http://localhost:3030/caliper'
     },
     'mixpanel': {
       'enabled': false

--- a/node_modules/col-analytics/lib/caliper.js
+++ b/node_modules/col-analytics/lib/caliper.js
@@ -27,6 +27,8 @@ var _ = require('lodash');
 var Caliper = require('caliperjs/src/sensor');
 var config = require('config');
 var moment = require('moment-timezone');
+var request = require('request');
+var util = require('util');
 
 var appPackage = require('../../../package.json');
 var CourseAPI = require('col-course');
@@ -35,6 +37,8 @@ var log = require('col-core/lib/logger')('col-analytics/caliper');
 var entityFactory = Caliper.Entities.EntityFactory;
 var eventFactory = Caliper.Events.EventFactory;
 var sensor = Caliper.Sensor;
+
+var caliperOptions = config.get('analytics.caliper');
 
 /**
  * Initialize Caliper sensor
@@ -45,12 +49,6 @@ var init = module.exports.init = function() {
   var schema = config.get('app.https') ? 'https' : 'http';
   var sensorId = schema + '://' + config.get('app.host') + '/sensor/1';
   sensor.initialize(sensorId);
-
-  var client = Caliper.Clients.HttpClient;
-  client.initialize(sensorId.concat('/client/1'), {
-    'url': config.get('analytics.caliper.url')
-  });
-  sensor.registerClient(client);
 };
 
 /**
@@ -67,17 +65,36 @@ var track = module.exports.track = function(user, event, metadata) {
       log.error({'user': user.id}, 'Could not retrieve course for user');
     }
 
+    var caliperRequest = null;
     try {
       var caliperEvent = buildEvent(user, course, event, metadata);
-      if (caliperEvent) {
-        var parsedEvent = JSON.parse(Caliper.Clients.ClientUtils.stringify(caliperEvent));
-        log.info({'event': parsedEvent}, 'Built Caliper event');
-
-        // TODO send event via sensor
+      if (!caliperEvent) {
+        log.debug({'user': user.id, 'event': event}, 'No match found for Caliper event');
+        return;
       }
+      caliperRequest = buildRequestOptions(caliperEvent);
     } catch (caliperError) {
-      log.error(caliperError);
+      log.error({'err': caliperError}, 'Error building Caliper envelope request');
+      return;
     }
+
+    log.debug({'request': caliperRequest}, 'Sending Caliper envelope request');
+
+    request(caliperRequest, function(requestError, res, body) {
+      if (requestError) {
+        log.error({'request': caliperRequest, 'err': requestError}, 'Caliper request errored');
+        return;
+      }
+
+      // Caliper doesn't specify how the LRS should respond, but we expect 200 OK or 201 Created as plausible statuses.
+      if (res.statusCode !== 200 && res.statusCode !== 201) {
+        log.error({
+          'request': caliperRequest,
+          'responseStatus': res.statusCode,
+          'responseBody': res.body
+        }, 'Caliper endpoint returned unexpected status code');
+      }
+    });
   });
 };
 
@@ -133,6 +150,34 @@ var buildEvent = function(user, course, eventDescription, metadata) {
     'group': courseSite,
     'membership': membership
   });
+};
+
+/**
+ * Build Caliper envelope request options from a Caliper event
+ *
+ * @param  {Object}         event             The supplied Caliper event
+ * @return {Object}                           The built request options
+ */
+var buildRequestOptions = function(event) {
+  var parsedEvent = JSON.parse(Caliper.Clients.ClientUtils.stringify(event));
+  log.debug({'event': parsedEvent}, 'Built Caliper event');
+
+  var envelope = sensor.createEnvelope({
+    'data': event
+  });
+  var serializedEnvelope = Caliper.Clients.ClientUtils.stringify(envelope);
+
+  var requestOptions = {
+    'uri': caliperOptions.url,
+    'method': 'POST',
+    'headers': {
+      'Authorization': util.format('Bearer %s', caliperOptions.apiKey),
+      'Content-Type': 'application/json'
+    },
+    'body': serializedEnvelope
+  };
+
+  return requestOptions;
 };
 
 /**

--- a/node_modules/col-analytics/tests/test-caliper.js
+++ b/node_modules/col-analytics/tests/test-caliper.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+var AnalyticsTestsUtil = require('./util');
+var LtiTestsUtil = require('col-lti/tests/util');
+var TestsUtil = require('col-tests');
+
+describe('Analytics', function() {
+
+  describe('Caliper', function() {
+
+    it('tracks an Asset Library launch', function(callback) {
+      var client = TestsUtil.getAnonymousClient();
+      var course = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var user = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+
+      AnalyticsTestsUtil.expectCaliperEvent(user, course, {
+        'type': 'NavigationEvent',
+        'action': 'NavigatedTo',
+        'object': {
+          'id': 'http://suitec.berkeley/lti/assetlibrary.xml',
+          'type': 'SoftwareApplication',
+          'name': 'Asset Library'
+        }
+      });
+
+      LtiTestsUtil.assertAssetLibraryLaunchSucceeds(client, course, user, function() {
+        return callback();
+      });
+    });
+
+    it('tracks an Engagement Index launch', function(callback) {
+      var client = TestsUtil.getAnonymousClient();
+      var course = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var user = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+
+      AnalyticsTestsUtil.expectCaliperEvent(user, course, {
+        'type': 'NavigationEvent',
+        'action': 'NavigatedTo',
+        'object': {
+          'id': 'http://suitec.berkeley/lti/engagementindex.xml',
+          'type': 'SoftwareApplication',
+          'name': 'Engagement Index'
+        }
+      });
+
+      LtiTestsUtil.assertEngagementIndexLaunchSucceeds(client, course, user, function() {
+        return callback();
+      });
+    });
+
+    it('tracks a Whiteboards launch', function(callback) {
+      var client = TestsUtil.getAnonymousClient();
+      var course = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var user = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+
+      AnalyticsTestsUtil.expectCaliperEvent(user, course, {
+        'type': 'NavigationEvent',
+        'action': 'NavigatedTo',
+        'object': {
+          'id': 'http://suitec.berkeley/lti/whiteboards.xml',
+          'type': 'SoftwareApplication',
+          'name': 'Whiteboards'
+        }
+      });
+
+      LtiTestsUtil.assertWhiteboardsLaunchSucceeds(client, course, user, function() {
+        return callback();
+      });
+    });
+
+    it('tracks an Impact Studio launch', function(callback) {
+      var client = TestsUtil.getAnonymousClient();
+      var course = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var user = TestsUtil.generateUser(global.tests.canvas.ucberkeley);
+
+      AnalyticsTestsUtil.expectCaliperEvent(user, course, {
+        'type': 'NavigationEvent',
+        'action': 'NavigatedTo',
+        'object': {
+          'id': 'http://suitec.berkeley/lti/dashboard.xml',
+          'type': 'SoftwareApplication',
+          'name': 'Impact Studio'
+        }
+      });
+
+      LtiTestsUtil.assertDashboardLaunchSucceeds(client, course, user, function() {
+        return callback();
+      });
+    });
+
+  });
+});

--- a/node_modules/col-analytics/tests/util.js
+++ b/node_modules/col-analytics/tests/util.js
@@ -1,0 +1,125 @@
+/**
+ * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+var _ = require('lodash');
+var assert = require('assert');
+var config = require('config');
+var url = require('url');
+
+var MockedRequest = require('col-tests/lib/model').MockedRequest;
+
+var caliperUrl = url.parse(config.get('analytics.caliper.url'));
+
+/**
+ * Expect to receive a Caliper event matching provided data
+ *
+ * @param  {User}               user                          The SuiteC user associated with the event
+ * @param  {Course}             course                        The SuiteC course associated with the event
+ * @param  {Object}             [opts]                        Optional parameters to verify
+ * @return {void}
+ * @throws {AssertionError}                                   Error thrown when an assertion failed
+ */
+var expectCaliperEvent = module.exports.expectCaliperEvent = function(user, course, opts) {
+  var mockedRequest = new MockedRequest('POST', caliperUrl.pathname, 201, null, null, null, function(req) {
+    assertCaliperPayload(req.body, user, course, opts);
+  });
+  global.tests.caliper.appServer.expect(mockedRequest);
+};
+
+/**
+ * Assert that a Caliper envelope containing a single event has expected properties
+ *
+ * @param  {Object}             envelope                      The Caliper envelope to be checked
+ * @param  {User}               user                          The SuiteC user associated with the event
+ * @param  {Course}             course                        The SuiteC course associated with the event
+ * @param  {Object}             [opts]                        Optional parameters to verify
+ * @return {void}
+ * @throws {AssertionError}                                   Error thrown when an assertion failed
+ */
+var assertCaliperPayload = module.exports.assertCaliperPayload = function(envelope, user, course, opts) {
+  opts = opts || {};
+
+  assert.ok(envelope);
+  assert.ok(envelope.sensor);
+  assert.ok(envelope.sendTime);
+
+  assert.strictEqual(envelope.dataVersion, 'http://purl.imsglobal.org/ctx/caliper/v1p1');
+  assert.strictEqual(envelope.data.length, 1);
+
+  assertCaliperEvent(envelope.data[0], user, course, opts);
+};
+
+/**
+ * Assert that a Caliper event has expected properties
+ *
+ * @param  {Object}             event                         The event object to assert the properties for
+ * @param  {User}               user                          The SuiteC user associated with the event
+ * @param  {Course}             course                        The SuiteC course associated with the event
+ * @param  {Object}             [opts]                        Optional parameters to verify
+ * @return {void}
+ * @throws {AssertionError}                                   Error thrown when an assertion failed
+ */
+var assertCaliperEvent = function(event, user, course, opts) {
+  assert.strictEqual(event['@context'], 'http://purl.imsglobal.org/ctx/caliper/v1p1');
+  assert.ok(event.id.startsWith('urn:uuid:'));
+  assert.ok(event.eventTime);
+
+  if (opts.type) {
+    assert.strictEqual(opts.type, event.type);
+  } else {
+    assert.ok(event.type);
+  }
+
+  if (opts.action) {
+    assert.strictEqual(opts.action, event.action);
+  } else {
+    assert.ok(event.action);
+  }
+
+  assert.ok(event.object.id);
+  if (opts.object) {
+    _.forOwn(opts.object, function(value, key) {
+      assert.deepEqual(value, event.object[key]);
+    });
+  }
+
+  if (user) {
+    assert.ok(event.actor.id.endsWith(user.id));
+    assert.strictEqual(event.actor.type, 'Person');
+    assert.strictEqual(event.actor.name, user.fullName);
+  }
+
+  if (course) {
+    assert.ok(event.group.id.endsWith(course.id));
+    assert.strictEqual(event.group.type, 'Organization');
+    assert.strictEqual(event.group.name, course.title);
+  }
+
+  if (user && course) {
+    assert.ok(event.membership.member.endsWith(user.id));
+    assert.ok(event.membership.organization.endsWith(course.id));
+    assert.strictEqual(event.membership.type, 'Membership');
+  }
+};

--- a/node_modules/col-assets/tests/test-assets.js
+++ b/node_modules/col-assets/tests/test-assets.js
@@ -679,7 +679,7 @@ describe('Assets', function() {
           AssetsTestUtil.assertBadges(assets, []);
 
           // Launch the Impact Studio and refresh the assets.
-          LtiTestsUtil.assertDashboardCartridgeSucceeds(client4, course, user4, function() {
+          LtiTestsUtil.assertDashboardLaunchSucceeds(client4, course, user4, function() {
             AssetsTestUtil.assertGetAssets(client1, course, null, 'impact', 12, null, 12, function(assets) {
               // The two most impactful assets should have badges.
               AssetsTestUtil.assertBadges(assets, [0, 1]);

--- a/node_modules/col-lti/tests/util.js
+++ b/node_modules/col-lti/tests/util.js
@@ -169,7 +169,7 @@ var assertAssetLibraryLaunchSucceeds = module.exports.assertAssetLibraryLaunchSu
  * @param  {Function}       callback      Standard callback function
  * @throws {AssertionError}               Error thrown when an assertion failed
  */
-var assertDashboardCartridgeSucceeds = module.exports.assertDashboardCartridgeSucceeds = function(client, course, user, callback) {
+var assertDashboardLaunchSucceeds = module.exports.assertDashboardLaunchSucceeds = function(client, course, user, callback) {
   // Get the LTI parameters which are signed with OAuth
   var parameters = getLaunchParameters(course, user, 'dashboard');
 

--- a/node_modules/col-tests/lib/beforeTests.js
+++ b/node_modules/col-tests/lib/beforeTests.js
@@ -26,8 +26,10 @@
 var _ = require('lodash');
 var assert = require('assert');
 var busboy = require('express-busboy');
+var config = require('config');
 var express = require('express');
 var randomstring = require('randomstring');
+var url = require('url');
 var util = require('util');
 
 var Collabosphere = require('col-core');
@@ -56,7 +58,13 @@ before(function(callback) {
               'ucdavis': ucdavisCanvas
             }
           };
-          return callback();
+
+          // Create mock Caliper endpoint and expose globally
+          createCaliperEndpoint(function(mockCaliperEndpoint) {
+            global.tests.caliper = mockCaliperEndpoint;
+
+            return callback();
+          });
         });
       });
     });
@@ -68,18 +76,23 @@ after(function(callback) {
   return callback();
 });
 
+
+var canvasPort = 3001;
+
 /**
- * Create a dummy canvas object
+ * Create a mock Canvas instance
  *
  * @param  {Function}     callback              Standard callback function
- * @param  {Object}       callback.canvas       The created canvas object
- * @return {Object}                             Processed canvas object
+ * @param  {Object}       callback.canvas       The created Canvas object
+ * @return {Object}                             Processed Canvas object
  */
 var createCanvas = function(callback) {
-  // Mock a canvas instance
-  mockCanvasAPI(function(api_domain, canvasAppServer) {
+  // Mock a Canvas instance
+  mockExternalAPI(canvasPort, true, function(apiDomain, canvasAppServer) {
+    canvasPort++;
+
     DB.Canvas.build({
-      'canvas_api_domain': api_domain,
+      'canvas_api_domain': apiDomain,
       'api_key': randomstring.generate(),
       'lti_key': randomstring.generate(),
       'lti_secret': randomstring.generate(),
@@ -93,27 +106,41 @@ var createCanvas = function(callback) {
   });
 };
 
-var canvasPort = 3001;
+/**
+ * Create a mock Caliper endpoint
+ *
+ * @param  {Function}     callback              Standard callback function
+ * @param  {Object}       callback.canvas       The created Caliper endpoint
+ * @return {Object}                             Processed Caliper endpoint
+ */
+var createCaliperEndpoint = function(callback) {
+  var caliperUrl = url.parse(config.get('analytics.caliper.url'));
+  mockExternalAPI(caliperUrl.port, false, function(apiDomain, caliperEndpointServer) {
+    return callback({
+      'appServer': caliperEndpointServer
+    });
+  });
+};
 
 /**
- * Mock the Canvas REST API by spinning up an express web server
+ * Mock an external API by spinning up an express web server
  *
+ * @param  {Number}           localPort                   The localhost port on which the mock API should listen
+ * @param  {Boolean}          emptyQueueError             When false, ignore requests on an empty queue; when true, throw an error
  * @param  {Function}         callback                    Standard callback function
- * @param  {String}           callback.apiDomain          The api domain on which the mocked REST api is available
- * @param  {Express}          callback.app                The express web server that will be used to mock the canvas API
+ * @param  {String}           callback.apiDomain          The API domain on which the mock API is available
+ * @param  {Express}          callback.app                The express web server that will be used to mock the REST API
  * @param  {Function}         callback.app.expect         A function that allows you to add an expected request
- * @return {Object}                                       Initialized mock Canvas
+ * @return {Object}                                       Initialized mock REST API
  * @api private
  */
-var mockCanvasAPI = function(callback) {
+var mockExternalAPI = function(localPort, emptyQueueError, callback) {
   var app = express();
 
-  // Holds a queue of expected requests that should hit the Canvas server
+  // Holds a queue of expected requests that should hit the server
   var queue = [];
 
-  var server = app.listen(canvasPort, function() {
-    canvasPort++;
-
+  var server = app.listen(localPort, function() {
     var port = server.address().port;
     var apiDomain = util.format('localhost:%d', port);
 
@@ -122,7 +149,11 @@ var mockCanvasAPI = function(callback) {
 
     app.use(function(req, res, next) {
       if (_.isEmpty(queue)) {
-        assert.fail('Was not expecting any requests reaching Canvas');
+        if (emptyQueueError) {
+          assert.fail('Mock API was expecting no requests');
+        } else {
+          return;
+        }
       }
 
       var mockedRequest = queue[0];


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1124

- Instead of sending events via the caliper-js sensor, which seems to be incompletely implemented, handle the request code ourselves.
- In dev environments, the `caliper-listener.js` script can be run (instructions included in script) to receive events as they're fired off.
- For test runs, a mock Caliper endpoint is set up on the pattern of our mock Canvas server to run assertions on generated events.