### PR TITLE
COL-1398, no more eslint and bower security vulnerabilities, for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "async": "2.4.1",
     "aws-sdk": "2.124.0",
     "body-parser": "1.17.2",
-    "bower": "1.8.2",
+    "bower": "1.8.8",
     "bunyan": "1.8.5",
     "bunyan-prettystream": "0.1.3",
     "caliperjs": "git+https://github.com/ets-berkeley-edu/caliper-js.git#master",
@@ -70,7 +70,7 @@
     "yargs": "8.0.2"
   },
   "devDependencies": {
-    "eslint": "4.17.0",
+    "eslint": "4.18.2",
     "gulp": "3.9.1",
     "gulp-add-src": "0.2.0",
     "gulp-angular-templatecache": "2.0.0",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1398
