### PR TITLE
COL-1358, bump node-postgres to 6.1.6 (security vulnerability)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "moment-timezone": "0.5.13",
     "node-sass": "4.4.0",
     "oauth": "0.9.15",
-    "pg": "6.1.2",
+    "pg": "6.1.6",
     "pg-hstore": "2.3.2",
     "pg-native": "1.10.0",
     "randomstring": "1.1.5",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1358

v6.1.6 has been patched according to https://node-postgres.com/announcements
