### PR TITLE
COL-1183 Failure to find activity during delete request is no cause for alarm

### DIFF
--- a/node_modules/col-activities/lib/api.js
+++ b/node_modules/col-activities/lib/api.js
@@ -689,15 +689,8 @@ var deleteActivity = module.exports.deleteActivity = function(course, user, type
       return callback({'code': 500, 'msg': err.message});
     }
 
-    // Return immediately if no activity has been provided
+    // Return immediately if no matching activity is found
     if (!activity) {
-      log.warn({
-        'course': course.id,
-        'user': user.id,
-        'type': type,
-        'objectId': objectId,
-        'objectType': objectType
-      }, 'Tried to delete an activity that could not be found');
       return callback();
     }
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1183

Keep calm. ActivitiesAPI.deleteActivity is used to remove any previous activities that may match certain criteria - for example, as part of creating a like activity, any previous likes are removed. Failure to find a match is quite in the normal course of business and doesn't need to be logged.