### PR TITLE
COL-1194, hidden assets can be viewed by only collaborators and admins

### DIFF
--- a/node_modules/col-assets/lib/api.js
+++ b/node_modules/col-assets/lib/api.js
@@ -1145,15 +1145,65 @@ var deleteAssets = module.exports.deleteAssets = function(ctx, assetIds, callbac
 };
 
 /**
+ * @param   {Category[]}    categories       The categories to review
+ * @return  {boolean}                        True if empty or at least one category is visible
+ */
+var isEmptyOrHasVisible = function(categories) {
+  return _.isEmpty(categories) || _.find(categories, 'visible');
+};
+
+/**
  * Returns true if the asset is hidden, deleted, or associated with only hidden categories.
  *
  * @param   {Asset}        asset             The asset to check for deleted or hidden status
  * @return  {boolean}                        True if deleted or hidden
  */
 var isDeletedOrHidden = module.exports.isDeletedOrHidden = function(asset) {
-  return !asset.visible || !!asset.deleted_at || !(_.isEmpty(asset.categories) || _.find(asset.categories, 'visible'));
+  return !asset.visible || !!asset.deleted_at || !isEmptyOrHasVisible(asset.categories);
 };
 
+/**
+ * Returns true user is authorized to view the specified asset.
+ *
+ * @param  {User}         user              The user viewing the event
+ * @param  {Asset}        asset             The asset to check for hidden status
+ * @return {boolean}                        True if not deleted or not hidden from this particular user
+ */
+var canUserView = module.exports.canUserView = function(user, asset) {
+  var canUserView = false;
+
+  if (asset.deleted_at) {
+    canUserView = false;
+  } else if (user.is_admin || _.find(asset.users, {'id': user.id})) {
+    canUserView = true;
+  } else {
+    var hidden = !asset.visible || !isEmptyOrHasVisible(asset.categories);
+
+    if (hidden) {
+      var params = {
+        'user_id': user.id,
+        'asset_id': asset.id
+      }
+      var whiteboardMembershipQuery = `SELECT count(*)
+        FROM whiteboard_members m
+        JOIN whiteboard_elements e ON e.whiteboard_id = m.whiteboard_id
+        WHERE m.user_id = :user_id AND e.asset_id = :asset_id`;
+
+      DB.getSequelize().query(whiteboardMembershipQuery, {'replacements': params}).complete(function(err, results) {
+        if (err) {
+          log.error({'err': err, 'user': user.id, 'asset': asset.id}, 'Error retrieving whiteboards associated with asset');
+        }
+        var count = results[0][0].count;
+
+        return count > 0;
+      });
+    } else {
+      canUserView = true;
+    }
+  }
+
+  return canUserView;
+};
 
 /* BADGES */
 

--- a/node_modules/col-assets/lib/rest.js
+++ b/node_modules/col-assets/lib/rest.js
@@ -53,6 +53,9 @@ Collabosphere.apiRouter.get('/assets/:assetId', function(req, res) {
     if (!!asset.deleted_at) {
       return res.status(404).send("The requested asset has been removed");
     }
+    if (!AssetsAPI.canUserView(req.ctx.user, asset)) {
+      return res.status(403).send("Sorry, you are not authorized to view the requested asset.");
+    }
 
     // Track the asset view
     if (incrementViews !== false) {
@@ -313,6 +316,9 @@ Collabosphere.apiRouter.get('/assets/:assetId/download', function(req, res) {
     }
     if (!!asset.deleted_at) {
       return res.status(404).send("The requested asset has been removed");
+    }
+    if (!AssetsAPI.canUserView(req.ctx.user, asset)) {
+      return res.status(403).send("Sorry, you are not authorized to download the requested asset.");
     }
     if (!asset.download_url) {
       return res.status(404).send("Requested asset has a null or undefined S3 Object Key");

--- a/node_modules/col-assets/tests/test-assets.js
+++ b/node_modules/col-assets/tests/test-assets.js
@@ -316,8 +316,9 @@ describe('Assets', function() {
 
         // Create a link without specifying its visibility
         AssetsTestUtil.assertCreateLink(client, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(visibleAsset1) {
-          // Create a hidden link
-          AssetsTestUtil.assertCreateLink(client, course, 'UC Berkeley', 'http://www.berkeley.edu/', {'visible': false}, function(hiddenAsset) {
+          // Create a hidden file
+          AssetsTestUtil.assertCreateFile(client, course, 'UC Berkeley', AssetsTestUtil.getFileStream('logo-ucberkeley.png'), {'visible': false}, function(hiddenAsset) {
+
             // Create a link with visibility explicitly set to true
             AssetsTestUtil.assertCreateLink(client, course, 'UC Irvine', 'http://www.uci.edu/', {'visible': true}, function(visibleAsset2) {
 
@@ -326,7 +327,19 @@ describe('Assets', function() {
                 AssetsTestUtil.assertAsset(assets.results[0], {'expectedAsset': visibleAsset2});
                 AssetsTestUtil.assertAsset(assets.results[1], {'expectedAsset': visibleAsset1});
 
-                return callback();
+                // Despite the 'hidden' status, user CAN view the asset via the asset detail page.
+                AssetsTestUtil.assertGetAsset(client, course, hiddenAsset.id, hiddenAsset, 0, function(asset) {
+                  AssetsTestUtil.assertAssetDownloadSucceeds(client, course, hiddenAsset.id, function() {
+
+                    TestsUtil.getAssetLibraryClient(null, null, null, function(client2, course2, user2) {
+                      // Download of hidden asset fails for other users
+                      AssetsTestUtil.assertAssetDownloadFails(client2, course2, hiddenAsset.id, 404, function() {
+
+                        return callback();
+                      });
+                    });
+                  });
+                });
               });
             });
           });

--- a/node_modules/col-assets/tests/util.js
+++ b/node_modules/col-assets/tests/util.js
@@ -1062,6 +1062,23 @@ var assertAssetDownloadFails = module.exports.assertAssetDownloadFails = functio
 };
 
 /**
+ * Authorized download
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
+ * @param  {Number}             assetId                         The id of the asset to download
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertAssetDownloadSucceeds = module.exports.assertAssetDownloadSucceeds = function(client, course, assetId, callback) {
+  client.assets.downloadAsset(course, assetId, function(err) {
+    assert.ok(!err);
+
+    return callback();
+  });
+};
+
+/**
  * Assert that an asset can be liked or disliked
  *
  * @param  {RestClient}         client                          The REST client to make the request with


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1194

Putting this logic at `/asset/:asset_id` and `/download/...` was a bit tougher than expected. I use a db query instead of WhiteboardsAPI call, which I believe would be more expensive. (See `badgeEligibleAssetsQuery` for similar decision.)