### PR TITLE
COL-553, if asset isDeletedOrHidden then deny attempt to view/download

### DIFF
--- a/node_modules/col-assets/lib/rest.js
+++ b/node_modules/col-assets/lib/rest.js
@@ -50,6 +50,9 @@ Collabosphere.apiRouter.get('/assets/:assetId', function(req, res) {
     if (err) {
       return res.status(err.code).send(err.msg);
     }
+    if (AssetsAPI.isDeletedOrHidden(asset)) {
+      return res.status(404).send("The requested asset has been removed");
+    }
 
     // Track the asset view
     if (incrementViews !== false) {
@@ -307,6 +310,9 @@ Collabosphere.apiRouter.get('/assets/:assetId/download', function(req, res) {
   AssetsAPI.getAssetProfile(req.ctx, req.params.assetId, false, function(err, asset) {
     if (err) {
       return res.status(err.code).send(err.msg);
+    }
+    if (AssetsAPI.isDeletedOrHidden(asset)) {
+      return res.status(404).send("The requested asset has been removed");
     }
     if (!asset.download_url) {
       return res.status(404).send("Requested asset has a null or undefined S3 Object Key");


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-553

If asset is deleted or hidden then `/asset/:id` and `/assets/:assetId/download` will return 404, "The requested asset has been removed".