### PR TITLE
NOJIRA, lodash upgraded to 4.17.10 (testing new Travis integration)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "gulp-usemin": "0.3.28",
     "ims-lti": "3.0.2",
     "joi": "10.2.0",
-    "lodash": "4.17.5",
+    "lodash": "4.17.10",
     "mime": "1.6.0",
     "mixpanel": "0.6.0",
     "mock-aws-s3": "2.6.0",


### PR DESCRIPTION
Old-school Travis integration was deleted.