### PR TITLE
COL-1158 Disable Mixpanel in default configuration

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -19,7 +19,7 @@
       "apiKey": "qwertyuiop"
     },
     "mixpanel": {
-      "enabled": true,
+      "enabled": false,
       "apiKey": "qwertyuiop"
     }
   },


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1158

Caliper-related changes to SuiteC analytics config require Mixpanel to be turned off by default. Turning it back on locally in suitec-qa and suitec-prod will be covered in release-specific instructions.