### PR TITLE
COL-1241 Exclude inactive users from interactions feed

### DIFF
--- a/node_modules/col-activities/lib/api.js
+++ b/node_modules/col-activities/lib/api.js
@@ -370,8 +370,8 @@ var getInteractions = module.exports.getInteractions = function(ctx, callback) {
   var interactionsQuery = `SELECT a.type AS type, a.actor_id as source, a.user_id as target, COUNT(a.type)::int AS count
     FROM activities a
       LEFT JOIN assets ON a.asset_id = assets.id
-      JOIN users AS u ON (a.user_id = u.id AND u.canvas_course_role IN (:student_roles))
-      JOIN users AS act ON (a.actor_id = act.id AND act.canvas_course_role IN (:student_roles))
+      JOIN users AS u ON (a.user_id = u.id AND u.canvas_course_role IN (:student_roles) AND u.canvas_enrollment_state != 'inactive')
+      JOIN users AS act ON (a.actor_id = act.id AND act.canvas_course_role IN (:student_roles) AND act.canvas_enrollment_state != 'inactive')
     WHERE a.course_id = :course_id
       AND a.reciprocal_id IS NOT NULL
       AND assets.deleted_at IS NULL
@@ -381,9 +381,9 @@ var getInteractions = module.exports.getInteractions = function(ctx, callback) {
   // from the assets table.
   var whiteboardCoCreationQuery = `SELECT 'co_create_whiteboard' AS type, au1.user_id AS source, au2.user_id AS target, count(*)::int AS count
     FROM assets a
-      JOIN (asset_users au1 JOIN users u1 ON au1.user_id = u1.id AND u1.canvas_course_role IN (:student_roles))
+      JOIN (asset_users au1 JOIN users u1 ON au1.user_id = u1.id AND u1.canvas_course_role IN (:student_roles) AND u1.canvas_enrollment_state != 'inactive')
         ON a.id = au1.asset_id
-      JOIN (asset_users au2 JOIN users u2 ON au2.user_id = u2.id AND u2.canvas_course_role IN (:student_roles))
+      JOIN (asset_users au2 JOIN users u2 ON au2.user_id = u2.id AND u2.canvas_course_role IN (:student_roles) AND u2.canvas_enrollment_state != 'inactive')
         ON a.id = au2.asset_id AND au1.user_id < au2.user_id
     WHERE a.course_id = :course_id
     AND a.type = 'whiteboard'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1241

These users don't show up in the user feed, meaning that d3-force can't match them up and goes on to lose its mind.