### PR TITLE
COL-1291, do not record 'Get engagement index' event when user hits profile page

### DIFF
--- a/public/app/dashboard/profileController.js
+++ b/public/app/dashboard/profileController.js
@@ -278,7 +278,7 @@
      */
     var determineRank = function(user) {
       if (me.is_admin || user.share_points) {
-        userFactory.getLeaderboard().then(function(users) {
+        userFactory.getLeaderboard(false).then(function(users) {
           $scope.leaderboardCount = users.length;
 
           // Extract user's rank then break

--- a/public/app/shared/userFactory.js
+++ b/public/app/shared/userFactory.js
@@ -67,10 +67,13 @@
     /**
      * Get the users in the current course and their points
      *
-     * @return {Promise<User[]>}                  $http promise returning the users in the current course and their points
+     * @param  {Boolean}            trackEvent      Default is true. If false then skip AnalyticsAPI step to track event.
+     * @return {Promise<User[]>}                    $http promise returning the users in the current course and their points
      */
-    var getLeaderboard = function() {
-      return $http.get(utilService.getApiUrl('/users/leaderboard'))
+    var getLeaderboard = function(trackEvent) {
+      var track = trackEvent === null || _.isUndefined(trackEvent) || trackEvent;
+      var apiPath = track ? '/users/leaderboard' : '/users/leaderboard?track=false';
+      return $http.get(utilService.getApiUrl(apiPath))
         .then(function(response) {
           var users = response.data;
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1291

On server side, at `/users/leaderboard`, we have:
```
  // Track the request unless explicitly told otherwise.
  var track = true;
  if (CollabosphereUtil.getBooleanParam(req.query.track) === false) {
    track = false;
  }
   ...
```