### PR TITLE
COL-1159, if asset image is in Amazon S3 then use /download route to grab it

### DIFF
--- a/public/app/whiteboards/board/whiteboardsBoardDirective.js
+++ b/public/app/whiteboards/board/whiteboardsBoardDirective.js
@@ -1624,6 +1624,11 @@
             }
           }
 
+          if (_.startsWith(asset.image_url, 's3://')) {
+            // Assets stored in S3 must be pulled from SuiteC route
+            asset.image_url = utilService.getApiUrl('/assets/' + asset.id + '/download');
+          }
+
           // Add the asset to the center of the whiteboard canvas
           fabric.Image.fromURL(asset.image_url, function(element) {
             var canvasCenter = getCanvasCenter();


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1159

whiteboardDirective is not impressed with our half-baked `s3://` protocol.  We must construct URL as seen on asset detail page > download button.