### PR TITLE
COL-1357, security vulnerability in mime < 1.4.1; upgrade to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ims-lti": "3.0.2",
     "joi": "10.2.0",
     "lodash": "4.17.5",
-    "mime": "1.3.4",
+    "mime": "1.6.0",
     "mixpanel": "0.6.0",
     "mock-aws-s3": "2.6.0",
     "moment-timezone": "0.5.13",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1357
