### PR TITLE
COL-1157 Force white background on whiteboard PNG exports

### DIFF
--- a/node_modules/col-whiteboards/data/whiteboardToPng.js
+++ b/node_modules/col-whiteboards/data/whiteboardToPng.js
@@ -248,6 +248,7 @@ fabric.Object.prototype.originX = fabric.Object.prototype.originY = 'center';
 var createCanvas = function(width, height) {
   // Create a canvas of the desired dimensions
   var canvas = fabric.createCanvasForNode(width, height);
+  canvas.backgroundColor = "#fff";
 
   // Add the Helvetica Neueu font so text elements can be rendered correctly
   var fontPath = __dirname + '/HelveticaNeueuLight.ttf';


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1157

It's not clear to me how we were ever getting white backgrounds without this explicit setting, but we can only fit so many mysteries into one day.