### PR TITLE
COL-1301, rest endpoint to track events, accepting optional id params

### DIFF
--- a/node_modules/col-analytics/lib/rest.js
+++ b/node_modules/col-analytics/lib/rest.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+var _ = require('lodash');
+
+var AnalyticsApi = require('./api');
+var Collabosphere = require('col-core');
+var CollabosphereUtil = require('col-core/lib/util');
+
+/**
+ * Track events (ie, user activity); site analytics
+ */
+Collabosphere.apiRouter.post('/track', function(req, res) {
+  var event = _.trim(req.body.event);
+  // The object ids will be extracted later and inserted into proper db column.
+  var metadata = _.merge(req.body.metadata || {}, {
+    activity_id: req.body.activityId,
+    asset_id: req.body.assetId,
+    comment_id: req.body.commentId,
+    whiteboard_id: req.body.whiteboardId,
+    whiteboard_element_uid: req.body.whiteboardElementUid
+  });
+
+  // Client-side code is not expected to send 'object' and 'contextObject'.
+  // Object IDs can be extracted for 'metadata'.
+  AnalyticsApi.track(req.ctx.user, event, metadata, null, null);
+  return res.status(200).send(true);
+});

--- a/node_modules/col-analytics/lib/util.js
+++ b/node_modules/col-analytics/lib/util.js
@@ -101,7 +101,7 @@ var getCourseIfMissing = module.exports.getCourseIfMissing = function(user, call
  * Extract relevant object ids per event type.
  *
  * @param  {String}         eventName                         The event type
- * @param  {Object}         eventMetadata                     Event metadata
+ * @param  {Object}         metadata                          Event metadata
  * @param  {Object}         [object]                          [Optional] Object associated with the event
  * @param  {Object}         [contextObject]                   [Optional] Additional context (e.g., the asset associated with a comment)
  * @param  {Function}       callback                          Standard callback
@@ -113,7 +113,7 @@ var getCourseIfMissing = module.exports.getCourseIfMissing = function(user, call
  * @param  {Number}         [callback.whiteboardElementUid]   Identifier relevant to event context
  * @return {void}
  */
-var describeEvent = module.exports.describeEvent = function(eventName, eventMetadata, object, contextObject, callback) {
+var describeEvent = module.exports.describeEvent = function(eventName, metadata, object, contextObject, callback) {
   var err = null;
   var activityId = null;
   var assetId = null;
@@ -127,23 +127,25 @@ var describeEvent = module.exports.describeEvent = function(eventName, eventMeta
     var subCategory = c[1];
     switch (category) {
       case 'asset':
-        assetId = _.get(object, 'id') || eventMetadata.asset_id;
+        assetId = _.get(object, 'id') || metadata.asset_id;
+        whiteboardId = metadata.whiteboard_id;
         break;
       case 'assetComment':
-        commentId = _.get(object, 'id') || eventMetadata.comment_id;
-        assetId = _.get(contextObject, 'id') || eventMetadata.asset_id;
+        commentId = _.get(object, 'id') || metadata.comment_id;
+        assetId = _.get(contextObject, 'id') || metadata.asset_id;
         break;
       case 'whiteboard':
-        whiteboardId = _.get(object, 'id') || eventMetadata.whiteboard_id;
+        assetId = _.get(contextObject, 'id') || metadata.asset_id;
+        whiteboardId = _.get(object, 'id') || metadata.whiteboard_id;
         break;
       case 'whiteboardChat':
         // object.id is chatMessage.id
-        whiteboardId = _.get(contextObject, 'id') || eventMetadata.whiteboard_id;
+        whiteboardId = _.get(contextObject, 'id') || metadata.whiteboard_id;
         break;
       case 'whiteboardElement':
-        assetId = eventMetadata.whiteboard_element_asset_id;
-        whiteboardElementUid = _.get(object, 'uid') || eventMetadata.whiteboard_element_id;
-        whiteboardId = _.get(contextObject, 'id') || eventMetadata.whiteboard_id;
+        whiteboardElementUid = _.get(object, 'uid') || metadata.whiteboard_element_uid;
+        whiteboardId = _.get(contextObject, 'id') || metadata.whiteboard_id;
+        assetId = metadata.whiteboard_element_asset_id;
         break;
       case 'assets':
       case 'bookmarklet':

--- a/node_modules/col-analytics/tests/test-event.js
+++ b/node_modules/col-analytics/tests/test-event.js
@@ -27,16 +27,48 @@ var _ = require('lodash');
 var assert = require('assert');
 var util = require('util');
 
-var EventTypes = require('../lib/constants');
-
 var AnalyticsTestsUtil = require('./util');
 var AssetsTestUtil = require('col-assets/tests/util');
+var EventTypes = require('../lib/constants');
 var LtiTestsUtil = require('col-lti/tests/util');
 var TestsUtil = require('col-tests');
 var WhiteboardsTestsUtil = require('col-whiteboards/tests/util');
 
 describe('Analytics', function() {
   describe('Event', function() {
+
+    it('API endpoint tracks event metadata', function(callback) {
+      TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
+        var eventName = EventTypes.asset.openFromWhiteboard;
+        var assetId = 1;
+        var whiteboardId = 2;
+        var metadata = {
+          asset_title: 'Divine Hammer',
+          asset_updated_at: '2018-02-13T00:22:15.591Z',
+          whiteboard_title: 'No Aloha',
+          whiteboard_updated_at: '2018-02-13T00:22:15.591Z'
+        };
+        // Create event
+        AnalyticsTestsUtil.assertTrackAPI(client, course, eventName, metadata, null, assetId, null, whiteboardId, null, function(apiErr) {
+          assert.ifError(apiErr);
+          // Get newly created event
+          AnalyticsTestsUtil.getMostRecentEvent(course, user, function(err, event) {
+            assert.ifError(err);
+            assert.ok(event);
+
+            // Verify event
+            var idSet = {
+              assetId: assetId,
+              whiteboardId: whiteboardId
+            };
+            AnalyticsTestsUtil.assertEvent(event, eventName, user, course, idSet, function() {
+              return callback();
+            });
+          });
+        });
+      });
+    });
+
     describe('Asset', function() {
       it('tracks Like event', function(callback) {
         TestsUtil.getAssetLibraryClient(null, null, null, function(client1, course1, user1) {
@@ -48,8 +80,7 @@ describe('Analytics', function() {
                 AnalyticsTestsUtil.getMostRecentEvent(course2, user2, function(err, event) {
                   assert.ifError(err);
                   // Verify event
-                  AnalyticsTestsUtil.assertEvent(event, EventTypes.asset.like, user2, course2);
-                  return callback();
+                  AnalyticsTestsUtil.assertEvent(event, EventTypes.asset.like, user2, course2, null, callback);
                 });
               });
             });
@@ -71,8 +102,7 @@ describe('Analytics', function() {
                   assetId: asset.id,
                   commentId: comment.id
                 };
-                AnalyticsTestsUtil.assertEvent(event, EventTypes.assetComment.create, user, course, ids);
-                return callback();
+                AnalyticsTestsUtil.assertEvent(event, EventTypes.assetComment.create, user, course, ids, callback);
               });
             });
           });
@@ -89,23 +119,21 @@ describe('Analytics', function() {
           AnalyticsTestsUtil.getMostRecentEvent(course, user, function(err1, event1) {
             assert.ifError(err1);
 
-            AnalyticsTestsUtil.assertEvent(event1, EventTypes.whiteboard.create, user, course, {whiteboardId: whiteboard.id});
+            AnalyticsTestsUtil.assertEvent(event1, EventTypes.whiteboard.create, user, course, {whiteboardId: whiteboard.id}, function() {
+              // Next, add element to whiteboard
+              WhiteboardsTestsUtil.addElementsToWhiteboard(client, course, whiteboard, function(elements) {
+                var element = _.last(elements);
 
-            // Next, add element to whiteboard
-            WhiteboardsTestsUtil.addElementsToWhiteboard(client, course, whiteboard, function(elements) {
-              var element = _.last(elements);
+                // Verify whiteboardElement event
+                AnalyticsTestsUtil.getMostRecentEvent(course, user, function(err2, event2) {
+                  assert.ifError(err2);
+                  var ids = {
+                    whiteboardId: whiteboard.id,
+                    whiteboardElementUid: element.id
+                  };
 
-              // Verify whiteboardElement event
-              AnalyticsTestsUtil.getMostRecentEvent(course, user, function(err2, event2) {
-                assert.ifError(err2);
-                var ids = {
-                  whiteboardId: whiteboard.id,
-                  whiteboardElementUid: element.id
-                };
-
-                AnalyticsTestsUtil.assertEvent(event2, EventTypes.whiteboardElement.create, user, course, ids);
-
-                return callback();
+                  AnalyticsTestsUtil.assertEvent(event2, EventTypes.whiteboardElement.create, user, course, ids, callback);
+                });
               });
             });
           });

--- a/node_modules/col-analytics/tests/util.js
+++ b/node_modules/col-analytics/tests/util.js
@@ -240,15 +240,16 @@ var getMostRecentEvent = module.exports.getMostRecentEvent = function(course, us
 /**
  * Assert that Event has expected properties
  *
- * @param  {Object}         event                      The actual event received in test
- * @param  {String}         eventName                  Human readable name of event
- * @param  {User}           user                       The user associated with the event
- * @param  {Course}         course                     The course associated with the event
- * @param  {Object}         ids                        Expected values for activityId, assetId, commentId, etc.
- * @return {void}
- * @throws {AssertionError}                            Error thrown when an assertion failed
+ * @param  {Object}         event             The actual event received in test
+ * @param  {String}         eventName         Human readable name of event
+ * @param  {User}           user              The user associated with the event
+ * @param  {Course}         course            The course associated with the event
+ * @param  {Object}         ids               Expected values for activityId, assetId, commentId, etc.
+ * @param  {Function}       callback          Standard callback function
+ * @return {Object}                           Callback return
+ * @throws {AssertionError}                   Error thrown when an assertion failed
  */
-var assertEvent = module.exports.assertEvent = function(event, eventName, user, course, ids) {
+var assertEvent = module.exports.assertEvent = function(event, eventName, user, course, ids, callback) {
   assert.ok(event);
   assert.ok(event.canvas_domain);
   assert.ok(event.event_metadata);
@@ -289,5 +290,39 @@ var assertEvent = module.exports.assertEvent = function(event, eventName, user, 
       assert.ok(metadata.whiteboard_updated_at);
     }
   }
+  return callback();
 };
 
+/**
+ * Assert that event can be tracked via API
+ *
+ * @param  {RestClient}         client                        The REST client to make the request with
+ * @param  {Course}             course                        Course per context
+ * @param  {String}             eventName                     Type of user activity
+ * @param  {Object}             [metadata]                    IDs associated with user activity on SuiteC
+ * @param  {Number}             [activityId]                  Object id
+ * @param  {Number}             [assetId]                     Object id
+ * @param  {Number}             [commentId]                   Object id
+ * @param  {Number}             [whiteboardId]                Object id
+ * @param  {Number}             [whiteboardElementUid]        Object id
+ * @param  {Function}           callback                      Standard callback function
+ * @param  {Object}             [callback.err]                Error, if any
+ * @return {Object}                                           Callback return
+ */
+var assertTrackAPI = module.exports.assertTrackAPI = function(
+  client,
+  course,
+  eventName,
+  metadata,
+  activityId,
+  assetId,
+  commentId,
+  whiteboardId,
+  whiteboardElementUid,
+  callback
+) {
+  // Too much of a good thing
+  client.events.track(course, eventName, metadata, activityId, assetId, commentId, whiteboardId, whiteboardElementUid, function(err) {
+    return callback(err);
+  });
+};

--- a/node_modules/col-rest/lib/api.js
+++ b/node_modules/col-rest/lib/api.js
@@ -33,7 +33,8 @@ var RestUtil = require('./util');
  * @param  {Object}     options                             The options that specify where the client should connect to and how
  * @param  {String}     options.protocol                    The protocol over which to connect. One of `http` or `https`
  * @param  {String}     options.host                        The host to which to connect (including the port)
- * @param  {Boolean}    [options.strictSSL]                 Whether or not SSL should be strictly enforced. This can be useful to connect to QA servers which have a self-signed certificate. Defaults to `false`
+ * @param  {Boolean}    [options.strictSSL]                 Whether or not SSL should be strictly enforced. This can be useful to
+ *                                                          connect to QA servers which have a self-signed certificate. Defaults to `false`
  * @param  {String}     [options.authenticationStrategy]    The authentication strategy for the user. If left blank, all requests will be made anonymously. Options are `local`
  * @param  {String}     [options.hostHeader]                The host header that should be sent to the server. If left blank, `options.host` will be sent
  * @param  {String}     [options.referer]                   The referer header that should be sent to the server
@@ -72,6 +73,7 @@ var createAnonymousClient = function(options) {
   require('./rest/config')(client);
   require('./rest/core')(client);
   require('./rest/course')(client);
+  require('./rest/events')(client);
   require('./rest/lti')(client);
   require('./rest/users')(client);
   require('./rest/whiteboards')(client);

--- a/node_modules/col-rest/lib/rest/events.js
+++ b/node_modules/col-rest/lib/rest/events.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+module.exports = function(client) {
+
+  client.events = {};
+
+  /**
+   * Track an event and its metadata (site analytics)
+   *
+   * @param  {Course}         course                     Course per context
+   * @param  {String}         eventName                  Type of user activity
+   * @param  {Object}         [metadata]                 IDs associated with user activity on SuiteC
+   * @param  {Number}         [activityId]               Object id
+   * @param  {Number}         [assetId]                  Object id
+   * @param  {Number}         [commentId]                Object id
+   * @param  {Number}         [whiteboardId]             Object id
+   * @param  {Number}         [whiteboardElementUid]     Object id
+   * @param  {Function}       callback                   Standard callback function
+   * @param  {Object}         callback.err               Error, if any
+   * @param  {Object}         callback.body              JSON response
+   * @param  {Response}       callback.response          The response object
+   */
+  client.events.track = function(course, eventName, metadata, activityId, assetId, commentId, whiteboardId, whiteboardElementUid, callback) {
+    var data = {
+      event: eventName,
+      metadata: metadata,
+      activityId: activityId,
+      assetId: assetId,
+      commentId: commentId,
+      whiteboardId: whiteboardId,
+      whiteboardElementUid: whiteboardElementUid
+    };
+    client.request(client.util.apiPrefix(course) + '/track', 'POST', data, null, function() {
+      return callback();
+    });
+  };
+};


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1301

In preparation for client-side cutover, we make `/api/track` available. The long list of optional object-id args seems cleaner than a more obscure `object` and `contextObject`.
