### PR TITLE
COL-1317, append 'track' to URL with proper query arg connector

### DIFF
--- a/public/app/whiteboards/board/whiteboardsBoardDirective.js
+++ b/public/app/whiteboards/board/whiteboardsBoardDirective.js
@@ -1633,7 +1633,8 @@
           }
 
           // Add the asset to the center of the whiteboard canvas
-          var imageUrl = asset.image_url + '?track=false';
+          var connector = _.includes(asset.image_url, '?') ? '&' : '?';
+          var imageUrl = asset.image_url + connector + 'track=false';
           fabric.Image.fromURL(imageUrl, function(element) {
             var canvasCenter = getCanvasCenter();
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1317

Bug caused by use of `?track=false` on URL with preexisting args.