### PR TITLE
COL-1085, migration script > Canvas filesystem to Amazon S3

### DIFF
--- a/node_modules/col-analytics/tests/test-caliper.js
+++ b/node_modules/col-analytics/tests/test-caliper.js
@@ -292,7 +292,7 @@ describe('Analytics', function() {
 
           AnalyticsTestsUtil.onExpectationResult(callback);
 
-          AssetsTestsUtil.assertFileCreateAndStorage(client, course, _.noop);
+          AssetsTestsUtil.assertFileCreateAndStorage(client, course, null, _.noop);
         });
       });
 

--- a/node_modules/col-assets/lib/migrate.js
+++ b/node_modules/col-assets/lib/migrate.js
@@ -25,17 +25,21 @@
 
 var _ = require('lodash');
 var async = require('async');
+var config = require('config');
 var contentDisposition = require('content-disposition');
 var fs = require('fs');
 var Joi = require('joi');
+var moment = require('moment-timezone');
 var os = require('os');
 var path = require('path');
 var request = require('request');
+var timezone = config.get('timezone');
 
 var AssetsAPI = require('col-assets');
 var CategoriesAPI = require('col-categories');
 var DB = require('col-core/lib/db');
 var log = require('col-core/lib/logger')('col-assets/migrate');
+var Storage = require('col-core/lib/storage');
 var UserAPI = require('col-users');
 var UserConstants = require('col-users/lib/constants');
 
@@ -324,12 +328,12 @@ var migrateLink = function(toCtx, link, categories, callback) {
  * Migrate a file asset
  *
  * @param  {Context}          toCtx               Context for user associated with destination assets
- * @param  {Asset}            file                The file to migrate
+ * @param  {Asset}            asset               The asset (file) to migrate
  * @param  {Number[]}         categories          Destination categories for the file asset
  * @param  {String}           downloadDir         Path for temporary download directory
  * @param  {Function}         callback            Standard callback function
  */
-var migrateFile = function(toCtx, file, categories, downloadDir, callback) {
+var migrateFile = function(toCtx, asset, categories, downloadDir, callback) {
   fs.stat(downloadDir, function(err, stat) {
     // Download the file to a temporary folder
     if (err) {
@@ -340,42 +344,84 @@ var migrateFile = function(toCtx, file, categories, downloadDir, callback) {
         return callback(err);
       }
     }
-    request(file.download_url).on('response', function(res) {
-      // Extract the name of the file
-      var disposition = contentDisposition.parse(res.headers['content-disposition']);
-      var filename = disposition.parameters.filename;
-      var filePath = path.join(downloadDir, filename);
 
-      // Function that will clean up the temporary file
-      var cleanTempFile = function(err) {
+    if (Storage.isS3Uri(asset.download_url)) {
+      var s3ObjectKey = asset.download_url;
+
+      Storage.getObject(s3ObjectKey, function(data) {
+        var filename = _.split(s3ObjectKey, '/').pop();
+        var filePath = path.join(downloadDir, filename);
+
+        downloadFileAndCreateAsset(toCtx, data.createReadStream(), filePath, asset, categories, function(err) {
+          // Clean up
+          fs.unlink(filePath, function() {
+            return callback(err);
+          });
+        });
+      });
+
+    } else if (_.startsWith(asset.download_url, 'file://')) {
+      var sourceFile = asset.download_url.substring(7);
+      var filename = _.split(sourceFile, '/').pop();
+      var timestamp = moment().tz(timezone).format('YYYY-MM-DD_HHmmss');
+      var filePath = path.join(downloadDir, timestamp + '_' + filename);
+
+      downloadFileAndCreateAsset(toCtx, fs.createReadStream(sourceFile, {autoClose: true}), filePath, asset, categories, function(err) {
+        // Clean up
         fs.unlink(filePath, function() {
           return callback(err);
         });
-      };
-
-      res.pipe(fs.createWriteStream(filePath))
-      .on('error', cleanTempFile)
-      .on('finish', function() {
-
-        // Create the file asset
-        AssetsAPI.createFile(toCtx, file.title, {
-          'mimetype': file.mime,
-          'file': filePath,
-          'filename': file.title
-        }, {
-          'categories': categories,
-          'description': file.description || undefined,
-          'thumbnail_url': file.thumbnail_url || undefined,
-          'image_url': file.image_url || undefined,
-          'embed_id': file.embed_id || undefined,
-          'embed_key': file.embed_key || undefined,
-          'embed_code': file.embed_code || undefined
-        }, cleanTempFile);
       });
-    });
+
+    } else {
+      request(asset.download_url).on('response', function(res) {
+        // Extract the name of the file
+        var disposition = contentDisposition.parse(res.headers['content-disposition']);
+        var filename = disposition.parameters.filename;
+        var filePath = path.join(downloadDir, filename);
+
+        downloadFileAndCreateAsset(toCtx, res, filePath, asset, categories, function(err) {
+          // Clean up
+          fs.unlink(filePath, function() {
+            return callback(err);
+          });
+        });
+      });
+    }
   });
 };
 
+/**
+ * Download file and create an asset with appropriate metadata
+ *
+ * @param  {Context}          toCtx               Context for user associated with destination assets
+ * @param  {Stream}           stream              A readable stream
+ * @param  {String}           filePath            Path to file reserved for temporary download
+ * @param  {Asset}            asset               The asset (file) to migrate
+ * @param  {Number[]}         categories          Destination categories for the file asset
+ * @param  {Function}         callback            Standard callback function
+ */
+var downloadFileAndCreateAsset = function(toCtx, stream, filePath, asset, categories, callback) {
+  stream.pipe(fs.createWriteStream(filePath))
+        .on('error', callback)
+        .on('finish', function() {
+
+          // Create the file asset
+          AssetsAPI.createFile(toCtx, asset.title, {
+            'mimetype': asset.mime,
+            'file': filePath,
+            'filename': asset.title
+          }, {
+            'categories': categories,
+            'description': asset.description || undefined,
+            'thumbnail_url': asset.thumbnail_url || undefined,
+            'image_url': asset.image_url || undefined,
+            'embed_id': asset.embed_id || undefined,
+            'embed_key': asset.embed_key || undefined,
+            'embed_code': asset.embed_code || undefined
+          }, callback);
+        });
+};
 
 /**
  * Create mock contexts for destination course and user
@@ -386,7 +432,6 @@ var migrateFile = function(toCtx, file, categories, downloadDir, callback) {
  * @param  {Function}     callback.userCtx     Mock context for destination user
  * @param  {Function}     callback.adminCtx    Mock admin context for destination course
  */
-
 var createDestinationContexts = function(destinationUserId, callback) {
   UserAPI.getUser(destinationUserId, function(err, destinationUser) {
     // Create mock context for destination user

--- a/node_modules/col-assets/tests/test-assets.js
+++ b/node_modules/col-assets/tests/test-assets.js
@@ -111,8 +111,8 @@ describe('Assets', function() {
        * Test verifies file creation against Amazon S3
        */
       it('can be created and stored', function(callback) {
-        AssetsTestUtil.setUpAmazonS3BackedCourse(function(client, course, user) {
-          AssetsTestUtil.assertFileCreateAndStorage(client, course, function(asset) {
+        AssetsTestUtil.setUpAmazonS3BackedCourse(null, function(client, course, user) {
+          AssetsTestUtil.assertFileCreateAndStorage(client, course, null, function(asset) {
             client.assets.getAsset(course, asset.id, null, function(err, asset) {
               assert.ok(asset);
               assert.ok(Storage.isS3Uri(asset.download_url));
@@ -127,7 +127,7 @@ describe('Assets', function() {
        * Test that verifies validation when creating a new file asset
        */
       it('is validated', function(callback) {
-        AssetsTestUtil.setUpAmazonS3BackedCourse(function(client, course, user) {
+        AssetsTestUtil.setUpAmazonS3BackedCourse(null, function(client, course, user) {
           // Missing file
           AssetsTestUtil.assertCreateFileFails(client, course, 'UC Berkeley', null, null, 400, function() {
             // Invalid file
@@ -157,7 +157,7 @@ describe('Assets', function() {
         TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
           assert.ok(!Storage.useAmazonS3(course));
 
-          AssetsTestUtil.assertFileCreateAndStorage(client, course, function(asset) {
+          AssetsTestUtil.assertFileCreateAndStorage(client, course, null, function(asset) {
             assert.ok(asset);
             assert.ok(asset.download_url);
             assert.ok(!Storage.isS3Uri(asset.download_url));

--- a/node_modules/col-assets/tests/test-migrate.js
+++ b/node_modules/col-assets/tests/test-migrate.js
@@ -26,11 +26,10 @@
 var _ = require('lodash');
 var assert = require('assert');
 
+var AssetsTestUtil = require('./util');
 var CategoriesTestUtil = require('col-categories/tests/util');
 var TestsUtil = require('col-tests');
 var UsersTestUtil = require('col-users/tests/util');
-
-var AssetsTestUtil = require('./util');
 
 describe('Migrate', function() {
 
@@ -85,6 +84,57 @@ describe('Migrate', function() {
           });
         });
       });
+    });
+
+    /**
+     * Test that verifies migration from legacy filesystem to Amazon S3
+     */
+    it('migrates file from Canvas filesystem to Amazon S3', function(callback) {
+      var course = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+      var instructor = TestsUtil.generateInstructor(global.tests.canvas.ucberkeley);
+      var categoryName = 'Category 1';
+
+      // Instructor is teaching course with files in Canvas filesystem
+      TestsUtil.getAssetLibraryClient(null, course, instructor, function(client, course, instructor) {
+
+        CategoriesTestUtil.assertCreateCategory(client, course, categoryName, function(category) {
+
+          // Put file to Canvas filesystem
+          var opts = {'categories': category.id};
+          AssetsTestUtil.assertFileCreateAndStorage(client, course, opts, function(sourceAsset) {
+
+            // Target course has files in Amazon S3
+            AssetsTestUtil.setUpAmazonS3BackedCourse(instructor, function(s3Client, s3Course, s3Instructor) {
+
+              // Migrate assets from instructor1's course to Amazon S3 backed course
+              UsersTestUtil.assertGetMe(s3Client, s3Course, null, function(s3me) {
+                AssetsTestUtil.assertMigrationCompletes(client, course, s3me.id, 3, 0, function() {
+
+                  // Get s3Instructor's assets in Amazon S3 back course
+                  AssetsTestUtil.assertGetAssets(s3Client, s3Course, null, null, null, null, 3, function(assets) {
+
+                    // Verify that asset was migrated and categories preserved
+                    AssetsTestUtil.assertGetMigratedAsset(s3Client, s3Course, assets.results[0].id, [categoryName], function() {
+
+                      return callback();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    /**
+     * Test that verifies migration from legacy filesystem to Amazon S3
+     */
+    it('migrates file from Amazon S3 to Amazon S3', function(callback) {
+
+      // TODO
+
+      return callback();
     });
 
     /**

--- a/node_modules/col-assets/tests/util.js
+++ b/node_modules/col-assets/tests/util.js
@@ -481,7 +481,7 @@ var assertCreateFile = module.exports.assertCreateFile = function(client, course
 
   // The file will be uploaded to Canvas
   if (!TestsUtil.expectAmazonS3(course)) {
-    CanvasTestsUtil.mockFileUpload(course);
+    CanvasTestsUtil.mockFileUpload(course, file);
   }
 
   client.assets.createFile(course, title, file, opts, function(err, asset, response) {
@@ -1309,13 +1309,16 @@ var setupPinnedAssets = module.exports.setupPinnedAssets = function(callback) {
 
 /**
  * Create a course in which Amazon S3 is used for file storage
- * @param  {Function}           callback                        Standard callback function
+ *
+ * @param  {User}               [user]                    Optional user to be attached to the client generated
+ * @param  {Function}           callback                  Standard callback function
  * @throws {AssertionError}
  */
-var setUpAmazonS3BackedCourse = module.exports.setUpAmazonS3BackedCourse = function(callback) {
-  var course = TestsUtil.generateCourse(global.tests.canvas.ucdavis);
+var setUpAmazonS3BackedCourse = module.exports.setUpAmazonS3BackedCourse = function(user, callback) {
+  var course = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
+  var user = user || TestsUtil.generateUser(global.tests.canvas.ucberkeley);
 
-  TestsUtil.getAssetLibraryClient(null, course, null, function(client, course, user) {
+  TestsUtil.getAssetLibraryClient(null, course, user, function(client, course, user) {
     // Course created_at date determines Amazon S3 (storage) eligibility
     var values = {
       'created_at': moment("9999-12-31", "YYYY-MM-DD").tz(config.get('timezone'))
@@ -1325,6 +1328,8 @@ var setUpAmazonS3BackedCourse = module.exports.setUpAmazonS3BackedCourse = funct
 
       CourseTestUtil.getDbCourse(course.id, function(dbCourse) {
         assert.ok(TestsUtil.expectAmazonS3(dbCourse));
+        // Give course the verified created_at date
+        course.created_at = dbCourse.created_at;
 
         callback(client, course, user);
       });
@@ -1572,23 +1577,24 @@ var assertRemixWhiteboardFails = module.exports.assertRemixWhiteboardFails = fun
  *
  * @param  {RestClient}         client                          The REST client to make the request with
  * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
+ * @param  {Number[]}           [opts.categories]               The ids of the categories to which the file should be associated
  * @param  {Function}           callback                        Standard callback function
  * @throws {AssertionError}                                     Error thrown when an assertion failed
  */
-var assertFileCreateAndStorage = module.exports.assertFileCreateAndStorage = function(client, course, callback) {
+var assertFileCreateAndStorage = module.exports.assertFileCreateAndStorage = function(client, course, opts, callback) {
   // Create a file asset with no optional metadata
-  assertCreateFile(client, course, 'UC Davis', getFileStream('logo-ucberkeley.png'), null, function(asset) {
+  assertCreateFile(client, course, 'UC Davis', getFileStream('logo-ucberkeley.png'), opts, function(asset) {
 
     // Create a file asset with no title. This should default the title to the name of the file
-    assertCreateFile(client, course, null, getFileStream('logo-ucberkeley.png'), null, function(asset) {
+    assertCreateFile(client, course, null, getFileStream('logo-ucberkeley.png'), opts, function(asset) {
       assert.equal(asset.title, 'logo-ucberkeley.png');
 
       // Create a file asset with optional metadata
-      var opts = {
+      var mergedOpts = _.merge(opts, {
         'description': 'University of California, Berkeley logo',
         'source': 'http://www.universityofcalifornia.edu/uc-system'
-      };
-      assertCreateFile(client, course, 'UC Berkeley', getFileStream('logo-ucberkeley.png'), opts, function(asset) {
+      });
+      assertCreateFile(client, course, 'UC Berkeley', getFileStream('logo-ucberkeley.png'), mergedOpts, function(asset) {
 
         return callback(asset);
       });

--- a/node_modules/col-canvas/tests/util.js
+++ b/node_modules/col-canvas/tests/util.js
@@ -25,6 +25,7 @@
 
 var _ = require('lodash');
 var assert = require('assert');
+var path = require('path');
 var url = require('url');
 var util = require('util');
 
@@ -35,10 +36,11 @@ var TestsUtil = require('col-tests/lib/util');
 /**
  * Mock all the requests that are involved in uploading a file to Canvas
  *
- * @param  {Course}   course    The course to which the file will be uploaded
- * @return {String}   fileUrl   The final URL for the uploaded file
+ * @param  {Course}    course                 The course to which the file will be uploaded
+ * @param  {Boolean}   [file]                 [Optional] Expect asset.file_download to serve a copy of this file
+ * @return {String}    fileUrl                The final URL for the uploaded file
  */
-var mockFileUpload = module.exports.mockFileUpload = function(course) {
+var mockFileUpload = module.exports.mockFileUpload = function(course, file) {
   var appServer = TestsUtil.getMockedCanvasAppServer(course.canvas);
   var apiDomain = course.canvas.canvas_api_domain;
 
@@ -68,9 +70,10 @@ var mockFileUpload = module.exports.mockFileUpload = function(course) {
 
   // 1c. Ask Canvas to upload the file
   var id = _.random(100000);
+  var downloadUrl = file ? 'file://' + file.path : util.format('http://%s/files/%d/download', apiDomain, id);
   var fileInfo = {
     'id': id,
-    'url': util.format('http://%s/files/%d/download', apiDomain, id),
+    'url': downloadUrl,
     'content-type': 'text/plain'
   };
   var askUrl = util.format('/api/v1/courses/%d/files', course.canvas_course_id || course.id);
@@ -236,7 +239,7 @@ var mockGetSubmissions = module.exports.mockGetSubmissions = function(course, as
           TestsUtil.getMockedCanvasAppServer(course.canvas).expect(mockedRequest);
 
           // The upload request
-          attachment.filePath = mockFileUpload(course);
+          attachment.filePath = mockFileUpload(course, false);
 
           // Any duplicates of this attachment should not be processed a second time
           attachment.expectProcessing = false;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1085

The migrate_assets script will download file to temp dir, upload to S3 and record resulting `s3://` address. The `mockFileUpload` op in our test utils did not produce a valid download_url therefore I extended the test util and our migrate script to recognize `file://` URIs. (Note: temp downloads are timestamped to avoid collisions.)