### PR TITLE
COL-1326 Activity network performance tweaking

### DIFF
--- a/node_modules/col-users/lib/api.js
+++ b/node_modules/col-users/lib/api.js
@@ -295,6 +295,8 @@ var getAllUsers = module.exports.getAllUsers = function(ctx, options, callback) 
   }
   if (options.includeLastActivity) {
     attributes.push('last_activity');
+    // created_at can be a useful fallback datum in cases where last_activity is null.
+    attributes.push('created_at');
   }
 
   // Get the users from the DB

--- a/public/app/dashboard/activityNetwork.html
+++ b/public/app/dashboard/activityNetwork.html
@@ -18,7 +18,7 @@
   </div>
 </div>
 <svg id="profile-activity-network" class="profile-activity-network" clip-path="url('#profile-activity-network-clipper')"></svg>
-<div class="profile-activity-network-controls-outer">
+<div id="profile-activity-network-controls-outer-bottom" class="profile-activity-network-controls-outer">
   <form id="profile-activity-network-controls" class="profile-activity-network-controls">
     <div class="profile-activity-network-controls-title">Collaboration activities:</div>
     <label class="profile-activity-network-controls-label" ng-repeat="(type, enabled) in interactionTypesEnabled">

--- a/public/app/dashboard/profile.css
+++ b/public/app/dashboard/profile.css
@@ -224,6 +224,7 @@
 
 .profile-activity-network {
   border: 1px solid #ccc;
+  min-width: 100%;
 }
 
 .profile-activity-network .links line {
@@ -289,6 +290,7 @@
 .profile-activity-network-controls-outer {
   display: flex;
   justify-content: space-between;
+  margin-bottom: 5px;
 }
 
 .profile-activity-network-controls-show-users {

--- a/public/app/dashboard/profileController.js
+++ b/public/app/dashboard/profileController.js
@@ -421,9 +421,10 @@
             _.each(users, function(interactionsUser) {
               if (interactionsUser.canvas_course_role === 'Student' || interactionsUser.canvas_course_role === 'Learner') {
                 allUsers.push(interactionsUser);
-                if (interactionsUser.last_activity &&
+                var lastActiveOrCreated = interactionsUser.last_activity || interactionsUser.created_at;
+                if (lastActiveOrCreated &&
                    // Recent user cutoff is expressed in days, date difference in milliseconds.
-                   ((new Date() - new Date(interactionsUser.last_activity)) / 86400000 < config.activityNetwork.recentUserCutoff)) {
+                   ((new Date() - new Date(lastActiveOrCreated)) / 86400000 < config.activityNetwork.recentUserCutoff)) {
                   recentUsers.push(interactionsUser);
                   recentIds[interactionsUser.id] = true;
                 }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1326

- Network viewport size increases for large classes;
- For users where last_activity is null, created_at is used to determine whether they count as "recent";
- Alpha decay is increased so the simulation settles down a little faster.
