### PR TITLE
COL-1184, poller does not deactivate deleted course sites; for now, deactivate them the hard way

### DIFF
--- a/scripts/20170831-col1184/deactivate_deleted_course_sites.sql
+++ b/scripts/20170831-col1184/deactivate_deleted_course_sites.sql
@@ -1,0 +1,16 @@
+-- The poller does not deactivate deleted course sites.
+-- For now, we deactivate them the hard way: 
+
+UPDATE courses
+SET
+  active = FALSE
+WHERE
+  canvas_course_id IN (1460736, 1461213, 1461536, 1462149, 1462239, 1462466, 1462469, 1462815)
+
+/**** ROLLBACK ****
+
+UPDATE courses
+SET
+  active = TRUE
+WHERE
+  canvas_course_id IN (1460736, 1461213, 1461536, 1462149, 1462239, 1462466, 1462469, 1462815)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1184

You can verify the deleted-ness of these course sites with:
* https://bcourses.berkeley.edu/api/v1/courses/1460736/users
* https://bcourses.berkeley.edu/api/v1/courses/1461213/users
* https://bcourses.berkeley.edu/api/v1/courses/1461536/users
* https://bcourses.berkeley.edu/api/v1/courses/1462149/users
* https://bcourses.berkeley.edu/api/v1/courses/1462239/users
* https://bcourses.berkeley.edu/api/v1/courses/1462466/users
* https://bcourses.berkeley.edu/api/v1/courses/1462469/users
* https://bcourses.berkeley.edu/api/v1/courses/1462815/users
