### PR TITLE
NOJIRA, set qa branch version to 2.8.3 (patch release)

### DIFF
--- a/node_modules/col-activities/package.json
+++ b/node_modules/col-activities/package.json
@@ -5,5 +5,5 @@
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"
   },
-  "version": "2.9.0"
+  "version": "2.8.3"
 }

--- a/node_modules/col-analytics/package.json
+++ b/node_modules/col-analytics/package.json
@@ -5,5 +5,5 @@
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"
   },
-  "version": "2.9.0"
+  "version": "2.8.3"
 }

--- a/node_modules/col-assets/package.json
+++ b/node_modules/col-assets/package.json
@@ -5,5 +5,5 @@
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"
   },
-  "version": "2.9.0"
+  "version": "2.8.3"
 }

--- a/node_modules/col-canvas/package.json
+++ b/node_modules/col-canvas/package.json
@@ -5,5 +5,5 @@
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"
   },
-  "version": "2.9.0"
+  "version": "2.8.3"
 }

--- a/node_modules/col-categories/package.json
+++ b/node_modules/col-categories/package.json
@@ -5,5 +5,5 @@
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"
   },
-  "version": "2.9.0"
+  "version": "2.8.3"
 }

--- a/node_modules/col-config/package.json
+++ b/node_modules/col-config/package.json
@@ -5,5 +5,5 @@
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"
   },
-  "version": "2.9.0"
+  "version": "2.8.3"
 }

--- a/node_modules/col-core/package.json
+++ b/node_modules/col-core/package.json
@@ -5,5 +5,5 @@
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"
   },
-  "version": "2.9.0"
+  "version": "2.8.3"
 }

--- a/node_modules/col-course/package.json
+++ b/node_modules/col-course/package.json
@@ -5,5 +5,5 @@
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"
   },
-  "version": "2.9.0"
+  "version": "2.8.3"
 }

--- a/node_modules/col-lti/package.json
+++ b/node_modules/col-lti/package.json
@@ -5,5 +5,5 @@
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"
   },
-  "version": "2.9.0"
+  "version": "2.8.3"
 }

--- a/node_modules/col-rest/package.json
+++ b/node_modules/col-rest/package.json
@@ -5,5 +5,5 @@
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"
   },
-  "version": "2.9.0"
+  "version": "2.8.3"
 }

--- a/node_modules/col-tests/package.json
+++ b/node_modules/col-tests/package.json
@@ -5,5 +5,5 @@
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"
   },
-  "version": "2.9.0"
+  "version": "2.8.3"
 }

--- a/node_modules/col-users/package.json
+++ b/node_modules/col-users/package.json
@@ -5,5 +5,5 @@
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"
   },
-  "version": "2.9.0"
+  "version": "2.8.3"
 }

--- a/node_modules/col-whiteboards/package.json
+++ b/node_modules/col-whiteboards/package.json
@@ -5,5 +5,5 @@
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"
   },
-  "version": "2.9.0"
+  "version": "2.8.3"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "suitec",
   "description": "SuiteC LTI Tools",
-  "version": "2.9.0",
+  "version": "2.8.3",
   "repository": {
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec.git"


### PR DESCRIPTION
This patch release has websockets-related work. We are recalibrating version number on qa branch because this is a patch release.  `master` branch will remain at 2.9.0.