### PR TITLE
COL-1341, real websocket connection; bumped version on socket.io dependencies

### DIFF
--- a/.ebextensions/01_create_apache_conf.config
+++ b/.ebextensions/01_create_apache_conf.config
@@ -27,8 +27,8 @@ files:
         # - proxy_ws_tunnel - so websockets can be proxied to the node.js app server
         # - deflate - so static assets can be compressed
         # - headers - so cache headers can be added on the static assets
-        <IfModule !proxy_ws_tunnel_module>
-          LoadModule proxy_wstunnel_module /etc/httpd/modules/mod_proxy_wstunnel.so
+        <IfModule !proxy_module>
+          LoadModule proxy_module /etc/httpd/modules/mod_proxy.so
         </IfModule>
         <IfModule !deflate_module>
           LoadModule deflate_module /etc/httpd/modules/mod_deflate.so
@@ -50,19 +50,11 @@ files:
 
         RewriteEngine on
 
-        # Required for socket.io's polling transport
-        RewriteCond %{QUERY_STRING} transport=polling
-        RewriteRule /(.*)$ http://localhost:2000/$1 [P]
-
         # Expose the LTI launch URLs
         RewriteRule ^/assetlibrary         /var/www/html/suitec/index.html
         RewriteRule ^/dashboard            /var/www/html/suitec/index.html
         RewriteRule ^/engagementindex      /var/www/html/suitec/index.html
         RewriteRule ^/whiteboards          /var/www/html/suitec/index.html
-
-        # Proxy websocket connections
-        ProxyPass         /socket.io/   ws://localhost:2000/socket.io/
-        ProxyPassReverse  /socket.io/   ws://localhost:2000/socket.io/
 
         # Proxy API & LTI calls to the application server
         ProxyPass         /api          http://localhost:2000/api retry=0
@@ -112,6 +104,13 @@ files:
       LoadModule ssl_module modules/mod_ssl.so
       Listen 443
       <VirtualHost *:443>
+        <IfModule !proxy_module>
+          LoadModule proxy_module /etc/httpd/modules/mod_proxy.so
+        </IfModule>
+        <IfModule !proxy_wstunnel_module>
+          LoadModule proxy_wstunnel_module /etc/httpd/modules/mod_proxy_wstunnel.so
+        </IfModule>
+
         <Proxy *>
           Order deny,allow
           Allow from all
@@ -128,6 +127,15 @@ files:
         Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains; preload"
         Header always set X-Content-Type-Options nosniff
         Header set Access-Control-Allow-Origin "*"
+
+        # Required for socket.io's polling transport
+        RewriteEngine on
+        RewriteCond %{QUERY_STRING}        transport=websocket
+        RewriteRule /(.*)$                 ws://localhost:2000/$1 [P]
+
+        # Proxy websocket connections
+        ProxyPass         /socket.io/   ws://localhost:2000/socket.io/dist/
+        ProxyPassReverse  /socket.io/   ws://localhost:2000/socket.io/dist/
 
         ProxyPass / http://localhost:80/ retry=0
         ProxyPassReverse / http://localhost:80/

--- a/apache/suitec.template
+++ b/apache/suitec.template
@@ -15,12 +15,12 @@
     CustomLog <%= logDirectory %>/suitec-combined_log combined
 
     RewriteEngine on
-    RewriteCond %{QUERY_STRING} transport=polling
-    RewriteRule /(.*)$ http://localhost:2000/$1 [P]
+    RewriteCond %{QUERY_STRING}        transport=websocket
+    RewriteRule /(.*)$                 ws://localhost:2000/$1 [P]
 
     # Proxy websocket connections
-    ProxyPass         /socket.io/   ws://localhost:<%= port %>/socket.io/
-    ProxyPassReverse  /socket.io/   ws://localhost:<%= port %>/socket.io/
+    ProxyPass         /socket.io/   ws://localhost:<%= port %>/socket.io/dist/
+    ProxyPassReverse  /socket.io/   ws://localhost:<%= port %>/socket.io/dist/
 
     # Proxy API & LTI calls to the application server
     ProxyPass         /api          http://localhost:<%= port %>/api retry=0

--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "oi.select": "0.2.21",
     "purl": "2.3.1",
     "remarkable-bootstrap-notify": "3.1.3",
-    "socket.io-client": "1.3.7"
+    "socket.io-client": "2.1.0"
   },
   "resolutions": {
     "angular": "1.4.1"

--- a/node_modules/col-core/lib/server.js
+++ b/node_modules/col-core/lib/server.js
@@ -50,7 +50,14 @@ var setUpServer = module.exports.setUpServer = function() {
   app.httpServer = http.createServer(app);
 
   // Create a Socket.IO server and expose it on the express app to allow other modules to hook into it
-  app.io = socketIO(app.httpServer);
+  app.io = socketIO(app.httpServer, {transports: ['websocket']});
+  app.io.on('connection', function(socket) {
+    log.info('Websocket connected');
+
+    socket.on('disconnect', function() {
+      log.info('Websocket disconnected');
+    });
+  });
 
   // Start listening for requests
   var port = config.get('app.port');

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "run-sequence": "1.2.2",
     "sendgrid": "5.1.1",
     "sequelize": "3.30.1",
-    "socket.io": "1.7.2",
+    "socket.io": "2.1.1",
     "uuid": "3.2.1",
     "validator": "6.2.1",
     "xml2js": "0.4.17",

--- a/public/app/whiteboards/board/whiteboardsBoardDirective.js
+++ b/public/app/whiteboards/board/whiteboardsBoardDirective.js
@@ -78,10 +78,14 @@
         var launchParams = utilService.getLaunchParams();
         if (!$scope.readonly) {
           var socket = io(window.location.origin, {
-            // Websocket handshakes are presently failing on Elastic Beanstalk deployments. Socket.io handles this by falling back to polling.
-            'transport': [ 'polling' ],
-            'upgrade': false,
+            'transports': [ 'websocket' ],
             'query': 'api_domain=' + launchParams.apiDomain + '&course_id=' + launchParams.courseId + '&whiteboard_id=' + $scope.whiteboard.id
+          });
+          socket.on('connect', function() {
+            console.log('Websocket connected');
+          });
+          socket.on('disconnect', function() {
+            console.log('Websocket disconnected');
           });
         }
 

--- a/public/index.html
+++ b/public/index.html
@@ -73,7 +73,7 @@
   <script src="/lib/oi.select/dist/select-tpls.js"></script>
   <script src="/lib/purl/purl.js"></script>
   <script src="/lib/re-tree/re-tree.js"></script>
-  <script src="/lib/socket.io-client/socket.io.js"></script>
+  <script src="/lib/socket.io-client/dist/socket.io.slim.js"></script>
   <!-- endbuild -->
 
   <!-- build:templateCache /static/templateCache.js -->


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1341

* `proxy_wstunnel_module` needs to happen in `VirtualHost *:443`
* upgrade related `socket.io` dependencies (server and client)
* minimal browser console logging confirms successful `websocket` connect  

`suitec-dev` is currently running code from my branch (ie, this PR). To test, open whiteboard on https://ucberkeley.beta.instructure.com/courses/1456107/external_tools/56484 and open browser console.

cc: @paulkerschen 