### PR TITLE
COL-1108, post S3-migration: remove code associated with file storage in Canvas

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -7,7 +7,6 @@
     "s3": {
       "awsSdkPackage": "aws-sdk",
       "bucket": "s3-bucket-development",
-      "cutoverDate": "2017-08-14",
       "region": "us-west-2",
       "version": "2006-03-01"
     }

--- a/config/test.js
+++ b/config/test.js
@@ -36,8 +36,7 @@ module.exports = {
   'aws': {
     's3': {
       'awsSdkPackage': 'mock-aws-s3',
-      'bucket': 's3-bucket-test',
-      'cutoverDate': '9999-12-31'
+      'bucket': 's3-bucket-test'
     }
   },
   'db': {

--- a/config/travis.js
+++ b/config/travis.js
@@ -36,8 +36,7 @@ module.exports = {
   'aws': {
     's3': {
       'awsSdkPackage': 'mock-aws-s3',
-      'bucket': 's3-bucket-travis',
-      'cutoverDate': '9999-12-31'
+      'bucket': 's3-bucket-travis'
     }
   },
   'db': {

--- a/node_modules/col-assets/lib/api.js
+++ b/node_modules/col-assets/lib/api.js
@@ -31,7 +31,6 @@ var util = require('util');
 
 var ActivitiesAPI = require('col-activities');
 var AssetsUtil = require('./util');
-var CanvasAPI = require('col-canvas');
 var CategoriesAPI = require('col-categories');
 var Collabosphere = require('col-core');
 var CollabosphereConstants = require('col-core/lib/constants');
@@ -720,63 +719,33 @@ var createFile = module.exports.createFile = function(ctx, title, file, opts, ca
     'visible': opts.visible
   };
 
-  if (Storage.useAmazonS3(ctx.course)) {
-    // Upload the file to Amazon S3
-    Storage.storeAsset(ctx.course.id, file.file, function(err, s3Uri, contentType) {
+  // Upload the file to Amazon S3
+  Storage.storeAsset(ctx.course.id, file.file, function(err, s3Uri, contentType) {
+    if (err) {
+      return callback(err);
+    }
+
+    var asset = DB.Asset.build(_.merge(assetProperties, {
+      'download_url': s3Uri,
+      'mime': contentType
+    }));
+
+    createAsset(ctx, asset, opts, function(err, asset) {
       if (err) {
+        log.error({'err': err, 'course': ctx.course.id, 'file': file.file}, 'Failed to create asset');
         return callback(err);
       }
 
-      var asset = DB.Asset.build(_.merge(assetProperties, {
-        'download_url': s3Uri,
-        'mime': contentType
-      }));
-
-      createAsset(ctx, asset, opts, function(err, asset) {
+      // Clean up temp space
+      fs.unlink(file.file, function(err) {
         if (err) {
-          log.error({'err': err, 'course': ctx.course.id, 'file': file.file}, 'Failed to create asset');
-          return callback(err);
+          log.warn({'err': err, 'file': file.file, 'asset': asset.id}, 'Failed to remove file from temp space');
         }
 
-        // Clean up temp space
-        fs.unlink(file.file, function(err) {
-          if (err) {
-            log.warn({'err': err, 'file': file.file, 'asset': asset.id}, 'Failed to remove file from temp space');
-          }
-
-          return callback(err, asset);
-        });
+        return callback(err, asset);
       });
     });
-
-  } else {
-    // Upload the file to Canvas (deprecated)
-    CanvasAPI.uploadFileToCanvas(ctx, file.file, null, function(err, canvasItem) {
-      if (err) {
-        return callback(err);
-      }
-
-      var asset = DB.Asset.build(_.merge(assetProperties, {
-        'download_url': canvasItem.url,
-        'mime': canvasItem['content-type']
-      }));
-
-      createAsset(ctx, asset, opts, function(err, asset) {
-        if (err) {
-          return callback(err);
-        }
-
-        // Clean up temp space
-        fs.unlink(file.file, function(err) {
-          if (err) {
-            log.warn({'err': err, 'file': file.file, 'asset': asset.id}, 'Failed to remove file from temp space');
-          }
-
-          return callback(err, asset);
-        });
-      });
-    });
-  }
+  });
 };
 
 /**

--- a/node_modules/col-assets/tests/test-assets.js
+++ b/node_modules/col-assets/tests/test-assets.js
@@ -148,48 +148,6 @@ describe('Assets', function() {
         });
       });
     });
-
-    describe('file in Canvas filesystem', function() {
-
-      /**
-       * Test verifies file creation against Canvas
-       */
-      it('can be created and stored', function(callback) {
-        TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
-          assert.ok(!Storage.useAmazonS3(course));
-
-          AssetsTestUtil.assertFileCreateAndStorage(client, course, null, function(assets) {
-            assert.ok(!Storage.isS3Uri(assets[0].download_url));
-
-            return callback();
-          });
-        });
-      });
-
-      /**
-       * Test that verifies validation when creating a new file asset
-       */
-      it('is validated', function(callback) {
-        TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
-          // Missing file
-          AssetsTestUtil.assertCreateFileFails(client, course, 'UC Berkeley', null, null, 400, function() {
-            // Invalid file
-            AssetsTestUtil.assertCreateFileFails(client, course, 'UC Berkeley', 'invalid file', null, 400, function() {
-              AssetsTestUtil.assertCreateFileFails(client, course, 'UC Berkeley', '42', null, 400, function() {
-
-                // Invalid source
-                AssetsTestUtil.assertCreateFileFails(client, course, 'UC Berkeley', AssetsTestUtil.getFileStream('logo-ucberkeley.png'), {'source': 'invalid url'}, 400, function() {
-                  AssetsTestUtil.assertCreateFileFails(client, course, 'UC Berkeley', AssetsTestUtil.getFileStream('logo-ucberkeley.png'), {'source': '/invalidurl'}, 400, function() {
-
-                    return callback();
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    });
   });
 
   describe('Get asset', function() {

--- a/node_modules/col-assets/tests/test-migrate.js
+++ b/node_modules/col-assets/tests/test-migrate.js
@@ -87,50 +87,6 @@ describe('Migrate', function() {
     });
 
     /**
-     * Test that verifies migration from legacy filesystem to Amazon S3
-     */
-    it('migrates files from Canvas filesystem to Amazon S3', function(callback) {
-      var course = TestsUtil.generateCourse(global.tests.canvas.ucberkeley);
-      var instructor = TestsUtil.generateInstructor(global.tests.canvas.ucberkeley);
-      var categoryName = 'Category 1';
-
-      // Instructor is teaching course with files in Canvas filesystem
-      TestsUtil.getAssetLibraryClient(null, course, instructor, function(client, course, instructor) {
-
-        CategoriesTestUtil.assertCreateCategory(client, course, categoryName, function(category) {
-
-          // Put file to Canvas filesystem
-          var opts = {'categories': category.id};
-          AssetsTestUtil.assertFileCreateAndStorage(client, course, opts, function(sourceAssets) {
-            assert.ok(_.startsWith(sourceAssets[0].download_url, 'file://'));
-
-            // Target course has files in Amazon S3
-            AssetsTestUtil.setUpAmazonS3BackedCourse(instructor, function(s3Client, s3Course, s3Instructor) {
-
-              // Migrate assets from instructor1's course to Amazon S3 backed course
-              UsersTestUtil.assertGetMe(s3Client, s3Course, null, function(s3me) {
-                AssetsTestUtil.assertMigrationCompletes(client, course, s3me.id, 3, 0, function() {
-
-                  // Get s3Instructor's assets in Amazon S3 back course
-                  AssetsTestUtil.assertGetAssets(s3Client, s3Course, null, null, null, null, 3, function(assets) {
-                    var asset = assets.results[0];
-                    assert.ok(_.startsWith(asset.download_url, 's3://'));
-
-                    // Verify that asset was migrated and categories preserved
-                    AssetsTestUtil.assertGetMigratedAsset(s3Client, s3Course, asset.id, [categoryName], function() {
-
-                      return callback();
-                    });
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    });
-
-    /**
      * Test that verifies migration from a course directory in Amazon S3 to a different course directory in Amazon S3
      */
     it('migrates files from Amazon S3 to Amazon S3', function(callback) {

--- a/node_modules/col-assets/tests/util.js
+++ b/node_modules/col-assets/tests/util.js
@@ -479,11 +479,6 @@ var assertCreateLinkBookmarkletFails = module.exports.assertCreateLinkBookmarkle
 var assertCreateFile = module.exports.assertCreateFile = function(client, course, title, file, opts, callback) {
   opts = opts || {};
 
-  // The file will be uploaded to Canvas
-  if (!TestsUtil.expectAmazonS3(course)) {
-    CanvasTestsUtil.mockFileUpload(course, file);
-  }
-
   client.assets.createFile(course, title, file, opts, function(err, asset, response) {
     assert.ifError(err);
     assert.ok(asset);
@@ -1344,7 +1339,6 @@ var setUpAmazonS3BackedCourse = module.exports.setUpAmazonS3BackedCourse = funct
       assert.ifError(err);
 
       CourseTestUtil.getDbCourse(course.id, function(dbCourse) {
-        assert.ok(TestsUtil.expectAmazonS3(dbCourse));
         // Give course the verified created_at date
         course.created_at = dbCourse.created_at;
 

--- a/node_modules/col-canvas/lib/api.js
+++ b/node_modules/col-canvas/lib/api.js
@@ -34,8 +34,6 @@ var util = require('util');
 var DB = require('col-core/lib/db');
 var log = require('col-core/lib/logger')('col-canvas');
 
-var CANVAS_UPLOAD_PATH = '_suitec';
-
 /**
  * Get a Canvas instance by its API domain and LTI key
  *
@@ -102,205 +100,17 @@ var getCanvases = module.exports.getCanvases = function(callback) {
 /* FILE UPLOAD */
 
 /**
- * Upload a file to a course in Canvas
- *
- * @param  {Context}        ctx                   Standard context containing the current user and the current course
- * @param  {String}         filePath              The path of the file that should be uploaded
- * @param  {String}         [remoteName]          The name the file should be given in the Canvas filesystem. Defaults to course id + timestamp + local filename
- * @param  {Function}       callback              Standard callback function
- * @param  {Object}         callback.err          An error that occurred, if any
- * @param  {Object}         callback.fileInfo     The metadata of the file as returned by Canvas
- */
-var uploadFileToCanvas = module.exports.uploadFileToCanvas = function(ctx, filePath, remoteName, callback) {
-  reloadCanvasObject(ctx.course.canvas, function(err) {
-    if (err) {
-      return callback(err);
-    }
-
-    // Step 1: Tell Canvas that we want to upload a file. Canvas will give us some information about
-    // where we should ship the file to in step 2
-    notifyCanvasOfUpload(ctx, filePath, remoteName, function(err, uploadInfo) {
-      if (err) {
-        return callback(err);
-      }
-
-      // Step 2: Upload the file to wherever Canvas wants us to upload it. In development this will
-      // be your local canvas instance, in production this will probably be an Amazon S3 bucket
-      uploadFile(ctx, filePath, uploadInfo, function(err, confirmUrl) {
-        if (err) {
-          return callback(err);
-        }
-
-        // Step 3: Confirm the file was uploaded to Canvas
-        confirmFile(ctx, confirmUrl, function(err, file) {
-          if (err) {
-            return callback(err);
-          }
-
-          // Step 4: Hide the file so it doesn't show up in the Files Tool for students
-          return hideFile(ctx, file, callback);
-        });
-      });
-    });
-  });
-};
-
-/**
- * Check for existence of upload folder in Canvas, creating if it doesn't exist.
- *
- * @param  {Context}        ctx                   Standard context containing the current user and the current course
- * @param  {Function}       callback              Standard callback function
- * @param  {Object}         callback.err          An error that occurred, if any
- * @api private
- */
-var checkCanvasUploadFolder = function(ctx, callback) {
-  var getFolderUrl = util.format('%s/api/v1/courses/%d/folders/by_path/%s', getCanvasBaseURI(ctx.course.canvas), ctx.course.canvas_course_id, CANVAS_UPLOAD_PATH);
-  var getFolderOpts = {
-    'url': getFolderUrl,
-    'method': 'GET',
-    'headers': {
-      'Authorization': util.format('Bearer %s', ctx.course.canvas.api_key)
-    }
-  };
-
-  request(getFolderOpts, function(err, response, body) {
-    if (err) {
-      log.error({'err': err, 'course': ctx.course.id}, 'Failed to check existence of Canvas upload folder');
-      return callback({'code': 500, 'msg': 'Failed to check existence of Canvas upload folder'});
-
-    } else if (response.statusCode === 200) {
-      // The folder exists; nothing more to do.
-      return callback();
-
-    } else if (response.statusCode !== 404) {
-      // We don't know what to do with this error.
-      log.error({'course': ctx.course.id, 'response': response, 'body': body}, 'Unexpected server response on checking existence of Canvas upload folder');
-      return callback({'code': 500, 'msg': 'Failed to check existence of Canvas upload folder'});
-    }
-
-    // A 404 response means the folder doesn't exist; create it.
-    createFolderUrl = util.format('%s/api/v1/courses/%d/folders', getCanvasBaseURI(ctx.course.canvas), ctx.course.canvas_course_id);
-    var createFolderOpts = {
-      'url': createFolderUrl,
-      'method': 'POST',
-      'headers': {
-        'Authorization': util.format('Bearer %s', ctx.course.canvas.api_key)
-      },
-      'form': {
-        // Specify a hidden folder under the root path.
-        'name': CANVAS_UPLOAD_PATH,
-        'hidden': true,
-        'parent_folder_path': '/'
-      }
-    };
-
-    request(createFolderOpts, function(err, response, body) {
-      if (err) {
-        log.error({'err': err, 'course': ctx.course.id}, 'Failed to create Canvas upload folder');
-        return callback({'code': 500, 'msg': 'Failed to create Canvas upload folder'});
-      } else if (response.statusCode !== 200) {
-        log.error({'course': ctx.course.id, 'response': response, 'body': body}, 'Unexpected server response on creating Canvas upload folder');
-        return callback({'code': 500, 'msg': 'Failed to create Canvas upload folder'});
-      }
-
-      return callback();
-    });
-  });
-};
-
-
-/**
- * Tell Canvas that we want to upload a file. Canvas will give us some information about where the
- * file should actually be stored.
- *
- * See step 1 at https://canvas.beta.instructure.com/doc/api/file.file_uploads.html
- *
- * @param  {Context}        ctx                   Standard context containing the current user and the current course
- * @param  {String}         filePath              The path for the file that should be uploaded
- * @param  {String}         [remoteName]          The name the file should be given in the Canvas filesystem. Defaults to course id + timestamp + local filename
- * @param  {Function}       callback              Standard callback function
- * @param  {Object}         callback.err          An error that occurred, if any
- * @param  {Object}         callback.uploadInfo   The signed information that allows us to upload the file
- * @api private
- */
-var notifyCanvasOfUpload = function(ctx, filePath, remoteName, callback) {
-  checkCanvasUploadFolder(ctx, function(err) {
-    if (err) {
-      return callback(err);
-    }
-
-    var url = util.format('%s/api/v1/courses/%d/files', getCanvasBaseURI(ctx.course.canvas), ctx.course.canvas_course_id);
-    var fileInfo = fs.statSync(filePath);
-    var contentType = mime.lookup(filePath);
-
-    // We hash the files into folders with an hourly granularity. This avoids generating folders
-    // which have to hold lots of files
-    var d = new Date();
-    var parentFolder = util.format('%s/%d/%d/%d/%d', CANVAS_UPLOAD_PATH, d.getFullYear(), d.getMonth(), d.getDate(), d.getHours());
-
-    // Unless a remote filename has been explicitly passed in, prefix the filename with course id and timestamp.
-    // This is a crude attempt at avoiding name collisions.
-    remoteName = remoteName || util.format('%d_%d_%s', ctx.course.id, d.getTime(), path.basename(filePath));
-
-    var opts = {
-      'url': url,
-      'method': 'POST',
-      'headers': {
-        'Authorization': util.format('Bearer %s', ctx.course.canvas.api_key)
-      },
-      'form': {
-        // Some information about the file
-        'name': remoteName,
-        'filesize': fileInfo.size,
-        'content_type': contentType,
-
-        // The folder in which the file should be uploaded
-        'parent_folder_path': parentFolder,
-
-        // Overwrite any existing files
-        'on_duplicate': 'overwrite'
-      }
-    };
-    request(opts, function(err, response, body) {
-      if (err) {
-        log.error({'err': err, 'course': ctx.course.id}, 'Failed to notify Canvas of a file upload');
-        return callback({'code': 500, 'msg': 'Failed to notify Canvas of a file upload'});
-      } else if (response.statusCode !== 200) {
-        log.error({'err': err, 'course': ctx.course.id, 'body': body}, 'Failed to notify Canvas of a file upload');
-        return callback({'code': 500, 'msg': 'Failed to notify Canvas of a file upload'});
-      }
-
-      var uploadInfo = null;
-      try {
-        uploadInfo = JSON.parse(body);
-      } catch (parseErr) {
-        log.error({'err': parseErr, 'course': ctx.course.id}, 'Failed to parse Canvas response');
-        return callback({'code': 500, 'msg': 'Failed to parse Canvas response'});
-      }
-
-      return callback(null, uploadInfo);
-    });
-  });
-};
-
-/**
- * Upload the file to the storage back-end. This could be a Canvas instance but could just as well be
- * an Amazon S3 bucket.
- *
- * See step 2 at https://canvas.beta.instructure.com/doc/api/file.file_uploads.html
+ * Upload the file to the storage back-end.
  *
  * @param  {Context}        ctx                   Standard context containing the current user and the current course
  * @param  {String}         filePath              The path of the file that should be uploaded
  * @param  {Object}         uploadInfo            The signed information that allows us to upload the file
  * @param  {Function}       callback              Standard callback function
  * @param  {Object}         callback.err          An error that occurred, if any
- * @param  {Object}         callback.fileInfo     The file information for the uploaded file as described by the Canvas API
+ * @param  {Object}         callback.fileInfo     The file information for the uploaded file
  * @api private
  */
 var uploadFile = function(ctx, filePath, uploadInfo, callback) {
-  // Note that we should not pass an Authorization header here. In production the `upload_url` will
-  // most likely point to an Amazon S3 bucket. Adding in any headers would break the signature that
-  // is part of the url
   var opts = {
     'url': uploadInfo.upload_url,
     'method': 'POST'
@@ -328,81 +138,6 @@ var uploadFile = function(ctx, filePath, uploadInfo, callback) {
 
   // Append the file. Note that the file should always be appended last
   form.append('file', fs.createReadStream(filePath));
-};
-
-/**
- * Confirm that a file has been uploaded to the appropriate file back-end
- *
- * See step 3 at https://canvas.beta.instructure.com/doc/api/file.file_uploads.html
- *
- * @param  {Context}        ctx                   Standard context containing the current user and the current course
- * @param  {String}         confirmUrl            The URL that was returned from the file back-end
- * @param  {Function}       callback              Standard callback function
- * @param  {Object}         callback.err          An error that occurred, if any
- * @param  {Object}         callback.fileInfo     The file information for the uploaded file as described by the Canvas API
- * @api private
- */
-var confirmFile = function(ctx, confirmUrl, callback) {
-  var opts = {
-    'url': confirmUrl,
-    'method': 'POST',
-    'headers': {
-      'Authorization': util.format('Bearer %s', ctx.course.canvas.api_key)
-    }
-  };
-  request(opts, function(err, response, body) {
-    if (err) {
-      log.error({'err': err, 'course': ctx.course.id}, 'Failed to confirm the file upload');
-      return callback({'code': 500, 'msg': 'Failed to confirm the file upload'});
-    } else if (response.statusCode !== 200) {
-      log.error({'err': err, 'course': ctx.course.id, 'body': body}, 'Failed to confirm the file upload');
-      return callback({'code': 500, 'msg': 'Failed to confirm the file upload'});
-    }
-
-    var fileInfo = null;
-    try {
-      fileInfo = JSON.parse(body);
-    } catch (parseErr) {
-      log.error({'err': parseErr, 'course': ctx.course.id}, 'Failed to parse Canvas confirm response');
-      return callback({'code': 500, 'msg': 'Failed to parse Canvas confirm response'});
-    }
-
-    return callback(null, fileInfo);
-  });
-};
-
-/**
- * Hide a file. This will ensure that students can't see the uploaded file in the Files tool.
- *
- * @param  {Context}        ctx                   Standard context containing the current user and the current course
- * @param  {Object}         file                  The file information for the uploaded file as described by the Canvas API
- * @param  {Function}       callback              Standard callback function
- * @param  {Object}         callback.err          An error that occurred, if any
- * @api private
- */
-var hideFile = function(ctx, file, callback) {
-  var url = util.format('%s/api/v1/files/%d', getCanvasBaseURI(ctx.course.canvas), file.id);
-  var opts = {
-    'url': url,
-    'method': 'PUT',
-    'headers': {
-      'Authorization': util.format('Bearer %s', ctx.course.canvas.api_key)
-    },
-    'form': {
-      'hidden': true
-    }
-  };
-  request(opts, function(err, response, body) {
-    if (err) {
-      log.error({'err': err, 'course': ctx.course.id}, 'Failed to hide the file');
-      return callback({'code': 500, 'msg': 'Failed to hide the file'});
-    } else if (response.statusCode !== 200) {
-      log.error({'err': err, 'course': ctx.course.id, 'body': body}, 'Failed to hide the file');
-      return callback({'code': 500, 'msg': 'Failed to hide the file'});
-    }
-
-    return callback(null, file);
-  });
 };
 
 /* Conversations */

--- a/node_modules/col-canvas/tests/model.js
+++ b/node_modules/col-canvas/tests/model.js
@@ -218,7 +218,6 @@ var CanvasFile = module.exports.CanvasFile = function(contentType, displayName, 
     'thumbnail_url': 'http://localhost:3000/images/thumbnails/show/' + id,
     'locked_for_user': false,
     'preview_url': null,
-
     'expectProcessing': expectProcessing
   };
 };

--- a/node_modules/col-canvas/tests/util.js
+++ b/node_modules/col-canvas/tests/util.js
@@ -34,86 +34,6 @@ var MockedRequest = require('col-tests/lib/model').MockedRequest;
 var TestsUtil = require('col-tests/lib/util');
 
 /**
- * Mock all the requests that are involved in uploading a file to Canvas
- *
- * @param  {Course}    course                 The course to which the file will be uploaded
- * @param  {Boolean}   [file]                 [Optional] Expect asset.file_download to serve a copy of this file
- * @return {String}    fileUrl                The final URL for the uploaded file
- */
-var mockFileUpload = module.exports.mockFileUpload = function(course, file) {
-  var appServer = TestsUtil.getMockedCanvasAppServer(course.canvas);
-  var apiDomain = course.canvas.canvas_api_domain;
-
-  // 1a. Check existence of Canvas upload folder
-  var folderUrl = util.format('/api/v1/courses/%d/folders/by_path/_suitec', course.canvas_course_id || course.id);
-  var folderHandler = function(req, res) {
-    return res.status(404).send('Folder not found');
-  };
-  var folderRequest = new MockedRequest('GET', folderUrl, null, null, null, folderHandler);
-  appServer.expect(folderRequest);
-
-  // 1b. Create Canvas upload folder
-  var folderCreateUrl = util.format('/api/v1/courses/%d/folders', course.canvas_course_id || course.id);
-  var folderCreateHandler = function(req, res) {
-    return res.status(200).send({
-      'id': _.random(100000)
-    });
-  };
-  var folderCreateValidator = function(req) {
-    // Assert all expected parameters are present
-    assert.ok(req.body.name);
-    assert.ok(req.body.parent_folder_path);
-    assert.ok(req.body.hidden);
-  };
-  var folderCreateRequest = new MockedRequest('POST', folderCreateUrl, null, null, null, folderCreateHandler, folderCreateValidator);
-  appServer.expect(folderCreateRequest);
-
-  // 1c. Ask Canvas to upload the file
-  var id = _.random(100000);
-  var downloadUrl = file ? 'file://' + file.path : util.format('http://%s/files/%d/download', apiDomain, id);
-  var fileInfo = {
-    'id': id,
-    'url': downloadUrl,
-    'content-type': 'text/plain'
-  };
-  var askUrl = util.format('/api/v1/courses/%d/files', course.canvas_course_id || course.id);
-  var askHandler = function(req, res) {
-    fileInfo['content-type'] = req.body.content_type;
-    return res.status(200).send({
-      'upload_url': util.format('http://%s/upload', apiDomain)
-    });
-  };
-  var askValidator = function(req) {
-    // Assert all required parameters are present
-    assert.ok(req.body.name);
-    assert.ok(req.body.filesize);
-    assert.ok(req.body.content_type);
-    assert.ok(req.body.parent_folder_path);
-    assert.ok(req.body.on_duplicate);
-  };
-  var askRequest = new MockedRequest('POST', askUrl, null, null, null, askHandler, askValidator);
-  appServer.expect(askRequest);
-
-  // 2. The actual file upload
-  var redirectHandler = function(req, res) {
-    return res.redirect(util.format('http://%s/confirm', apiDomain));
-  };
-  var uploadRequest = new MockedRequest('POST', '/upload', null, null, null, redirectHandler);
-  appServer.expect(uploadRequest);
-
-  // 3. Confirming to Canvas the file was uploaded
-  var confirmRequest = new MockedRequest('POST', '/confirm', 200, fileInfo);
-  appServer.expect(confirmRequest);
-
-  // 4. Hiding the file
-  var fileUrl = util.format('/api/v1/files/%d', id);
-  var hideRequest = new MockedRequest('PUT', fileUrl, 200, fileInfo);
-  appServer.expect(hideRequest);
-
-  return fileUrl;
-};
-
-/**
  * As it is infeasible to bootstrap an actual Canvas instance during the tests, the Canvas REST API
  * will be mocked. This method allows you to declare the data that should be returned during a single polling
  * run.
@@ -231,9 +151,6 @@ var mockGetSubmissions = module.exports.mockGetSubmissions = function(course, as
           var expectedPath = url.parse(attachment.url).pathname;
           var mockedRequest = new MockedRequest('GET', expectedPath, 200, 'The file body');
           TestsUtil.getMockedCanvasAppServer(course.canvas).expect(mockedRequest);
-
-          // The upload request
-          attachment.filePath = mockFileUpload(course, false);
 
           // Any duplicates of this attachment should not be processed a second time
           attachment.expectProcessing = false;

--- a/node_modules/col-core/lib/storage.js
+++ b/node_modules/col-core/lib/storage.js
@@ -85,17 +85,6 @@ var storeWhiteboardImage = module.exports.storeWhiteboardImage = function(whiteb
 };
 
 /**
- * Course is eligible for AWS S3 storage based on created_at date.
- *
- * @param  {Course}         course          The Canvas course in which the user is interacting with the API
- * @return {Boolean}                        True if course is eligible to store assets in AWS S3
- */
-var useAmazonS3 = module.exports.useAmazonS3 = function(course) {
-  var s3CutoverDate = moment(config.get("aws.s3.cutoverDate"), "YYYY-MM-DD");
-  return s3CutoverDate.isValid() && moment(course.created_at).startOf('day').diff(s3CutoverDate, 'days') >= 0;
-};
-
-/**
  * Get object from Amazon S3
  *
  * @param  {String}     s3Uri                       S3 address (e.g., s3://my-bucket/my-object-key)

--- a/node_modules/col-tests/lib/util.js
+++ b/node_modules/col-tests/lib/util.js
@@ -233,14 +233,6 @@ var generateUser = module.exports.generateUser = function(canvas, id, roles, giv
   };
 };
 
-/**
- * @param  {Course}        course      The Canvas course in which the user is interacting with the API
- * @return {Boolean}                   True if course qualifies for AWS S3 storage
- */
-var expectAmazonS3 = module.exports.expectAmazonS3 = function(course) {
-  return Storage.useAmazonS3(course);
-};
-
 // Variable that will keep track of the expected and sent number of emails for a user
 var expectedEmailCounts = {};
 

--- a/node_modules/col-whiteboards/lib/api.js
+++ b/node_modules/col-whiteboards/lib/api.js
@@ -42,7 +42,6 @@ var util = require('util');
 var ActivitiesAPI = require('col-activities');
 var AnalyticsAPI = require('col-analytics');
 var AssetsAPI = require('col-assets');
-var CanvasAPI = require('col-canvas');
 var CategoriesAPI = require('col-categories');
 var Collabosphere = require('col-core');
 var CollabosphereConstants = require('col-core/lib/constants');
@@ -1597,31 +1596,15 @@ var getWhiteboardAsPngFile = function(whiteboard, callback) {
           return cleanUpFile(imagePath, callback, err);
         }
 
-        // Upload the file to storage
-        if (Storage.useAmazonS3(course)) {
-          // Upload the file to Amazon S3
-          Storage.storeWhiteboardImage(whiteboard, imagePath, function(err, objectKey, contentType) {
-            if (err) {
-              log.error({'err': err, 'whiteboard': whiteboard.id}, 'Failed to upload whiteboard PNG to AWS S3');
-              return cleanUpFile(imagePath, callback, err);
-            }
+        // Upload the file to Amazon S3
+        Storage.storeWhiteboardImage(whiteboard, imagePath, function(err, objectKey, contentType) {
+          if (err) {
+            log.error({'err': err, 'whiteboard': whiteboard.id}, 'Failed to upload whiteboard PNG to AWS S3');
+            return cleanUpFile(imagePath, callback, err);
+          }
 
-            return cleanUpFile(imagePath, callback, null, dimensions, objectKey);
-          });
-
-        } else {
-          var ctx = {'course': course};
-          var remoteName = util.format('%d_whiteboard_%d.png', ctx.course.id, whiteboard.id);
-
-          CanvasAPI.uploadFileToCanvas(ctx, imagePath, remoteName, function(err, canvasItem) {
-            if (err) {
-              log.error({'err': err, 'whiteboard': whiteboard.id}, 'Failed to upload whiteboard PNG to Canvas');
-              return cleanUpFile(imagePath, callback, err);
-            }
-
-            return cleanUpFile(imagePath, callback, null, dimensions, canvasItem.url);
-          });
-        }
+          return cleanUpFile(imagePath, callback, null, dimensions, objectKey);
+        });
       });
     });
   });

--- a/node_modules/col-whiteboards/tests/util.js
+++ b/node_modules/col-whiteboards/tests/util.js
@@ -704,9 +704,6 @@ var assertExportWhiteboardToAsset = module.exports.assertExportWhiteboardToAsset
     // Get the whiteboard that is being exported
     assertGetWhiteboard(client, course, id, null, null, function(whiteboard) {
 
-      // A whiteboard PNG will be uploaded to Canvas
-      CanvasTestsUtil.mockFileUpload(course);
-
       // Export the whiteboard
       client.whiteboards.exportWhiteboardToAsset(course, id, title, opts, function(err, asset) {
         assert.ifError(err);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1108

* the `move_canvas_files_to_amazon_s3.js` script is still usable
* Canvas assignment integration should not be impacted
* all obsolete code removed, I hope