### PR TITLE
COL-1156, Migrate deleted assets, properly record failures and 'csv_directory' arg is now required

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,7 +11,7 @@ rules:
     - multiline: true
       minItems: 4
   array-bracket-spacing:
-    - 1
+    - 2
     - never
     - singleValue: true
   array-element-newline:

--- a/node_modules/col-analytics/tests/test-caliper.js
+++ b/node_modules/col-analytics/tests/test-caliper.js
@@ -692,7 +692,7 @@ describe('Analytics', function() {
     describe('Whiteboard creation and editing', function() {
 
       it('tracks whiteboard creation', function(callback) {
-        AnalyticsTestsUtil.allowCaliperActions(['NavigatedTo']);
+        AnalyticsTestsUtil.allowCaliperActions([ 'NavigatedTo' ]);
         TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
 
           AnalyticsTestsUtil.expectCaliperEvent(user, course, {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "del": "2.2.2",
     "ejs": "2.5.5",
     "email-templates": "2.5.4",
-    "eslint": "4.0.0",
+    "eslint": "4.3.0",
     "event-stream": "3.3.4",
     "express": "4.14.1",
     "express-busboy": "5.0.0",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1154
https://jira.ets.berkeley.edu/jira/browse/COL-1156

* We want to migrate deleted assets in case they are later undeleted 
* The SuiteC db will certainly have invalid Canvas URLs (especially in test environments); a "failures" CSV file makes sense
* Finally, the CSVs generated by this script are important and we want the executor of the script to be well aware of their location. Thus, we now require `--csv_directory`