### PR TITLE
COL-1166 Tell socket.io not to attempt failing websocket handshake

### DIFF
--- a/public/app/whiteboards/board/whiteboardsBoardDirective.js
+++ b/public/app/whiteboards/board/whiteboardsBoardDirective.js
@@ -78,6 +78,9 @@
         var launchParams = utilService.getLaunchParams();
         if (!$scope.readonly) {
           var socket = io(window.location.origin, {
+            // Websocket handshakes are presently failing on Elastic Beanstalk deployments. Socket.io handles this by falling back to polling.
+            'transport': [ 'polling' ],
+            'upgrade': false,
             'query': 'api_domain=' + launchParams.apiDomain + '&course_id=' + launchParams.courseId + '&whiteboard_id=' + $scope.whiteboard.id
           });
         }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1166

It's unknown why our websocket handshake is currently failing on AWS, but until we get around to investigating, we may as well tell our code not to attempt and error.