### PR TITLE
COL-1196, video_url, on asset detail view, is preview_metadata.converted_video or /assets/:id/download

### DIFF
--- a/public/app/assetlibrary/item/assetLibraryItemController.js
+++ b/public/app/assetlibrary/item/assetLibraryItemController.js
@@ -78,6 +78,8 @@
     // in the hosting Canvas instance.
     utilService.setParentHash({'asset': assetId});
 
+    $scope.getDownloadUrl = utilService.getDownloadUrl;
+
     /**
      * Get the current asset
      *
@@ -96,7 +98,7 @@
             if (asset.pdf_url) {
               asset.embedUrl = '/viewer/viewer.html?file=' + encodeURIComponent(asset.pdf_url);
             } else if (asset.mime && asset.mime.lastIndexOf('video') === 0 && asset.image_url !== null && asset.download_url !== null) {
-              asset.video_url = $sce.trustAsResourceUrl(asset.preview_metadata.converted_video || asset.download_url);
+              asset.video_url = utilService.getVideoUrl(asset);
               asset.height = asset.preview_metadata.image_height;
               asset.width = asset.preview_metadata.image_width;
             }
@@ -165,14 +167,6 @@
         // Indicate that the asset has been updated
         $scope.$emit('assetLibraryAssetUpdated', $scope.asset);
       });
-    };
-
-    /**
-     * @param  {Object}               asset         Asset being viewed by user
-     * @return {String}                             URL to download asset file
-     */
-    $scope.getDownloadUrl = function(asset) {
-      return utilService.getApiUrl('/assets/' + assetId + '/download');
     };
 
     /**

--- a/public/app/shared/utilService.js
+++ b/public/app/shared/utilService.js
@@ -27,7 +27,7 @@
 
   'use strict';
 
-  angular.module('collabosphere').service('utilService', function(analyticsService, me, $cookies, $location, $q, $timeout) {
+  angular.module('collabosphere').service('utilService', function(analyticsService, me, $cookies, $location, $q, $sce, $timeout) {
 
     // Cache the API domain and Course ID that were passed in through
     // the iFrame launch URL. These variables need to be used to construct
@@ -503,18 +503,45 @@
       });
     };
 
+    /**
+     * @param  {Object}               asset         Asset being viewed by user
+     * @return {String}                             URL to download asset file
+     */
+    var getDownloadUrl = function(asset) {
+      return getApiUrl('/assets/' + asset.id + '/download');
+    };
+
+    /**
+     * @param  {Object}     asset         Asset being viewed by user
+     * @return {String}                   Fully qualified URL if asset mime-type is video; otherwise null.
+     */
+    var getVideoUrl = function(asset) {
+      var url = null;
+      if (_.startsWith(asset.mime, 'video/')) {
+        if (asset.preview_metadata.converted_video) {
+          url = asset.preview_metadata.converted_video;
+        } else {
+          url = getDownloadUrl(asset);
+        }
+        url = url && $sce.trustAsResourceUrl(url);
+      }
+      return url;
+    };
+
     return {
       'appendOrdinalSuffix': appendOrdinalSuffix,
       'buildSearchResultsMessage': buildSearchResultsMessage,
       'getAdvancedSearchId': getAdvancedSearchId,
       'getApiUrl': getApiUrl,
       'getColorConstants': getColorConstants,
+      'getDownloadUrl': getDownloadUrl,
       'getLaunchParams': getLaunchParams,
       'getParentUrlData': getParentUrlData,
       'getScrollInformation': getScrollInformation,
       'getScrollPosition': getScrollPosition,
       'getToolHref': getToolHref,
       'getToolUrl': getToolUrl,
+      'getVideoUrl': getVideoUrl,
       'narrowSearchPerSort': narrowSearchPerSort,
       'resizeIFrame': resizeIFrame,
       'scrollTo': scrollTo,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1196

When it comes to `download_url` and `video_url`, SuiteC server-side is a proxy to Amazon S3.
