### PR TITLE
COL-1128 Caliper instrumentation: asset (dis/un)liking

### DIFF
--- a/node_modules/col-analytics/lib/caliper.js
+++ b/node_modules/col-analytics/lib/caliper.js
@@ -120,9 +120,12 @@ var buildEvent = function(user, course, eventDescription, metadata, eventObject)
   var courseSite = buildOrganization(course);
   var membership = buildMembership(user, actor, courseSite);
 
+  var currentTime = moment.utc();
+
   var action = null;
   var eventType = null;
   var object = null;
+  var generated = null;
   var extensions = null;
 
   switch (eventDescription) {
@@ -174,6 +177,7 @@ var buildEvent = function(user, course, eventDescription, metadata, eventObject)
       break;
 
     // Asset creation and editing
+
     case 'Create link asset':
     case 'Create file asset':
       action = Caliper.Actions.created;
@@ -187,7 +191,40 @@ var buildEvent = function(user, course, eventDescription, metadata, eventObject)
       object = buildDigitalResourceFromAsset(eventObject, course);
       break;
 
+    // (Dis/un)liking
+
+    case 'Like asset':
+      action = Caliper.Actions.liked;
+      eventType = Caliper.Events.Event;
+      object = buildDigitalResourceFromAsset(eventObject, course);
+      generated = entityFactory.create(Caliper.Entities.Annotation, {
+        'id': util.format('%s/likes/%s', object.id, user.canvas_user_id),
+        'name': 'Like',
+        'annotator': actor.id,
+        'annotated': object.id,
+        'dateCreated': currentTime
+      });
+      break;
+    case 'Dislike asset':
+      action = Caliper.Actions.disliked;
+      eventType = Caliper.Events.Event;
+      object = buildDigitalResourceFromAsset(eventObject, course);
+      generated = entityFactory.create(Caliper.Entities.Annotation, {
+        'id': util.format('%s/likes/%s', object.id, user.canvas_user_id),
+        'name': 'Dislike',
+        'annotator': actor.id,
+        'annotated': object.id,
+        'dateCreated': currentTime
+      });
+      break;
+    case 'Unlike asset':
+      action = Caliper.Actions.removed;
+      eventType = Caliper.Events.Event;
+      object = util.format('%s/likes/%s', getEntityIdForAsset(eventObject, course), user.canvas_user_id);
+      break;
+
     // If event description is not matched, exit early
+
     default:
       return null;
   }
@@ -196,10 +233,14 @@ var buildEvent = function(user, course, eventDescription, metadata, eventObject)
     'actor': actor,
     'action': action.term,
     'object': object,
-    'eventTime': moment.utc(),
+    'eventTime': currentTime,
     'group': courseSite,
     'membership': membership
   };
+
+  if (generated) {
+    eventProperties.generated = generated;
+  }
 
   if (extensions) {
     eventProperties.extensions = extensions;
@@ -237,6 +278,17 @@ var buildRequestOptions = function(event) {
 };
 
 /**
+ * Return a Caliper Entity id for a SuiteC asset
+ *
+ * @param  {Asset}       asset         The supplied asset
+ * @param  {Course}      course        The course associated with the event
+ * @return {Object}                    The created DigitalResource entity
+ */
+var getEntityIdForAsset = function(asset, course) {
+  return util.format('%s/api/%s/%s/assets/%s', appUrlBase, course.canvas_api_domain, course.canvas_course_id, asset.id);
+};
+
+/**
  * Create a Caliper DigitalResource entity from a SuiteC asset
  *
  * @param  {Asset}       asset         The supplied asset
@@ -244,7 +296,7 @@ var buildRequestOptions = function(event) {
  * @return {Object}                    The created DigitalResource entity
  */
 var buildDigitalResourceFromAsset = function(asset, course) {
-  var id = util.format('%s/api/%s/%s/assets/%s', appUrlBase, course.canvas_api_domain, course.canvas_course_id, asset.id);
+  var id = getEntityIdForAsset(asset, course);
 
   var creators = _.map(asset.users, function(user) {
     return buildPerson(user, course);

--- a/node_modules/col-analytics/tests/test-caliper.js
+++ b/node_modules/col-analytics/tests/test-caliper.js
@@ -120,9 +120,7 @@ describe('Analytics', function() {
     describe('Asset library view events', function() {
 
       it('tracks an Asset Library listing', function(callback) {
-        AnalyticsTestsUtil.allowCaliperEvents(function(event) {
-          return (event.action === 'NavigatedTo' || event.action === 'Created');
-        });
+        AnalyticsTestsUtil.allowCaliperActions(['NavigatedTo', 'Created']);
 
         TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
           AssetsTestsUtil.assertCreateLink(client, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset1) {
@@ -150,9 +148,7 @@ describe('Analytics', function() {
       });
 
       it('tracks an Asset Library search', function(callback) {
-        AnalyticsTestsUtil.allowCaliperEvents(function(event) {
-          return (event.action === 'NavigatedTo' || event.action === 'Created');
-        });
+        AnalyticsTestsUtil.allowCaliperActions(['NavigatedTo', 'Created']);
 
         TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
           AssetsTestsUtil.assertCreateLink(client, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset1) {
@@ -181,9 +177,7 @@ describe('Analytics', function() {
       });
 
       it('tracks an asset view', function(callback) {
-        AnalyticsTestsUtil.allowCaliperEvents(function(event) {
-          return (event.action === 'NavigatedTo' || event.action === 'Created');
-        });
+        AnalyticsTestsUtil.allowCaliperActions(['NavigatedTo', 'Created']);
 
         TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
           AssetsTestsUtil.assertCreateLink(client, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset) {
@@ -224,9 +218,7 @@ describe('Analytics', function() {
     describe('Asset creation and modification', function() {
 
       it('tracks link asset creation', function(callback) {
-        AnalyticsTestsUtil.allowCaliperEvents(function(event) {
-          return (event.action === 'NavigatedTo');
-        });
+        AnalyticsTestsUtil.allowCaliperActions(['NavigatedTo']);
 
         TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
           var linkTitle = 'UC Berkeley';
@@ -268,9 +260,7 @@ describe('Analytics', function() {
       });
 
       it('tracks file asset creation', function(callback) {
-        AnalyticsTestsUtil.allowCaliperEvents(function(event) {
-          return (event.action === 'NavigatedTo');
-        });
+        AnalyticsTestsUtil.allowCaliperActions(['NavigatedTo']);
 
         TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
 
@@ -304,9 +294,7 @@ describe('Analytics', function() {
       });
 
       it('tracks asset modification', function(callback) {
-        AnalyticsTestsUtil.allowCaliperEvents(function(event) {
-          return (event.action === 'NavigatedTo' || event.action === 'Created');
-        });
+        AnalyticsTestsUtil.allowCaliperActions(['NavigatedTo', 'Created']);
 
         TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
           AssetsTestsUtil.assertCreateLink(client, course, 'UC Davis', 'http://www.berkeley.edu/', null, function(asset) {
@@ -335,6 +323,95 @@ describe('Analytics', function() {
             AnalyticsTestsUtil.onExpectationResult(callback);
 
             AssetsTestsUtil.assertEditAsset(client, course, asset.id, modifiedTitle, {'description': modifiedDescription}, _.noop);
+          });
+        });
+      });
+    });
+
+    describe('Asset (dis/un)liking', function() {
+
+      it('tracks like creation and removal', function(callback) {
+        AnalyticsTestsUtil.allowCaliperActions(['NavigatedTo', 'Created', 'Viewed']);
+
+        TestsUtil.getAssetLibraryClient(null, null, null, function(creatorClient, creatorCourse, creatorUser) {
+          AssetsTestsUtil.assertCreateLink(creatorClient, creatorCourse, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset) {
+            TestsUtil.getAssetLibraryClient(null, creatorCourse, null, function(reactorClient, course, reactorUser) {
+
+              var caliperAssetId = util.format('http://suitec.berkeley/api/%s/%s/assets/%s', course.canvas.canvas_api_domain, course.id, asset.id);
+              var caliperUserId = util.format('http://%s/users/%s', course.canvas.canvas_api_domain, reactorUser.id);
+              var caliperLikeId = util.format('%s/likes/%s', caliperAssetId, reactorUser.id);
+
+              AnalyticsTestsUtil.expectCaliperEvent(reactorUser, course, {
+                'type': 'Event',
+                'action': 'Liked',
+                'object': {
+                  'id': caliperAssetId,
+                  'type': 'DigitalResource'
+                },
+                'generated': {
+                  'id': caliperLikeId,
+                  'type': 'Annotation',
+                  'name': 'Like',
+                  'annotator': caliperUserId,
+                  'annotated': caliperAssetId
+                }
+              });
+
+              AnalyticsTestsUtil.expectCaliperEvent(reactorUser, course, {
+                'type': 'Event',
+                'action': 'Removed',
+                'object': caliperLikeId
+              });
+
+              AnalyticsTestsUtil.onExpectationResult(callback);
+
+              AssetsTestsUtil.assertLike(reactorClient, course, asset.id, true, function() {
+                AssetsTestsUtil.assertLike(reactorClient, course, asset.id, null, _.noop);
+              });
+            });
+          });
+        });
+      });
+
+      it('tracks dislike creation and removal', function(callback) {
+        AnalyticsTestsUtil.allowCaliperActions(['NavigatedTo', 'Created', 'Viewed']);
+
+        TestsUtil.getAssetLibraryClient(null, null, null, function(creatorClient, creatorCourse, creatorUser) {
+          AssetsTestsUtil.assertCreateLink(creatorClient, creatorCourse, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset) {
+            TestsUtil.getAssetLibraryClient(null, creatorCourse, null, function(reactorClient, course, reactorUser) {
+
+              var caliperAssetId = util.format('http://suitec.berkeley/api/%s/%s/assets/%s', course.canvas.canvas_api_domain, course.id, asset.id);
+              var caliperUserId = util.format('http://%s/users/%s', course.canvas.canvas_api_domain, reactorUser.id);
+              var caliperDislikeId = util.format('%s/likes/%s', caliperAssetId, reactorUser.id);
+
+              AnalyticsTestsUtil.expectCaliperEvent(reactorUser, course, {
+                'type': 'Event',
+                'action': 'Disliked',
+                'object': {
+                  'id': caliperAssetId,
+                  'type': 'DigitalResource'
+                },
+                'generated': {
+                  'id': caliperDislikeId,
+                  'type': 'Annotation',
+                  'name': 'Dislike',
+                  'annotator': caliperUserId,
+                  'annotated': caliperAssetId
+                }
+              });
+
+              AnalyticsTestsUtil.expectCaliperEvent(reactorUser, course, {
+                'type': 'Event',
+                'action': 'Removed',
+                'object': caliperDislikeId
+              });
+
+              AnalyticsTestsUtil.onExpectationResult(callback);
+
+              AssetsTestsUtil.assertLike(reactorClient, course, asset.id, false, function() {
+                AssetsTestsUtil.assertLike(reactorClient, course, asset.id, null, _.noop);
+              });
+            });
           });
         });
       });

--- a/node_modules/col-analytics/tests/util.js
+++ b/node_modules/col-analytics/tests/util.js
@@ -82,6 +82,18 @@ var allowCaliperEvents = module.exports.allowCaliperEvents = function(eventTest)
 };
 
 /**
+ * Shorthand to allow (i.e. ignore and let pass) any Caliper events matching supplied actions.
+ *
+ * @param  {String[]}           actions                     Array of string terms for allowed action
+ * @return {void}
+ */
+var allowCaliperActions = module.exports.allowCaliperActions = function(actions) {
+  allowCaliperEvents(function(event) {
+    return _.includes(actions, event.action);
+  });
+};
+
+/**
  * Execute a supplied callback when all expectations are satisfied or an expectation fails. This forces the test to
  * wait while expectations remains unsatisfied; if an expected event is never received, the callback will never execute
  * and the test will time out.
@@ -143,17 +155,23 @@ var assertCaliperEvent = function(event, user, course, opts) {
     assert.ok(event.action);
   }
 
-  assert.ok(event.object.id);
-  if (opts.object) {
-    _.forOwn(opts.object, function(value, key) {
-      if (key === 'extensions') {
-        _.forOwn(value, function(extensionValue, extensionKey) {
-          assert.deepEqual(extensionValue, event.object.extensions[extensionKey]);
-        });
-      } else {
-        assert.deepEqual(value, event.object[key]);
-      }
-    });
+  if (_.isString(event.object)) {
+    if (opts.object) {
+      assert.strictEqual(event.object, opts.object);
+    }
+  } else {
+    assert.ok(event.object.id);
+    if (opts.object) {
+      _.forOwn(opts.object, function(value, key) {
+        if (key === 'extensions') {
+          _.forOwn(value, function(extensionValue, extensionKey) {
+            assert.deepEqual(extensionValue, event.object.extensions[extensionKey]);
+          });
+        } else {
+          assert.deepEqual(value, event.object[key]);
+        }
+      });
+    }
   }
 
   if (user) {
@@ -172,6 +190,12 @@ var assertCaliperEvent = function(event, user, course, opts) {
     assert.ok(event.membership.member.endsWith(user.id));
     assert.ok(event.membership.organization.endsWith(course.id));
     assert.strictEqual(event.membership.type, 'Membership');
+  }
+
+  if (opts.generated) {
+    _.forOwn(opts.generated, function(value, key) {
+      assert.deepEqual(value, event.generated[key]);
+    });
   }
 
   if (opts.extensions) {

--- a/node_modules/col-assets/lib/rest.js
+++ b/node_modules/col-assets/lib/rest.js
@@ -360,7 +360,7 @@ Collabosphere.apiRouter.post('/assets/:assetId/like', function(req, res) {
     } else {
       event = 'Unlike asset';
     }
-    AnalyticsAPI.track(req.ctx.user, event, AnalyticsAPI.getAssetProperties(asset));
+    AnalyticsAPI.track(req.ctx.user, event, AnalyticsAPI.getAssetProperties(asset), asset);
 
     return res.sendStatus(200);
   });


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1128

'Disliking' is of course not supported in the current UX, but we may as well shoot for consistency.

Like and dislike events generate a Caliper AnnotationEntity with id derived from the asset and user. 'Unliking' (i.e., removing a previous like or dislike) is then modeled as a Caliper 'remove' action taking that AnnotationEntity as its object.